### PR TITLE
reduce the number of channels involved in reading messages

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -90,7 +90,7 @@ func NewReader(config ReaderConfig) *Reader {
 	}
 
 	if config.MaxBytes == 0 {
-		config.MaxBytes = 10e6 // 10 MB
+		config.MaxBytes = 1e6 // 1 MB
 	}
 
 	if config.MinBytes == 0 {

--- a/reader.go
+++ b/reader.go
@@ -143,7 +143,7 @@ func (r *Reader) ReadMessage(ctx context.Context) (Message, error) {
 	for {
 		r.mutex.Lock()
 
-		if r.version == 0 {
+		if !r.closed && r.version == 0 {
 			r.start()
 		}
 

--- a/reader.go
+++ b/reader.go
@@ -166,9 +166,9 @@ func (r *Reader) ReadMessage(ctx context.Context) (Message, error) {
 				case m.error != nil:
 				case version == r.version:
 					r.offset = m.message.Offset + 1
+					r.lag = m.watermark - r.offset
 				}
 
-				r.lag = m.watermark - r.offset
 				r.mutex.Unlock()
 				return m.message, m.error
 			}

--- a/reader_test.go
+++ b/reader_test.go
@@ -136,9 +136,9 @@ func prepareReader(t *testing.T, ctx context.Context, r *Reader, msgs ...Message
 }
 
 var (
-	benchmarkReaderOnce   sync.Once
-	benchmarkReaderTopic  = makeTopic()
-	benchmarkReaderPaylod = make([]byte, 16*1024)
+	benchmarkReaderOnce    sync.Once
+	benchmarkReaderTopic   = makeTopic()
+	benchmarkReaderPayload = make([]byte, 16*1024)
 )
 
 func BenchmarkReader(b *testing.B) {
@@ -154,7 +154,7 @@ func BenchmarkReader(b *testing.B) {
 
 		msgs := make([]Message, 1000)
 		for i := range msgs {
-			msgs[i].Value = benchmarkReaderPaylod
+			msgs[i].Value = benchmarkReaderPayload
 		}
 
 		for i := 0; i != 10; i++ { // put 10K messages


### PR DESCRIPTION
This pull request addresses a performance issue that was mainly due to the use of unbuffered channels to pass messages between the internal goroutine of the Reader and the caller of ReadMessage.

Here are profiles before and after the change:
```
$ go tool pprof ./kafka-go.test /tmp/base1.cpu
Entering interactive mode (type "help" for commands)
(pprof) top10
3440ms of 4620ms total (74.46%)
Dropped 31 nodes (cum <= 23.10ms)
Showing top 10 nodes out of 88 (cum >= 650ms)
      flat  flat%   sum%        cum   cum%
    1240ms 26.84% 26.84%     2800ms 60.61%  runtime.selectgoImpl
     410ms  8.87% 35.71%      410ms  8.87%  runtime.unlock
     360ms  7.79% 43.51%      500ms 10.82%  runtime.lock
     260ms  5.63% 49.13%      280ms  6.06%  syscall.(*Errno).Timeout
     250ms  5.41% 54.55%      250ms  5.41%  runtime.mach_msg_trap
     210ms  4.55% 59.09%      560ms 12.12%  runtime.selectrecv
     210ms  4.55% 63.64%      210ms  4.55%  runtime.selectrecvImpl
     200ms  4.33% 67.97%      200ms  4.33%  runtime.munmap
     160ms  3.46% 71.43%      160ms  3.46%  runtime.selectrecv2
     140ms  3.03% 74.46%      650ms 14.07%  github.com/segmentio/kafka-go.(*Reader).ReadMessage
```
```
$ go tool pprof ./kafka-go.test /tmp/base2.cpu
Entering interactive mode (type "help" for commands)
(pprof) top10
490ms of 490ms total (  100%)
Showing top 10 nodes out of 105 (cum >= 30ms)
      flat  flat%   sum%        cum   cum%
     170ms 34.69% 34.69%      180ms 36.73%  syscall.Syscall
      80ms 16.33% 51.02%       80ms 16.33%  runtime.mach_semaphore_timedwait
      70ms 14.29% 65.31%       70ms 14.29%  runtime.usleep
      50ms 10.20% 75.51%       50ms 10.20%  runtime.kevent
      50ms 10.20% 85.71%       50ms 10.20%  runtime.mach_semaphore_signal
      30ms  6.12% 91.84%       30ms  6.12%  runtime.mach_semaphore_wait
      20ms  4.08% 95.92%       20ms  4.08%  runtime.freedefer
      10ms  2.04% 97.96%       10ms  2.04%  runtime.memmove
      10ms  2.04%   100%       10ms  2.04%  runtime.readvarint
         0     0%   100%       30ms  6.12%  bufio.(*Reader).Peek
```
Most of the time used to be spent in the `select` statement of ReadMessage, now it's spent in the `read` syscall, which is what we'd expect for an operation that's supposed to be I/O bound (reading from Kafka).

Please take a look and let me know if something should be changed.