### PR TITLE
don't report lag until at least one message is read

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -136,8 +136,8 @@ func testReaderReadLag(t *testing.T, ctx context.Context, r *Reader) {
 
 	if lag, err := r.ReadLag(ctx); err != nil {
 		t.Error(err)
-	} else if lag != N+1 {
-		t.Errorf("the initial lag value is %d but was expected to be %d", lag, N+1)
+	} else if lag != 0 {
+		t.Errorf("the initial lag value is %d but was expected to be 0", lag)
 	}
 
 	for i := 0; i != N; i++ {


### PR DESCRIPTION
We've run into a weird situation where when the consumer hasn't read any messages it believes that it has the entire all-time backlog of lag. This PR addresses this issue by reporting no lag until at least one message has been read to set the offset to a positive value.