### PR TITLE
better timeout management

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -705,7 +705,7 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 	conn.SetReadDeadline(deadline)
 
 	for {
-		if now := time.Now(); deadline.Sub(now) < (safetyTimeout / 10) {
+		if now := time.Now(); deadline.Sub(now) < (safetyTimeout / 2) {
 			deadline = now.Add(safetyTimeout)
 			conn.SetReadDeadline(deadline)
 		}


### PR DESCRIPTION
This PR changes the hard 10s limit we used to have to read a full batch of messages into a 5s to 10s limit to read each message of a batch. The intent of this time limit is to act as a safety net in case the connection is dropped, but if the output channel is filling up it ends up triggering and dropping the connection.