### PR TITLE
Add the Writer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,41 @@ for {
 
 r.Close()
 ```
+
+## Writer
+
+To produce messages to Kafka, a program may use the low-level `Conn` API, but
+the package also provides a higher level `Writer` type which is more appropriate
+to use in most cases because it provides additional features:
+
+- Automatic retries and reconnections on errors.
+- Configurable distribution of messages across available partitions.
+- Synchronously or asynchronously writing messages to Kafka.
+- Asynchronous cancellation using contexts.
+- Flush pending messages on close to support graceful shutdowns.
+
+```go
+// make a writer that produces to topic-A, using the least-bytes distribution
+w := kafka.NewWriter(kafka.WriterConfig{
+	Brokers: []string{"localhost:9092"},
+	Topic:   "topic-A",
+    Balancer: &kafka.LeastBytes{},
+})
+
+w.WriteMessages(context.Background(),
+	kafka.Message{
+		Key:   []byte("Key-A"),
+		Value: []byte("Hello World!"),
+	},
+	kafka.Message{
+		Key:   []byte("Key-B"),
+		Value: []byte("One!"),
+	},
+	kafka.Message{
+		Key:   []byte("Key-C"),
+		Value: []byte("Two!"),
+	},
+)
+
+w.Close()
+```

--- a/balancer.go
+++ b/balancer.go
@@ -1,5 +1,7 @@
 package kafka
 
+import "sort"
+
 // The Balancer interface provides an abstraction of the message distribution
 // logic used by Writer instances to route messages to the partitions available
 // on a kafka cluster.
@@ -10,6 +12,11 @@ package kafka
 type Balancer interface {
 	// Balance receives a message and a set of available partitions and
 	// returns the partition number that the message should be routed to.
+	//
+	// An application should refrain from using a balancer to manage multiple
+	// sets of partitions (from different topics for examples), use one balancer
+	// instance for each partition set, so the balancer can detect when the
+	// partitions change and assume that the kafka topic has been rebalanced.
 	Balance(msg Message, partitions ...int) (partition int)
 }
 
@@ -34,4 +41,65 @@ func (rr *RoundRobin) Balance(msg Message, partitions ...int) int {
 	offset := rr.offset
 	rr.offset++
 	return partitions[offset%length]
+}
+
+// LeastBytes is a Balancer implementation that routes messages to the partition
+// that has received the least amount of data.
+//
+// Note that no coordination is done between multiple producers, having good
+// balancing relies on the fact that each producer using a LeastBytes balancer
+// should produce well balanced messages.
+type LeastBytes struct {
+	counters []leastBytesCounter
+}
+
+type leastBytesCounter struct {
+	partition int
+	bytes     uint64
+}
+
+// Balance satisfies the Balancer interface.
+func (lb *LeastBytes) Balance(msg Message, partitions ...int) int {
+	for _, p := range partitions {
+		if c := lb.counterOf(p); c == nil {
+			lb.counters = lb.makeCounters(partitions...)
+		}
+	}
+
+	minBytes := lb.counters[0].bytes
+	minIndex := 0
+
+	for i, c := range lb.counters[1:] {
+		if c.bytes < minBytes {
+			minIndex = i + 1
+			minBytes = c.bytes
+		}
+	}
+
+	c := &lb.counters[minIndex]
+	c.bytes += uint64(len(msg.Key) + len(msg.Value))
+	return c.partition
+}
+
+func (lb *LeastBytes) counterOf(partition int) *leastBytesCounter {
+	i := sort.Search(len(lb.counters), func(i int) bool {
+		return lb.counters[i].partition >= partition
+	})
+	if i == len(lb.counters) || lb.counters[i].partition != partition {
+		return nil
+	}
+	return &lb.counters[i]
+}
+
+func (lb *LeastBytes) makeCounters(partitions ...int) (counters []leastBytesCounter) {
+	counters = make([]leastBytesCounter, len(partitions))
+
+	for i, p := range partitions {
+		counters[i].partition = p
+	}
+
+	sort.Slice(counters, func(i int, j int) bool {
+		return counters[i].partition < counters[j].partition
+	})
+	return
 }

--- a/balancer.go
+++ b/balancer.go
@@ -1,0 +1,21 @@
+package kafka
+
+import "sync/atomic"
+
+type Balancer interface {
+	Balance(key []byte, partitions ...int) (partition int)
+}
+
+type BalancerFunc func([]byte, ...int) int
+
+func (f BalancerFunc) Balance(key []byte, partitions ...int) int {
+	return f(key, partitions...)
+}
+
+type RoundRobin struct {
+	offset uint32
+}
+
+func (rr *RoundRobin) Balance(key []byte, partitions ...int) int {
+	return partitions[int(atomic.AddUint32(&rr.offset, 1))%len(partitions)]
+}

--- a/balancer.go
+++ b/balancer.go
@@ -63,6 +63,7 @@ func (lb *LeastBytes) Balance(msg Message, partitions ...int) int {
 	for _, p := range partitions {
 		if c := lb.counterOf(p); c == nil {
 			lb.counters = lb.makeCounters(partitions...)
+			break
 		}
 	}
 

--- a/balancer.go
+++ b/balancer.go
@@ -77,7 +77,7 @@ func (lb *LeastBytes) Balance(msg Message, partitions ...int) int {
 	}
 
 	c := &lb.counters[minIndex]
-	c.bytes += uint64(len(msg.Key) + len(msg.Value))
+	c.bytes += uint64(len(msg.Key)) + uint64(len(msg.Value))
 	return c.partition
 }
 

--- a/conn.go
+++ b/conn.go
@@ -442,6 +442,8 @@ func (c *Conn) ReadPartitions(topics ...string) (partitions []Partition, err err
 				return err
 			}
 
+			fmt.Printf("%#v\n", res)
+
 			brokers := make(map[int32]Broker, len(res.Brokers))
 			for _, b := range res.Brokers {
 				brokers[b.NodeID] = Broker{

--- a/conn.go
+++ b/conn.go
@@ -442,8 +442,6 @@ func (c *Conn) ReadPartitions(topics ...string) (partitions []Partition, err err
 				return err
 			}
 
-			fmt.Printf("%#v\n", res)
-
 			brokers := make(map[int32]Broker, len(res.Brokers))
 			for _, b := range res.Brokers {
 				brokers[b.NodeID] = Broker{

--- a/dialer.go
+++ b/dialer.go
@@ -155,6 +155,8 @@ func (d *Dialer) LookupLeader(ctx context.Context, network string, address strin
 				}
 			}
 		}
+
+		errch <- UnknownTopicOrPartition
 	}()
 
 	var brk Broker
@@ -220,7 +222,7 @@ type Resolver interface {
 }
 
 func sleep(ctx context.Context, duration time.Duration) bool {
-	if duration != 0 {
+	if duration == 0 {
 		select {
 		default:
 			return true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ kafka:
     - "9092:9092"
   environment:
     KAFKA_VERSION: "0.10.1.0"
-    KAFKA_CREATE_TOPICS: "events:2:1,test:1:1"
+    KAFKA_CREATE_TOPICS: "test-writer-0:3:1,test-writer-1:3:1"
     KAFKA_ADVERTISED_HOST_NAME: "localhost"
     KAFKA_ADVERTISED_PORT: "9092"
     KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"

--- a/example_writer_test.go
+++ b/example_writer_test.go
@@ -1,0 +1,23 @@
+package kafka_test
+
+import (
+	"context"
+
+	kafka "github.com/segmentio/kafka-go"
+)
+
+func ExampleWriter() {
+	w := kafka.NewWriter(kafka.WriterConfig{
+		Brokers: []string{"localhost:9092"},
+		Topic:   "Topic-1",
+	})
+
+	w.WriteMessages(context.Background(),
+		kafka.Message{
+			Key:   []byte("Key-A"),
+			Value: []byte("Hello World!"),
+		},
+	)
+
+	w.Close()
+}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,469 @@
+package kafka
+
+import (
+	"context"
+	"io"
+	"sort"
+	"sync"
+	"time"
+)
+
+type Writer struct {
+	config WriterConfig
+
+	mutex  sync.RWMutex
+	closed bool
+
+	join sync.WaitGroup
+	msgs chan writerMessage
+	done chan struct{}
+}
+
+type WriterConfig struct {
+	Brokers []string
+
+	Topic string
+
+	Dialer *Dialer
+
+	Balancer Balancer
+
+	Attempts int
+
+	Capacity int
+
+	BatchSize int
+
+	BatchTimeout time.Duration
+
+	ReadTimeout time.Duration
+
+	WriteTimeout time.Duration
+
+	RebalanceInterval time.Duration
+}
+
+func NewWriter(config WriterConfig) *Writer {
+	if len(config.Brokers) == 0 {
+		panic("cannot create a kafka writer with an empty list of brokers")
+	}
+
+	if len(config.Topic) == 0 {
+		panic("cannot create a kafak writer with an empty topic")
+	}
+
+	if config.Dialer == nil {
+		config.Dialer = DefaultDialer
+	}
+
+	if config.Balancer == nil {
+		config.Balancer = &RoundRobin{}
+	}
+
+	if config.Attempts == 0 {
+		config.Attempts = 10
+	}
+
+	if config.Capacity == 0 {
+		config.Capacity = 100
+	}
+
+	if config.BatchSize == 0 {
+		config.BatchSize = 100
+	}
+
+	if config.BatchTimeout == 0 {
+		config.BatchTimeout = 1 * time.Second
+	}
+
+	if config.ReadTimeout == 0 {
+		config.ReadTimeout = 10 * time.Second
+	}
+
+	if config.WriteTimeout == 0 {
+		config.WriteTimeout = 10 * time.Second
+	}
+
+	if config.RebalanceInterval == 0 {
+		config.RebalanceInterval = 15 * time.Second
+	}
+
+	w := &Writer{
+		config: config,
+		msgs:   make(chan writerMessage, config.Capacity),
+		done:   make(chan struct{}),
+	}
+
+	w.join.Add(1)
+	go w.run()
+	return w
+}
+
+func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	var res = make(chan error, 1)
+	var err error
+
+	for attempt := 0; attempt != w.config.Attempts; attempt++ {
+		w.mutex.RLock()
+
+		if w.closed {
+			w.mutex.RUnlock()
+			return io.ErrClosedPipe
+		}
+
+		for _, msg := range msgs {
+			select {
+			case w.msgs <- writerMessage{
+				msg: msg,
+				res: res,
+			}:
+			case <-ctx.Done():
+				w.mutex.RUnlock()
+				return ctx.Err()
+			}
+		}
+
+		w.mutex.RUnlock()
+
+		var retry []Message
+		for i := 0; i != len(msgs); i++ {
+			select {
+			case e := <-res:
+				if e != nil {
+					if we, ok := e.(*writerError); ok {
+						retry, err = append(retry, we.msgs...), we.err
+					} else {
+						err = e
+					}
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		if msgs = retry; len(msgs) == 0 {
+			break
+		}
+
+		timer := time.NewTimer(backoff(attempt+1, 100*time.Millisecond, 1*time.Second))
+		select {
+		case <-timer.C:
+			err = nil
+		case <-ctx.Done():
+			err = ctx.Err()
+		case <-w.done:
+			err = io.ErrClosedPipe
+		}
+		timer.Stop()
+
+		if err != nil {
+			break
+		}
+	}
+
+	return err
+}
+
+func (w *Writer) Close() (err error) {
+	w.mutex.Lock()
+
+	if !w.closed {
+		w.closed = true
+		close(w.msgs)
+		close(w.done)
+	}
+
+	w.mutex.Unlock()
+	w.join.Wait()
+	return
+}
+
+func (w *Writer) run() {
+	defer w.join.Done()
+
+	ticker := time.NewTicker(w.config.RebalanceInterval)
+	defer ticker.Stop()
+
+	var rebalance = true
+	var writers = make(map[int]*writer)
+	var partitions []int
+	var err error
+
+	for {
+		if rebalance {
+			rebalance = false
+
+			var newPartitions []int
+			var oldPartitions = partitions
+
+			if newPartitions, err = w.partitions(); err == nil {
+				for _, partition := range diffp(oldPartitions, newPartitions) {
+					w.close(writers[partition])
+					delete(writers, partition)
+				}
+
+				for _, partition := range diffp(newPartitions, oldPartitions) {
+					writers[partition] = w.open(partition)
+				}
+
+				partitions = newPartitions
+			}
+		}
+
+		select {
+		case wm, ok := <-w.msgs:
+			if !ok {
+				for _, writer := range writers {
+					w.close(writer)
+				}
+				return
+			}
+
+			if len(partitions) != 0 {
+				writers[w.config.Balancer.Balance(wm.msg.Key, partitions...)].msgs <- wm
+			} else {
+				select {
+				default:
+				case wm.res <- err:
+				}
+			}
+
+		case <-ticker.C:
+			rebalance = true
+		}
+	}
+}
+
+func (w *Writer) partitions() (partitions []int, err error) {
+	for _, broker := range w.config.Brokers {
+		var conn *Conn
+		var plist []Partition
+
+		ctx, cancel := context.WithTimeout(context.Background(), w.config.ReadTimeout)
+
+		if conn, err = w.config.Dialer.DialContext(ctx, "tcp", broker); err != nil {
+			cancel()
+			continue
+		}
+
+		deadline, _ := ctx.Deadline()
+		cancel()
+		conn.SetReadDeadline(deadline)
+
+		plist, err = conn.ReadPartitions(w.config.Topic)
+		conn.Close()
+
+		if err == nil {
+			partitions = make([]int, len(plist))
+			for i, p := range plist {
+				partitions[i] = p.ID
+			}
+			break
+		}
+	}
+
+	sort.Ints(partitions)
+	return
+}
+
+func (w *Writer) open(partition int) (writer *writer) {
+	writer = newWriter(partition, w.config)
+	w.join.Add(1)
+
+	go func() {
+		defer w.join.Done()
+		writer.run()
+	}()
+
+	return writer
+}
+
+func (w *Writer) close(writer *writer) {
+	writer.close()
+	w.join.Add(1)
+
+	go func() {
+		defer w.join.Done()
+		w.mutex.RLock()
+
+		if w.closed {
+			for wm := range writer.msgs {
+				select {
+				case wm.res <- io.ErrClosedPipe:
+				default:
+				}
+			}
+		} else {
+			for wm := range writer.msgs {
+				w.msgs <- wm
+			}
+		}
+
+		w.mutex.RUnlock()
+	}()
+}
+
+func diffp(new []int, old []int) (diff []int) {
+	for _, p := range new {
+		if i := sort.SearchInts(old, p); i == len(old) || old[i] != p {
+			diff = append(diff, p)
+		}
+	}
+	return
+}
+
+type writer struct {
+	brokers      []string
+	topic        string
+	partition    int
+	batchSize    int
+	batchTimeout time.Duration
+	writeTimeout time.Duration
+	dialer       *Dialer
+	msgs         chan writerMessage
+}
+
+func newWriter(partition int, config WriterConfig) *writer {
+	return &writer{
+		brokers:      config.Brokers,
+		topic:        config.Topic,
+		partition:    partition,
+		batchSize:    config.BatchSize,
+		batchTimeout: config.BatchTimeout,
+		writeTimeout: config.WriteTimeout,
+		dialer:       config.Dialer,
+		msgs:         make(chan writerMessage, config.Capacity),
+	}
+}
+
+func (w *writer) close() {
+	close(w.msgs)
+}
+
+func (w *writer) run() {
+	ticker := time.NewTicker(w.batchTimeout / 10)
+	defer ticker.Stop()
+
+	var conn *Conn
+	var done bool
+	var batch = make([]Message, 0, w.batchSize)
+	var resch = make([](chan<- error), 0, w.batchSize)
+	var lastFlushAt = time.Now()
+
+	defer func() {
+		if conn != nil {
+			conn.Close()
+		}
+	}()
+
+	for !done {
+		var mustFlush bool
+
+		select {
+		case wm, ok := <-w.msgs:
+			if !ok {
+				done, mustFlush = true, true
+			} else {
+				batch = append(batch, wm.msg)
+				resch = append(resch, wm.res)
+				mustFlush = len(batch) >= w.batchSize
+			}
+
+		case now := <-ticker.C:
+			mustFlush = now.Sub(lastFlushAt) > w.batchTimeout
+		}
+
+		if mustFlush {
+			lastFlushAt = time.Now()
+
+			if len(batch) != 0 {
+				var err error
+				conn, err = w.write(conn, batch...)
+
+				for _, res := range resch {
+					select {
+					case res <- err:
+					default:
+						// The goroutine that generated tht message may have
+						// given up if its context was canceled, in that case
+						// blocking would result in a dead lock.
+					}
+				}
+
+				batch = batch[:0]
+			}
+		}
+	}
+}
+
+func (w *writer) write(conn *Conn, msgs ...Message) (ret *Conn, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), w.writeTimeout)
+	if conn == nil {
+		conn, err = w.dial(ctx)
+	}
+
+	deadline, _ := ctx.Deadline()
+	cancel()
+
+	if conn != nil {
+		conn.SetWriteDeadline(deadline)
+
+		_, err = conn.WriteMessages(msgs...)
+		conn.Close()
+	}
+
+	if err != nil {
+		err = &writerError{
+			msgs: copyMessages(msgs),
+			err:  err,
+		}
+	}
+
+	ret = conn
+	return
+}
+
+func (w *writer) dial(ctx context.Context) (conn *Conn, err error) {
+	for _, broker := range w.brokers {
+		if conn, err = w.dialer.DialLeader(ctx, "tcp", broker, w.topic, w.partition); err == nil {
+			break
+		}
+	}
+	return
+}
+
+type writerMessage struct {
+	msg Message
+	res chan<- error
+}
+
+type writerError struct {
+	msgs []Message
+	err  error
+}
+
+func (e *writerError) Cause() error {
+	return e.err
+}
+
+func (e *writerError) Error() string {
+	return e.err.Error()
+}
+
+func (e *writerError) Temporary() bool {
+	return isTemporary(e.err)
+}
+
+func (e *writerError) Timeout() bool {
+	return isTimeout(e.err)
+}
+
+func copyMessages(msgs []Message) []Message {
+	cpy := make([]Message, len(msgs))
+	copy(cpy, msgs)
+	return cpy
+}

--- a/writer.go
+++ b/writer.go
@@ -92,7 +92,7 @@ type WriterConfig struct {
 
 	// Setting this flag to true causes the WriteMessages method to never block.
 	// It also means that errors are ignored since the caller will not receive
-	// the returned value. Use this only if you don't care about garantees of
+	// the returned value. Use this only if you don't care about guarantees of
 	// whether the messages were written to kafka.
 	Async bool
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,132 @@
+package kafka
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestWriter(t *testing.T) {
+	tests := []struct {
+		scenario string
+		function func(*testing.T)
+	}{
+		{
+			scenario: "closing a writer right after creating it returns promptly with no error",
+			function: testWriterClose,
+		},
+
+		{
+			scenario: "writing 1 message through a writer using round-robin balancing produces 1 message to the first partition",
+			function: testWriterRoundRobin1,
+		},
+	}
+
+	t.Parallel()
+	// Kafka takes a while to create the initial topics and partitions...
+	time.Sleep(15 * time.Second)
+
+	for _, test := range tests {
+		testFunc := test.function
+		t.Run(test.scenario, func(t *testing.T) {
+			t.Parallel()
+			testFunc(t)
+		})
+	}
+}
+
+func newTestWriter(config WriterConfig) *Writer {
+	config.Brokers = []string{"localhost:9092"}
+	return NewWriter(config)
+}
+
+func testWriterClose(t *testing.T) {
+	w := newTestWriter(WriterConfig{
+		Topic: "test-writer-0",
+	})
+
+	if err := w.Close(); err != nil {
+		t.Error(err)
+	}
+}
+
+func testWriterRoundRobin1(t *testing.T) {
+	const topic = "test-writer-1"
+
+	offset, err := readOffset(topic, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := newTestWriter(WriterConfig{
+		Topic:    topic,
+		Balancer: &RoundRobin{},
+	})
+	defer w.Close()
+
+	if err := w.WriteMessages(context.Background(), Message{
+		Value: []byte("Hello World!"),
+	}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	msgs, err := readPartition(topic, 0, offset)
+
+	if err != nil {
+		t.Error("error reading partition", err)
+		return
+	}
+
+	if len(msgs) != 1 {
+		t.Error("bad messages in partition", msgs)
+		return
+	}
+
+	for _, m := range msgs {
+		if string(m.Value) != "Hello World!" {
+			t.Error("bad messages in partition", msgs)
+			break
+		}
+	}
+}
+
+func readOffset(topic string, partition int) (offset int64, err error) {
+	var conn *Conn
+
+	if conn, err = DialLeader(context.Background(), "tcp", "localhost:9092", topic, partition); err != nil {
+		return
+	}
+	defer conn.Close()
+
+	offset, err = conn.ReadLastOffset()
+	return
+}
+
+func readPartition(topic string, partition int, offset int64) (msgs []Message, err error) {
+	var conn *Conn
+
+	if conn, err = DialLeader(context.Background(), "tcp", "localhost:9092", topic, partition); err != nil {
+		return
+	}
+	defer conn.Close()
+
+	conn.Seek(offset, 1)
+	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	batch := conn.ReadBatch(0, 1000000000)
+	defer batch.Close()
+
+	for {
+		var msg Message
+
+		if msg, err = batch.ReadMessage(); err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return
+		}
+
+		msgs = append(msgs, msg)
+	}
+}


### PR DESCRIPTION
Hey Kafka boyz, Here's the implementation of a high-level Writer API to produce messages to kafka, a couple of highlights:

- automatically discovers the available partitions for a topic
- balancing messages across partitions using the `Balancer` abstraction
- supports automatic retries on failures
- supports sync and async modes
- supports async cancellation via contexts
- gracefully closes, waits for inflight messages to be flushed before returning

I still have to add more tests for the message balancing algorithms and a section to the README but I think the code is mature enough to be reviewed now.

Please take a look and let me know if anything should be changed.