### PR TITLE
EOF on closed reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -233,6 +233,8 @@ func (r *Reader) Close() error {
 // ReadMessage reads and return the next message from the r. The method call
 // blocks until a message becomes available, or an error occurs. The program
 // may also specify a context to asynchronously cancel the blocking operation.
+//
+// The method returns io.EOF to indicate that the reader has been closed.
 func (r *Reader) ReadMessage(ctx context.Context) (Message, error) {
 	if r.config.ReadLagInterval > 0 && atomic.CompareAndSwapUint32(&r.once, 0, 1) {
 		go r.readLag(r.stctx)


### PR DESCRIPTION
This PR changes the error returned by ReadMessage to EOF when the reader has been closed, there are two reasons why we make this change:

- io.EOF is the _correct_ error for indicating that a read operation has reached the end of the data stream it was reading
- io.ErrClosedPipe maybe returned by the inner reader if the connection is lost, and would confuse the application into thinking that the reader has reached the end

This may be considered a breaking change, however it was not previously documented and doesn't break the compilation either.

Please take a look and let me know if you have any concerns.