### PR TITLE
resolves race condition where Batch.close called during readMessage

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -158,9 +158,12 @@ func (batch *Batch) ReadMessage() (Message, error) {
 		},
 	)
 
-	batch.mutex.Unlock()
+	// capture Topic and Partition before we Unlock to avoid edge case where 
+	// Batch.close is called during Batch.readMessage
 	msg.Topic = batch.conn.topic
 	msg.Partition = int(batch.conn.partition)
+
+	batch.mutex.Unlock()
 	msg.Offset = offset
 	msg.Time = timestampToTime(timestamp)
 	return msg, err

--- a/batch.go
+++ b/batch.go
@@ -24,6 +24,8 @@ type Batch struct {
 	deadline      time.Time
 	throttle      time.Duration
 	remain        int
+	topic         string
+	partition     int
 	offset        int64
 	highWaterMark int64
 	err           error
@@ -158,12 +160,9 @@ func (batch *Batch) ReadMessage() (Message, error) {
 		},
 	)
 
-	// capture Topic and Partition before we Unlock to avoid edge case where 
-	// Batch.close is called during Batch.readMessage
-	msg.Topic = batch.conn.topic
-	msg.Partition = int(batch.conn.partition)
-
 	batch.mutex.Unlock()
+	msg.Topic = batch.topic
+	msg.Partition = batch.partition
 	msg.Offset = offset
 	msg.Time = timestampToTime(timestamp)
 	return msg, err

--- a/conn.go
+++ b/conn.go
@@ -357,6 +357,8 @@ func (c *Conn) ReadBatch(minBytes int, maxBytes int) *Batch {
 		throttle:      duration(throttle),
 		lock:          lock,
 		remain:        remain,
+		topic:         c.topic,          // topic is copied to Batch to prevent race with Batch.close
+		partition:     int(c.partition), // partition is copied to Batch to prevent race with Batch.close
 		offset:        offset,
 		highWaterMark: highWaterMark,
 		err:           err,


### PR DESCRIPTION
solution was to give the Batch its own copy of topic and partition