### PR TITLE
fix panic on out-of-bounds error

### DIFF
--- a/error.go
+++ b/error.go
@@ -94,7 +94,7 @@ func (e Error) Title() string {
 	case Unknown:
 		return "Unknown"
 	case OffsetOutOfRange:
-		return "Ouffset Out Of Range"
+		return "Offset Out Of Range"
 	case InvalidMessage:
 		return "Invalid Message"
 	case UnknownTopicOrPartition:

--- a/reader.go
+++ b/reader.go
@@ -550,6 +550,7 @@ func (r *reader) run(ctx context.Context, offset int64, join *sync.WaitGroup) {
 			r.withErrorLogger(func(log *log.Logger) {
 				log.Printf("error initializing the kafka reader for partition %d of %s: %s", r.partition, r.topic, OffsetOutOfRange)
 			})
+			continue
 		default:
 			// Wait 4 attempts before reporting the first errors, this helps
 			// mitigate situations where the kafka server is temporarily


### PR DESCRIPTION
Fixes #30 

When initializing the inner reader returns an offset out-of-bounds error it should simply apply the backoff logic and retry the connection later.