### PR TITLE
Logging + Reader bug fix

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -55,6 +55,7 @@ func TestReader(t *testing.T) {
 				Topic:    makeTopic(),
 				MinBytes: 1,
 				MaxBytes: 10e6,
+				MaxWait:  100 * time.Millisecond,
 			})
 			defer r.Close()
 			testFunc(t, ctx, r)
@@ -136,8 +137,8 @@ func testReaderReadLag(t *testing.T, ctx context.Context, r *Reader) {
 
 	if lag, err := r.ReadLag(ctx); err != nil {
 		t.Error(err)
-	} else if lag != 0 {
-		t.Errorf("the initial lag value is %d but was expected to be 0", lag)
+	} else if lag != N {
+		t.Errorf("the initial lag value is %d but was expected to be %d", lag, N)
 	}
 
 	for i := 0; i != N; i++ {


### PR DESCRIPTION
This PR adds the ability to set a logger on a kafka reader to get insights into the internals, while also probably fixing a bug with offset management.
I haven't been able to really identify the root cause of the issue but this code has been running in production for a week now and the bug hasn't triggered (where it did consistently before).

The problem we were seeing was the reader being unable to make progress, its offset was always being reset to a previous value.

Please take a look and let me know if something should be changed.