### PR TITLE
add high offset (watermark) support

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -17,21 +17,27 @@ import (
 //
 // Batches are safe to use concurrently from multiple goroutines.
 type Batch struct {
-	mutex    sync.Mutex
-	conn     *Conn
-	lock     *sync.Mutex
-	reader   *bufio.Reader
-	deadline time.Time
-	throttle time.Duration
-	remain   int
-	offset   int64
-	err      error
+	mutex         sync.Mutex
+	conn          *Conn
+	lock          *sync.Mutex
+	reader        *bufio.Reader
+	deadline      time.Time
+	throttle      time.Duration
+	remain        int
+	offset        int64
+	highWaterMark int64
+	err           error
 }
 
 // Throttle gives the throttling duration applied by the kafka server on the
 // connection.
 func (batch *Batch) Throttle() time.Duration {
 	return batch.throttle
+}
+
+// Watermark returns the current highest watermark in a partition.
+func (batch *Batch) HighWaterMark() int64 {
+	return batch.highWaterMark
 }
 
 // Offset returns the offset of the next message in the batch.

--- a/conn.go
+++ b/conn.go
@@ -338,16 +338,17 @@ func (c *Conn) ReadBatch(minBytes int, maxBytes int) *Batch {
 		return &Batch{err: err}
 	}
 
-	throttle, remain, err := readFetchResponseHeader(&c.rbuf, size)
+	throttle, highWaterMark, remain, err := readFetchResponseHeader(&c.rbuf, size)
 	return &Batch{
-		conn:     c,
-		reader:   &c.rbuf,
-		deadline: adjustedDeadline,
-		throttle: duration(throttle),
-		lock:     lock,
-		remain:   remain,
-		offset:   offset,
-		err:      err,
+		conn:          c,
+		reader:        &c.rbuf,
+		deadline:      adjustedDeadline,
+		throttle:      duration(throttle),
+		lock:          lock,
+		remain:        remain,
+		offset:        offset,
+		highWaterMark: highWaterMark,
+		err:           err,
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -390,7 +390,7 @@ func testConnReadWatermarkFromBatch(t *testing.T, conn *Conn) {
 			}
 		}
 
-		if batch.HighWatermark() != 10 {
+		if batch.HighWaterMark() != 10 {
 			t.Fatal("expected highest offset (watermark) to be 10")
 		}
 	}

--- a/read.go
+++ b/read.go
@@ -215,7 +215,7 @@ func readSlice(r *bufio.Reader, sz int, v reflect.Value) (int, error) {
 	return sz, nil
 }
 
-func readFetchResponseHeader(r *bufio.Reader, size int) (throttle int32, remain int, err error) {
+func readFetchResponseHeader(r *bufio.Reader, size int) (throttle int32, watermark int64, remain int, err error) {
 	var n int32
 	var p struct {
 		Partition           int32
@@ -273,6 +273,7 @@ func readFetchResponseHeader(r *bufio.Reader, size int) (throttle int32, remain 
 		return
 	}
 
+	watermark = p.HighwaterMarkOffset
 	return
 }
 

--- a/reader.go
+++ b/reader.go
@@ -382,7 +382,7 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 			break
 		}
 
-		if err = r.sendMessage(ctx, msg, batch.HighWatermark()); err != nil {
+		if err = r.sendMessage(ctx, msg, batch.HighWaterMark()); err != nil {
 			err = batch.Close()
 			break
 		}

--- a/reader.go
+++ b/reader.go
@@ -28,6 +28,7 @@ type Reader struct {
 	cancel  context.CancelFunc
 	version int64
 	offset  int64
+	lag     int64
 	dirty   bool
 	closed  bool
 }
@@ -167,13 +168,13 @@ func (r *Reader) ReadMessage(ctx context.Context) (msg Message, err error) {
 		case <-ctx.Done():
 			err = ctx.Err()
 			return
-
 		case m := <-r.msgs:
 			if m.version >= version {
 				r.mutex.Lock()
 				if version == r.version {
 					r.offset = m.message.Offset + 1
 				}
+				r.lag = m.watermark - r.offset
 				r.mutex.Unlock()
 				msg = m.message
 				return
@@ -201,6 +202,15 @@ func (r *Reader) Offset() int64 {
 	offset := r.offset
 	r.mutex.Unlock()
 	return offset
+}
+
+// Lag returns the difference between the highest offset in a Kafka partition and the reader's
+// current offset. This can be used as a queue-depth indicator.
+func (r *Reader) Lag() int64 {
+	r.mutex.Lock()
+	lag := r.lag
+	r.mutex.Unlock()
+	return lag
 }
 
 // SetOffset changes the offset from which the next batch of messages will be
@@ -238,8 +248,9 @@ type reader struct {
 }
 
 type readerMessage struct {
-	version int64
-	message Message
+	version   int64
+	message   Message
+	watermark int64
 }
 
 type readerError struct {
@@ -371,8 +382,8 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 			break
 		}
 
-		if err = r.sendMessage(ctx, msg); err != nil {
-			batch.Close()
+		if err = r.sendMessage(ctx, msg, batch.HighWatermark()); err != nil {
+			err = batch.Close()
 			break
 		}
 
@@ -382,9 +393,9 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 	return offset, err
 }
 
-func (r *reader) sendMessage(ctx context.Context, msg Message) error {
+func (r *reader) sendMessage(ctx context.Context, msg Message, watermark int64) error {
 	select {
-	case r.msgs <- readerMessage{version: r.version, message: msg}:
+	case r.msgs <- readerMessage{version: r.version, message: msg, watermark: watermark}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
cc @achille-roussel 

This propagates the high watermark offset to the batch. This is used to calculate the lag of a reader by comparing the current offset to the watermark.