### PR TITLE
created Hash balancer for producer compatibility with sarama

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,18 @@ w.Close()
 ```
 
 **Note:** Even though kafka.Message contain ```Topic``` and ```Partition``` fields, they **MUST NOT** be 
-set when writing messages.  They are intended for read use only.   
+set when writing messages.  They are intended for read use only.
+
+### Compatibility with Sarama
+
+If you're switching from Sarama and need/want to use the same algorithm for message
+partitioning, you can use the ```kafka.Hash``` balancer.  ```kafka.Hash``` routes
+messages to the same partitions that sarama's default partitioner would route to.
+
+```go
+w := kafka.NewWriter(kafka.WriterConfig{
+	Brokers: []string{"localhost:9092"},
+	Topic:   "topic-A",
+	Balancer: &kafka.Hash{},
+})
+```

--- a/balancer.go
+++ b/balancer.go
@@ -131,7 +131,7 @@ type Hash struct {
 
 func (h *Hash) Balance(msg Message, partitions ...int) (partition int) {
 	if msg.Key == nil {
-		return (&h.rr).Balance(msg, partitions...)
+		return h.rr.Balance(msg, partitions...)
 	}
 
 	hasher := fnv1aPool.Get().(hash.Hash32)
@@ -139,7 +139,7 @@ func (h *Hash) Balance(msg Message, partitions ...int) (partition int) {
 
 	hasher.Reset()
 	if _, err := hasher.Write(msg.Key); err != nil {
-		return (&h.rr).Balance(msg, partitions...)
+		return h.rr.Balance(msg, partitions...)
 	}
 
 	// uses same algorithm that Sarama's hashPartitioner uses

--- a/balancer.go
+++ b/balancer.go
@@ -1,6 +1,11 @@
 package kafka
 
-import "sort"
+import (
+	"hash"
+	"hash/fnv"
+	"sort"
+	"sync"
+)
 
 // The Balancer interface provides an abstraction of the message distribution
 // logic used by Writer instances to route messages to the partitions available
@@ -102,5 +107,46 @@ func (lb *LeastBytes) makeCounters(partitions ...int) (counters []leastBytesCoun
 	sort.Slice(counters, func(i int, j int) bool {
 		return counters[i].partition < counters[j].partition
 	})
+	return
+}
+
+var (
+	fnv1aPool = &sync.Pool{
+		New: func() interface{} {
+			return fnv.New32a()
+		},
+	}
+)
+
+// Hash is a Balancer implementation that routes messages to the partition
+// based on the FNV-1a hash of the key.  This ensures that messages with the
+// same key end up on the same partition.
+//
+// Note that this is the same algorithm used by the Sarama Producer and ensures
+// that messages produced by kafka-go will be delivered to the same topics that
+// the Sarama producer would be delivered to
+type Hash struct {
+	rr RoundRobin
+}
+
+func (h *Hash) Balance(msg Message, partitions ...int) (partition int) {
+	if msg.Key == nil {
+		return (&h.rr).Balance(msg, partitions...)
+	}
+
+	hasher := fnv1aPool.Get().(hash.Hash32)
+	defer fnv1aPool.Put(hasher)
+
+	hasher.Reset()
+	if _, err := hasher.Write(msg.Key); err != nil {
+		return (&h.rr).Balance(msg, partitions...)
+	}
+
+	// uses same algorithm that Sarama's hashPartitioner uses
+	partition = int(hasher.Sum32()) % len(partitions)
+	if partition < 0 {
+		partition = -partition
+	}
+
 	return
 }

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -1,0 +1,43 @@
+package kafka
+
+import "testing"
+
+func TestHashBalancer(t *testing.T) {
+	testCases := map[string]struct {
+		Key        []byte
+		Partitions []int
+		Partition  int
+	}{
+		"nil": {
+			Key:        nil,
+			Partitions: []int{0, 1, 2},
+			Partition:  0,
+		},
+		"partition-0": {
+			Key:        []byte("blah"),
+			Partitions: []int{0, 1},
+			Partition:  0,
+		},
+		"partition-1": {
+			Key:        []byte("blah"),
+			Partitions: []int{0, 1, 2},
+			Partition:  1,
+		},
+		"partition-2": {
+			Key:        []byte("boop"),
+			Partitions: []int{0, 1, 2},
+			Partition:  2,
+		},
+	}
+
+	for label, test := range testCases {
+		t.Run(label, func(t *testing.T) {
+			msg := Message{Key: test.Key}
+			h := Hash{}
+			partition := h.Balance(msg, test.Partitions...)
+			if partition != test.Partition {
+				t.Errorf("expected %v; got %v", test.Partition, partition)
+			}
+		})
+	}
+}


### PR DESCRIPTION
by default, sarama uses the fnv1a algorithm to determine which partition to route messages to.  

To ensure that messages are routed to the same partition, I've added a Hash balancer that uses the same logic.

Even if one is not coming from sarama, having a partitioner that routes messages with the same key to the same partition is critical.
