### PR TITLE
reader improvements

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
-      go.test='sleep 10 && govendor test -v -cover .'
+      go.test='sleep 10 && govendor test -v -covermode atomic .'
       go.bench='true'
       # - sleep to give kafka time to start
       # - disable the race detector because there's too much concurrency going on in the tests and it takes too long to complete

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,6 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
-      go.test='sleep 10 && govendor test -v -race -cover .'
+      go.test='sleep 10 && govendor test -v -cover .'
       go.bench='true' # skip on CI
 

--- a/circle.yml
+++ b/circle.yml
@@ -24,5 +24,7 @@ test:
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
       go.test='sleep 10 && govendor test -v -cover .'
-      go.bench='true' # skip on CI
-
+      go.bench='true'
+      # - sleep to give kafka time to start
+      # - disable the race detector because there's too much concurrency going on in the tests and it takes too long to complete
+      # - disable benchmarks because they rely on having kafka running

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,6 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
-      go.test='sleep 30 && govendor test -v -race -cover .'
+      go.test='sleep 10 && govendor test -v -race -cover .'
       go.bench='true' # skip on CI
 

--- a/dialer.go
+++ b/dialer.go
@@ -220,6 +220,14 @@ type Resolver interface {
 }
 
 func sleep(ctx context.Context, duration time.Duration) bool {
+	if duration != 0 {
+		select {
+		default:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 	timer := time.NewTimer(duration)
 	defer timer.Stop()
 	select {

--- a/reader.go
+++ b/reader.go
@@ -332,7 +332,7 @@ func (r *reader) initialize(ctx context.Context, offset int64) (conn *Conn, star
 			continue
 		}
 
-		// This deadline controls how long the offset negatiation may take.
+		// This deadline controls how long the offset negotiation may take.
 		conn.SetDeadline(time.Now().Add(10 * time.Second))
 
 		if first, err = conn.ReadFirstOffset(); err != nil {

--- a/reader.go
+++ b/reader.go
@@ -305,7 +305,7 @@ func (r *reader) run(ctx context.Context, offset int64) {
 			case RequestTimedOut:
 				// Timeout on the kafka side, this can be safely retried.
 			case OffsetOutOfRange:
-				// We may be reading past the last offset, this should be
+				// We may be reading past the last offset, will retry later.
 			case context.Canceled:
 				// Another reader has taken over, we can safely quit.
 				conn.Close()

--- a/reader_test.go
+++ b/reader_test.go
@@ -40,9 +40,10 @@ func TestReader(t *testing.T) {
 			defer cancel()
 
 			r := NewReader(ReaderConfig{
-				Brokers: []string{"localhost:9092"},
-				Topic:   makeTopic(),
-				MaxWait: 500 * time.Millisecond,
+				Brokers:  []string{"localhost:9092"},
+				Topic:    makeTopic(),
+				MinBytes: 1,
+				MaxBytes: 10e6,
 			})
 			defer r.Close()
 			testFunc(t, ctx, r)


### PR DESCRIPTION
I noticed kafka often fails saying the the requested offsets are out of range on the reader, I'm not sure why this is happening because it seems like the tests would never request an offset that's out of range so I suspect some sort of race condition within kafka (AKA a behavior that I may not be aware of).

This PR attempts to make the reader implementation more resilient to those cases by changing the behavior to always gracefully handle out-of-range offset errors:
- if the starting offset is before the first, the reader will start from the first offset
- if the starting offset is after the last, the reader will wait for the last offset to catch up by retrying periodically (with a backoff)

Please take a look and let me know if anything should be changed!