### PR TITLE
added consumer group support to Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ r := kafka.NewReader(kafka.ReaderConfig{
     Brokers:   []string{"localhost:9092"},
     GroupID:   "consumer-group-id",
     Topic:     "topic-A",
-    Partition: 0,
     MinBytes:  10e3, // 10KB
     MaxBytes:  10e6, // 10MB
 })
@@ -158,7 +157,6 @@ r := kafka.NewReader(kafka.ReaderConfig{
     Brokers:        []string{"localhost:9092"},
     GroupID:        "consumer-group-id",
     Topic:          "topic-A",
-    Partition:      0,
     MinBytes:       10e3, // 10KB
     MaxBytes:       10e6, // 10MB
     CommitInterval: time.Second, // flushes commits to Kafka every second

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ for {
     if err != nil {
         break
     }
-    fmt.Printf("message at offset %d: %s = %s\n", m.Offset, string(m.Key), string(m.Value))
+    fmt.Printf("message at topic/partition/offset %v/%v/%v: %s = %s\n", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value))
     r.CommitMessage(m)
 }
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ r.Close()
 To enable consumer groups, simplify specify the GroupID in the ReaderConfig.
 
 ```go
-// make a new reader that consumes from topic-A, partition 0, at offset 42
+// make a new reader that consumes from topic-A
 r := kafka.NewReader(kafka.ReaderConfig{
     Brokers:   []string{"localhost:9092"},
     GroupID:   "consumer-group-id",
@@ -152,7 +152,7 @@ by setting CommitInterval on the ReaderConfig.
 
 
 ```go
-// make a new reader that consumes from topic-A, partition 0, at offset 42
+// make a new reader that consumes from topic-A
 r := kafka.NewReader(kafka.ReaderConfig{
     Brokers:        []string{"localhost:9092"},
     GroupID:        "consumer-group-id",

--- a/README.md
+++ b/README.md
@@ -148,22 +148,23 @@ There are a number of limitations when using consumer groups:
 ### Explicit Commits
 
 ```kafka-go``` also supports explicit commits.  Instead of calling ```ReadMessage```,
-call ```FetchMessage``` followed by ```CommitMessage```.
+call ```FetchMessage``` followed by ```CommitMessages```.
 
 ```go
+ctx := context.Background()
 for {
-    m, err := r.FetchMessage(context.Background())
+    m, err := r.FetchMessage(ctx)
     if err != nil {
         break
     }
     fmt.Printf("message at topic/partition/offset %v/%v/%v: %s = %s\n", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value))
-    m.CommitMessage(m)
+    m.CommitMessages(ctx, m)
 }
 ```
 
 ### Managing Commits
 
-By default, CommitMessage will synchronously commit offsets to Kafka.  For
+By default, CommitMessages will synchronously commit offsets to Kafka.  For
 improved performance, you can instead periodically commit offsets to Kafka
 by setting CommitInterval on the ReaderConfig.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ r.Close()
 ```kafka-go``` also supports Kafka consumer groups including broker managed offsets.
 To enable consumer groups, simplify specify the GroupID in the ReaderConfig.
 
+ReadMessage automatically commits offsets when using consumer groups.
+
 ```go
 // make a new reader that consumes from topic-A
 r := kafka.NewReader(kafka.ReaderConfig{
@@ -130,7 +132,6 @@ for {
         break
     }
     fmt.Printf("message at topic/partition/offset %v/%v/%v: %s = %s\n", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value))
-    r.CommitMessage(m)
 }
 
 r.Close()
@@ -143,6 +144,22 @@ There are a number of limitations when using consumer groups:
 * ```(*Reader).Lag``` will always return ```-1``` when GroupID is set
 * ```(*Reader).ReadLag``` will return an error when GroupID is set
 * ```(*Reader).Stats``` will return a partition of ```-1``` when GroupID is set
+
+### Explicit Commits
+
+```kafka-go``` also supports explicit commits.  Instead of calling ```ReadMessage```,
+call ```FetchMessage``` followed by ```CommitMessage```.
+
+```go
+for {
+    m, err := r.FetchMessage(context.Background())
+    if err != nil {
+        break
+    }
+    fmt.Printf("message at topic/partition/offset %v/%v/%v: %s = %s\n", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value))
+    m.CommitMessage(m)
+}
+```
 
 ### Managing Commits
 

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -245,7 +245,8 @@ func TestDialerTLS(t *testing.T) {
 
 type MockConn struct {
 	net.Conn
-	done chan struct{}
+	done       chan struct{}
+	partitions []Partition
 }
 
 func (m *MockConn) Read(b []byte) (n int, err error) {
@@ -275,6 +276,10 @@ func (m *MockConn) Close() error {
 		close(m.done)
 	}
 	return nil
+}
+
+func (m *MockConn) ReadPartitions(topics ...string) (partitions []Partition, err error) {
+	return m.partitions, err
 }
 
 func TestDialerConnectTLSHonorsContext(t *testing.T) {

--- a/joingroup.go
+++ b/joingroup.go
@@ -2,7 +2,54 @@ package kafka
 
 import (
 	"bufio"
+	"bytes"
 )
+
+type memberGroupMetadata struct {
+	// MemberID assigned by the group coordinator or null if joining for the
+	// first time.
+	MemberID string
+	Metadata groupMetadata
+}
+
+type groupMetadata struct {
+	Version  int16
+	Topics   []string
+	UserData []byte
+}
+
+func (t groupMetadata) size() int32 {
+	return sizeofInt16(t.Version) +
+		sizeofStringArray(t.Topics) +
+		sizeofBytes(t.UserData)
+}
+
+func (t groupMetadata) writeTo(w *bufio.Writer) {
+	writeInt16(w, t.Version)
+	writeStringArray(w, t.Topics)
+	writeBytes(w, t.UserData)
+}
+
+func (t groupMetadata) bytes() []byte {
+	buf := bytes.NewBuffer(nil)
+	w := bufio.NewWriter(buf)
+	t.writeTo(w)
+	w.Flush()
+	return buf.Bytes()
+}
+
+func (t *groupMetadata) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt16(r, size, &t.Version); err != nil {
+		return
+	}
+	if remain, err = readStringArray(r, remain, &t.Topics); err != nil {
+		return
+	}
+	if remain, err = readBytes(r, remain, &t.UserData); err != nil {
+		return
+	}
+	return
+}
 
 type joinGroupRequestGroupProtocolV2 struct {
 	ProtocolName     string

--- a/joingroup_test.go
+++ b/joingroup_test.go
@@ -7,6 +7,100 @@ import (
 	"testing"
 )
 
+func TestSaramaCompatibility(t *testing.T) {
+	var (
+		// sample data from github.com/Shopify/sarama
+		//
+		// See consumer_group_members_test.go
+		//
+		groupMemberMetadata = []byte{
+			0, 1, // Version
+			0, 0, 0, 2, // Topic array length
+			0, 3, 'o', 'n', 'e', // Topic one
+			0, 3, 't', 'w', 'o', // Topic two
+			0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
+		}
+		groupMemberAssignment = []byte{
+			0, 1, // Version
+			0, 0, 0, 1, // Topic array length
+			0, 3, 'o', 'n', 'e', // Topic one
+			0, 0, 0, 3, // Topic one, partition array length
+			0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4, // 0, 2, 4
+			0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
+		}
+	)
+
+	t.Run("verify metadata", func(t *testing.T) {
+		var item groupMetadata
+		remain, err := (&item).readFrom(bufio.NewReader(bytes.NewReader(groupMemberMetadata)), len(groupMemberMetadata))
+		if err != nil {
+			t.Fatalf("bad err: %v", err)
+		}
+		if remain != 0 {
+			t.Fatalf("expected 0; got %v", remain)
+		}
+
+		if v := item.Version; v != 1 {
+			t.Errorf("expected Version 1; got %v", v)
+		}
+		if v := item.Topics; !reflect.DeepEqual([]string{"one", "two"}, v) {
+			t.Errorf(`expected {"one", "two"}; got %v`, v)
+		}
+		if v := item.UserData; !reflect.DeepEqual([]byte{0x01, 0x02, 0x03}, v) {
+			t.Errorf("expected []byte{0x01, 0x02, 0x03}; got %v", v)
+		}
+	})
+
+	t.Run("verify assignments", func(t *testing.T) {
+		var item groupAssignment
+		remain, err := (&item).readFrom(bufio.NewReader(bytes.NewReader(groupMemberAssignment)), len(groupMemberAssignment))
+		if err != nil {
+			t.Fatalf("bad err: %v", err)
+		}
+		if remain != 0 {
+			t.Fatalf("expected 0; got %v", remain)
+		}
+
+		if v := item.Version; v != 1 {
+			t.Errorf("expected Version 1; got %v", v)
+		}
+		if v := item.Topics; !reflect.DeepEqual(map[string][]int32{"one": {0, 2, 4}}, v) {
+			t.Errorf(`expected map[string][]int32{"one": {0, 2, 4}}; got %v`, v)
+		}
+		if v := item.UserData; !reflect.DeepEqual([]byte{0x01, 0x02, 0x03}, v) {
+			t.Errorf("expected []byte{0x01, 0x02, 0x03}; got %v", v)
+		}
+	})
+}
+
+func TestMemberMetadata(t *testing.T) {
+	item := groupMetadata{
+		Version:  1,
+		Topics:   []string{"a", "b"},
+		UserData: []byte(`blah`),
+	}
+
+	buf := bytes.NewBuffer(nil)
+	w := bufio.NewWriter(buf)
+	item.writeTo(w)
+	w.Flush()
+
+	var found groupMetadata
+	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}
+
 func TestJoinGroupResponseV1(t *testing.T) {
 	item := joinGroupResponseV2{
 		ThrottleTimeMS: 1,

--- a/read.go
+++ b/read.go
@@ -143,8 +143,8 @@ func readStringArray(r *bufio.Reader, sz int, v *[]string) (remain int, err erro
 }
 
 func readMapStringInt32(r *bufio.Reader, sz int, v *map[string][]int32) (remain int, err error) {
-	var len int16
-	if remain, err = readInt16(r, sz, &len); err != nil {
+	var len int32
+	if remain, err = readInt32(r, sz, &len); err != nil {
 		return
 	}
 

--- a/read_test.go
+++ b/read_test.go
@@ -55,7 +55,7 @@ func TestReadMapStringInt32(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
 
 			w := bufio.NewWriter(buf)
-			writeInt16(w, int16(len(test.Data)))
+			writeInt32(w, int32(len(test.Data)))
 			for key, values := range test.Data {
 				writeString(w, key)
 				writeInt32Array(w, values)

--- a/reader.go
+++ b/reader.go
@@ -1093,6 +1093,15 @@ func (r *Reader) Close() error {
 	r.stop()
 	r.join.Wait()
 
+	if r.useConsumerGroup() {
+		// gracefully attempt to leave the consumer group on close
+		if generationID, membershipID := r.membership(); generationID > 0 && membershipID != "" {
+			if conn, err := r.coordinator(); err == nil {
+				_ = r.leaveGroup(conn)
+			}
+		}
+	}
+
 	<-r.done
 
 	if !closed {

--- a/reader.go
+++ b/reader.go
@@ -1787,7 +1787,7 @@ func (r *reader) withErrorLogger(do func(*log.Logger)) {
 // extractTopics returns the unique list of topics represented by the set of
 // provided members
 func extractTopics(members []memberGroupMetadata) []string {
-	visited := map[string]struct{}{}
+	var visited = map[string]struct{}{}
 	var topics []string
 
 	for _, member := range members {

--- a/reader.go
+++ b/reader.go
@@ -1062,8 +1062,8 @@ func NewReader(config ReaderConfig) *Reader {
 			panic(fmt.Sprintf("HeartbeatInterval out of bounds: %d", config.HeartbeatInterval))
 		}
 
-		if config.SessionTimeout < 0 || (config.HeartbeatInterval/time.Millisecond) >= math.MaxInt32 {
-			panic(fmt.Sprintf("HeartbeatInterval out of bounds: %d", config.HeartbeatInterval))
+		if config.SessionTimeout < 0 || (config.SessionTimeout/time.Millisecond) >= math.MaxInt32 {
+			panic(fmt.Sprintf("SessionTimeout out of bounds: %d", config.SessionTimeout))
 		}
 
 		if config.RebalanceTimeout < 0 || (config.RebalanceTimeout/time.Millisecond) >= math.MaxInt32 {

--- a/reader.go
+++ b/reader.go
@@ -506,11 +506,13 @@ func (r *Reader) waitThrottleTime(throttleTimeMS int32) {
 		return
 	}
 
+	t := time.NewTimer(time.Duration(throttleTimeMS) * time.Millisecond)
+	defer t.Stop()
+
 	select {
 	case <-r.stctx.Done():
 		return
-
-	case <-time.After(time.Duration(throttleTimeMS) * time.Millisecond):
+	case <-t.C:
 	}
 }
 

--- a/reader.go
+++ b/reader.go
@@ -470,7 +470,7 @@ func (r *Reader) subscribe(subs map[string][]int32) error {
 	r.start(offsetsByPartition)
 	r.mutex.Unlock()
 
-	r.withErrorLogger(func(l *log.Logger) {
+	r.withLogger(func(l *log.Logger) {
 		l.Printf("subscribed to partitions: %+v", offsetsByPartition)
 	})
 

--- a/reader.go
+++ b/reader.go
@@ -945,7 +945,7 @@ type ReaderConfig struct {
 	// Only used when GroupID is set
 	CommitInterval time.Duration
 
-	// HeartbeatInterval optionally sets the length of time that may pass without a heartbeat
+	// SessionTimeout optionally sets the length of time that may pass without a heartbeat
 	// before the coordinator considers the consumer dead and initiates a rebalance.
 	//
 	// Default: 30s

--- a/reader.go
+++ b/reader.go
@@ -444,12 +444,12 @@ func (r *Reader) rebalance() (map[string][]int32, error) {
 		return nil, err
 	}
 
-	subs, err := r.syncGroup(members)
+	assignments, err := r.syncGroup(members)
 	if err != nil {
 		return nil, err
 	}
 
-	return subs, nil
+	return assignments, nil
 }
 
 func (r *Reader) unsubscribe() error {

--- a/reader.go
+++ b/reader.go
@@ -176,9 +176,9 @@ func (r *Reader) refreshCoordinator() (err error) {
 	return nil
 }
 
-// newJoinGroupRequestV2 handles the logic of constructing a joinGroup
+// makeJoinGroupRequestV2 handles the logic of constructing a joinGroup
 // request
-func (r *Reader) newJoinGroupRequestV2() (joinGroupRequestV2, error) {
+func (r *Reader) makeJoinGroupRequestV2() (joinGroupRequestV2, error) {
 	_, memberID := r.membership()
 
 	request := joinGroupRequestV2{
@@ -283,7 +283,7 @@ func (r *Reader) joinGroup() (memberGroupAssignments, error) {
 	}
 	defer conn.Close()
 
-	request, err := r.newJoinGroupRequestV2()
+	request, err := r.makeJoinGroupRequestV2()
 	if err != nil {
 		return nil, err
 	}

--- a/reader.go
+++ b/reader.go
@@ -174,7 +174,7 @@ func (r *Reader) makeJoinGroupRequestV2() (joinGroupRequestV2, error) {
 	}
 
 	for _, strategy := range allStrategies {
-		meta, err := strategy.ProtocolMetadata([]string{r.config.Topic})
+		meta, err := strategy.GroupMetadata([]string{r.config.Topic})
 		if err != nil {
 			return joinGroupRequestV2{}, fmt.Errorf("unable to construct protocol metadata for member, %v: %v\n", strategy.ProtocolName(), err)
 		}

--- a/reader.go
+++ b/reader.go
@@ -183,8 +183,8 @@ func (r *Reader) makeJoinGroupRequestV2() (joinGroupRequestV2, error) {
 	return request, nil
 }
 
-// newMemberProtocolMetadata maps encoded member metadata ([]byte) into memberGroupMetadata
-func (r *Reader) newMemberProtocolMetadata(in []joinGroupResponseMemberV2) ([]memberGroupMetadata, error) {
+// makeMemberProtocolMetadata maps encoded member metadata ([]byte) into memberGroupMetadata
+func (r *Reader) makeMemberProtocolMetadata(in []joinGroupResponseMemberV2) ([]memberGroupMetadata, error) {
 	members := make([]memberGroupMetadata, 0, len(in))
 	for _, item := range in {
 		metadata := groupMetadata{}
@@ -220,7 +220,7 @@ func (r *Reader) assignTopicPartitions(conn partitionReader, group joinGroupResp
 		return nil, fmt.Errorf("unable to find selected strategy, %v, for group, %v", group.GroupProtocol, r.config.GroupID)
 	}
 
-	members, err := r.newMemberProtocolMetadata(group.Members)
+	members, err := r.makeMemberProtocolMetadata(group.Members)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct MemberProtocolMetadata: %v", err)
 	}
@@ -321,7 +321,7 @@ func (r *Reader) joinGroup() (memberGroupAssignments, error) {
 	return assignments, nil
 }
 
-func (r *Reader) newSyncGroupRequestV1(memberAssignments memberGroupAssignments) syncGroupRequestV1 {
+func (r *Reader) makeSyncGroupRequestV1(memberAssignments memberGroupAssignments) syncGroupRequestV1 {
 	generationID, memberID := r.membership()
 	request := syncGroupRequestV1{
 		GroupID:      r.config.GroupID,
@@ -363,7 +363,7 @@ func (r *Reader) syncGroup(memberAssignments memberGroupAssignments) (map[string
 	}
 	defer conn.Close()
 
-	request := r.newSyncGroupRequestV1(memberAssignments)
+	request := r.makeSyncGroupRequestV1(memberAssignments)
 	response, err := conn.syncGroups(request)
 	if err != nil {
 		switch err {

--- a/reader.go
+++ b/reader.go
@@ -86,6 +86,11 @@ type Reader struct {
 	stats readerStats
 }
 
+// useConsumerGroup indicates the Reader is part of a consumer group
+func (r *Reader) useConsumerGroup() bool {
+	return r.config.GroupID != ""
+}
+
 // membership returns the group generationID and memberID of the reader.
 //
 // Only used when config.GroupID != ""
@@ -1178,7 +1183,7 @@ func (r *Reader) ReadMessage(ctx context.Context) (Message, error) {
 // The function returns a lag of zero when the reader's current offset is
 // negative.
 func (r *Reader) ReadLag(ctx context.Context) (lag int64, err error) {
-	if r.config.GroupID != "" {
+	if r.useConsumerGroup() {
 		return 0, errNotAvailable
 	}
 
@@ -1241,7 +1246,7 @@ func (r *Reader) ReadLag(ctx context.Context) (lag int64, err error) {
 
 // Offset returns the current offset of the reader.
 func (r *Reader) Offset() int64 {
-	if r.config.GroupID != "" {
+	if r.useConsumerGroup() {
 		return -1
 	}
 
@@ -1256,7 +1261,7 @@ func (r *Reader) Offset() int64 {
 
 // Lag returns the lag of the last message returned by ReadMessage.
 func (r *Reader) Lag() int64 {
-	if r.config.GroupID != "" {
+	if r.useConsumerGroup() {
 		return -1
 	}
 
@@ -1274,7 +1279,7 @@ func (r *Reader) Lag() int64 {
 //
 // The method fails with io.ErrClosedPipe if the reader has already been closed.
 func (r *Reader) SetOffset(offset int64) error {
-	if r.config.GroupID != "" {
+	if r.useConsumerGroup() {
 		return errNotAvailable
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -578,10 +578,10 @@ func (r *Reader) heartbeat() error {
 
 func (r *Reader) heartbeatLoop(stop <-chan struct{}) {
 	r.withLogger(func(l *log.Logger) {
-		l.Printf("started heartbeat group, %v [%v]", r.config.GroupID, r.config.HeartbeatInterval)
+		l.Printf("started heartbeat for group, %v [%v]", r.config.GroupID, r.config.HeartbeatInterval)
 	})
 	defer r.withLogger(func(l *log.Logger) {
-		l.Println("stopped heartbeat group,", r.config.GroupID)
+		l.Println("stopped heartbeat for group,", r.config.GroupID)
 	})
 
 	ticker := time.NewTicker(r.config.HeartbeatInterval)
@@ -727,10 +727,10 @@ func (r *Reader) commitLoopInterval(conn offsetCommitter, stop <-chan struct{}) 
 // commitLoop processes commits off the commit chan
 func (r *Reader) commitLoop(stop <-chan struct{}) {
 	r.withLogger(func(l *log.Logger) {
-		l.Println("started commit group,", r.config.GroupID)
+		l.Println("started commit for group,", r.config.GroupID)
 	})
 	defer r.withLogger(func(l *log.Logger) {
-		l.Println("stopped commit group,", r.config.GroupID)
+		l.Println("stopped commit for group,", r.config.GroupID)
 	})
 
 	conn, err := r.connect(r.stctx)
@@ -753,10 +753,10 @@ func (r *Reader) commitLoop(stop <-chan struct{}) {
 // consumer group.  handshake will be called whenever the group is disrupted
 // (member join, member leave, coordinator changed, etc)
 func (r *Reader) handshake() error {
-	// always clear prior subscriptions
+	// always clear prior to subscribe
 	r.unsubscribe()
 
-	// rebalance and fetch subscriptions
+	// rebalance and fetch assignments
 	assignments, err := r.rebalance()
 	if err != nil {
 		return fmt.Errorf("rebalance failed for consumer group, %v: %v", r.config.GroupID, err)

--- a/reader.go
+++ b/reader.go
@@ -637,7 +637,7 @@ func (r *Reader) heartbeat() error {
 	return nil
 }
 
-func (r *Reader) hbLoop(stop <-chan struct{}, done chan<- struct{}) {
+func (r *Reader) heartbeatLoop(stop <-chan struct{}, done chan<- struct{}) {
 	defer close(done)
 
 	r.withLogger(func(l *log.Logger) {
@@ -844,7 +844,7 @@ func (r *Reader) run() {
 
 		// start the heartbeat
 		hbStop, hbDone := make(chan struct{}), make(chan struct{})
-		go r.hbLoop(hbStop, hbDone)
+		go r.heartbeatLoop(hbStop, hbDone)
 
 		commitStop, commitDone := make(chan struct{}), make(chan struct{})
 		go r.commitLoop(commitStop, commitDone)

--- a/reader.go
+++ b/reader.go
@@ -813,11 +813,6 @@ func (r *Reader) commitLoop(stop <-chan struct{}, done chan<- struct{}) {
 func (r *Reader) run() {
 	defer close(r.done)
 
-	const (
-		backoffDelayMin = 100 * time.Millisecond
-		backoffDelayMax = 3 * time.Second
-	)
-
 	if r.config.GroupID == "" {
 		return
 	}
@@ -827,12 +822,6 @@ func (r *Reader) run() {
 	})
 
 	for attempt := 0; true; attempt++ {
-		if attempt != 0 {
-			if !sleep(r.stctx, backoff(attempt, backoffDelayMin, backoffDelayMax)) {
-				return
-			}
-		}
-
 		// rebalance and fetch subscriptions
 		assignments, err := r.rebalance()
 		if err != nil {

--- a/reader.go
+++ b/reader.go
@@ -797,7 +797,7 @@ func (r *Reader) runOnce() error {
 func (r *Reader) run() {
 	defer close(r.done)
 
-	if r.config.GroupID == "" {
+	if !r.useConsumerGroup() {
 		return
 	}
 
@@ -1358,7 +1358,7 @@ func (r *Reader) activateReadLag() {
 	if r.config.ReadLagInterval > 0 && atomic.CompareAndSwapUint32(&r.once, 0, 1) {
 		// read lag will only be calculated when not using consumer groups
 		// todo discuss how capturing read lag should interact with rebalancing
-		if r.config.GroupID == "" {
+		if !r.useConsumerGroup() {
 			go r.readLag(r.stctx)
 		}
 	}
@@ -1421,7 +1421,7 @@ func (r *Reader) start(offsetsByPartition map[int]int64) {
 }
 
 func (r *Reader) CommitMessage(m Message) error {
-	if r.config.GroupID == "" {
+	if !r.useConsumerGroup() {
 		return errNotAvailable
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -1467,6 +1467,11 @@ func (r *Reader) readLag(ctx context.Context) {
 }
 
 func (r *Reader) start(offsetsByPartition map[int]int64) {
+	if r.closed {
+		// don't start child reader if parent Reader is closed
+		return
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	r.cancel() // always cancel the previous reader

--- a/reader.go
+++ b/reader.go
@@ -457,9 +457,6 @@ func (r *Reader) fetchOffsets(subs map[string][]int32) (map[int]int64, error) {
 }
 
 func (r *Reader) subscribe(subs map[string][]int32) error {
-	// always clear prior subscriptions
-	r.unsubscribe()
-
 	if len(subs[r.config.Topic]) == 0 {
 		return nil
 	}
@@ -765,6 +762,9 @@ func (r *Reader) commitLoop(stop <-chan struct{}) {
 }
 
 func (r *Reader) runOnce() error {
+	// always clear prior subscriptions
+	r.unsubscribe()
+
 	// rebalance and fetch subscriptions
 	assignments, err := r.rebalance()
 	if err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -820,11 +820,11 @@ func testReaderConsumerGroupHandshake(t *testing.T, ctx context.Context, r *Read
 func testReaderConsumerGroupVerifyOffsetCommitted(t *testing.T, ctx context.Context, r *Reader) {
 	prepareReader(t, context.Background(), r, makeTestSequence(3)...)
 
-	if _, err := r.ReadMessage(ctx); err != nil {
+	if _, err := r.FetchMessage(ctx); err != nil {
 		t.Errorf("bad err: %v", err) // skip the first message
 	}
 
-	m, err := r.ReadMessage(ctx)
+	m, err := r.FetchMessage(ctx)
 	if err != nil {
 		t.Errorf("bad err: %v", err)
 	}
@@ -848,11 +848,11 @@ func testReaderConsumerGroupVerifyOffsetCommitted(t *testing.T, ctx context.Cont
 func testReaderConsumerGroupVerifyPeriodicOffsetCommitter(t *testing.T, ctx context.Context, r *Reader) {
 	prepareReader(t, context.Background(), r, makeTestSequence(3)...)
 
-	if _, err := r.ReadMessage(ctx); err != nil {
+	if _, err := r.FetchMessage(ctx); err != nil {
 		t.Errorf("bad err: %v", err) // skip the first message
 	}
 
-	m, err := r.ReadMessage(ctx)
+	m, err := r.FetchMessage(ctx)
 	if err != nil {
 		t.Errorf("bad err: %v", err)
 	}
@@ -883,11 +883,11 @@ func testReaderConsumerGroupVerifyPeriodicOffsetCommitter(t *testing.T, ctx cont
 func testReaderConsumerGroupVerifyCommitsOnClose(t *testing.T, ctx context.Context, r *Reader) {
 	prepareReader(t, context.Background(), r, makeTestSequence(3)...)
 
-	if _, err := r.ReadMessage(ctx); err != nil {
+	if _, err := r.FetchMessage(ctx); err != nil {
 		t.Errorf("bad err: %v", err) // skip the first message
 	}
 
-	m, err := r.ReadMessage(ctx)
+	m, err := r.FetchMessage(ctx)
 	if err != nil {
 		t.Errorf("bad err: %v", err)
 	}
@@ -934,7 +934,7 @@ func testReaderConsumerGroupReadContentAcrossPartitions(t *testing.T, ctx contex
 
 	partitions := map[int]struct{}{}
 	for i := 0; i < N; i++ {
-		m, err := r.ReadMessage(ctx)
+		m, err := r.FetchMessage(ctx)
 		if err != nil {
 			t.Errorf("bad error: %s", err)
 		}
@@ -972,10 +972,10 @@ func testReaderConsumerGroupRebalance(t *testing.T, ctx context.Context, r *Read
 
 	// after rebalance, each reader should have a partition to itself
 	for i := 0; i < N; i++ {
-		if _, err := r2.ReadMessage(ctx); err != nil {
+		if _, err := r2.FetchMessage(ctx); err != nil {
 			t.Errorf("expect to read from reader 2")
 		}
-		if _, err := r.ReadMessage(ctx); err != nil {
+		if _, err := r.FetchMessage(ctx); err != nil {
 			t.Errorf("expect to read from reader 1")
 		}
 	}
@@ -1020,13 +1020,13 @@ func testReaderConsumerGroupRebalanceAcrossTopics(t *testing.T, ctx context.Cont
 	}
 
 	// after rebalance, r2 should read topic2 and r1 should read ALL of the original topic
-	if _, err := r2.ReadMessage(ctx); err != nil {
+	if _, err := r2.FetchMessage(ctx); err != nil {
 		t.Errorf("expect to read from reader 2")
 	}
 
 	// all N messages on the original topic should be read by the original reader
 	for i := 0; i < N; i++ {
-		if _, err := r.ReadMessage(ctx); err != nil {
+		if _, err := r.FetchMessage(ctx); err != nil {
 			t.Errorf("expect to read from reader 1")
 		}
 	}

--- a/rungroup.go
+++ b/rungroup.go
@@ -6,7 +6,7 @@ import (
 )
 
 // runGroup is a collection of goroutines working together. If any one goroutine
-// stops, then all goroutines must be stopped.
+// stops, then all goroutines will be stopped.
 //
 // A zero runGroup is valid
 type runGroup struct {

--- a/rungroup.go
+++ b/rungroup.go
@@ -1,0 +1,61 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+)
+
+// runGroup is a collection of goroutines working together. If any one goroutine
+// stops, then all goroutines must be stopped.
+//
+// A zero runGroup is valid
+type runGroup struct {
+	initOnce sync.Once
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	wg sync.WaitGroup
+}
+
+func (r *runGroup) init() {
+	if r.cancel == nil {
+		r.ctx, r.cancel = context.WithCancel(context.Background())
+	}
+}
+
+func (r *runGroup) WithContext(ctx context.Context) *runGroup {
+	ctx, cancel := context.WithCancel(ctx)
+	return &runGroup{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// Wait blocks until all function calls have returned.
+func (r *runGroup) Wait() {
+	r.wg.Wait()
+}
+
+// Stop stops the goroutines and waits for them to complete
+func (r *runGroup) Stop() {
+	r.initOnce.Do(r.init)
+	r.cancel()
+	r.Wait()
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (r *runGroup) Go(f func(stop <-chan struct{})) {
+	r.initOnce.Do(r.init)
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		defer r.cancel()
+
+		f(r.ctx.Done())
+	}()
+}

--- a/rungroup_test.go
+++ b/rungroup_test.go
@@ -1,0 +1,61 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRunGroup(t *testing.T) {
+	t.Run("Wait returns on empty group", func(t *testing.T) {
+		rg := &runGroup{}
+		rg.Wait()
+	})
+
+	t.Run("Stop returns on empty group", func(t *testing.T) {
+		rg := &runGroup{}
+		rg.Stop()
+	})
+
+	t.Run("Stop cancels running tasks", func(t *testing.T) {
+		rg := &runGroup{}
+		rg.Go(func(stop <-chan struct{}) {
+			<-stop
+		})
+		rg.Stop()
+	})
+
+	t.Run("Honors parent context", func(t *testing.T) {
+		now := time.Now()
+		timeout := time.Millisecond * 100
+
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		rg := &runGroup{}
+		rg = rg.WithContext(ctx)
+		rg.Go(func(stop <-chan struct{}) {
+			<-stop
+		})
+		rg.Wait()
+
+		elapsed := time.Now().Sub(now)
+		if elapsed < timeout {
+			t.Errorf("expected elapsed > %v; got %v", timeout, elapsed)
+		}
+	})
+
+	t.Run("Any death kills all; one for all and all for one", func(t *testing.T) {
+		rg := &runGroup{}
+		rg.Go(func(stop <-chan struct{}) {
+			<-stop
+		})
+		rg.Go(func(stop <-chan struct{}) {
+			<-stop
+		})
+		rg.Go(func(stop <-chan struct{}) {
+			// return immediately
+		})
+		rg.Wait()
+	})
+}

--- a/strategy.go
+++ b/strategy.go
@@ -1,0 +1,182 @@
+package kafka
+
+import "sort"
+
+// strategy encapsulates the client side rebalancing logic
+type strategy interface {
+	// ProtocolName of strategy
+	ProtocolName() string
+
+	// ProtocolMetadata returns the metadata for the protocol
+	ProtocolMetadata(topics []string) (groupMetadata, error)
+
+	// DefineMemberships returns which members will be consuming
+	// which topic partitions
+	AssignGroups(members []memberGroupMetadata, partitions []Partition) memberGroupAssignments
+}
+
+var (
+	// allStrategies the kafka-go Reader supports
+	allStrategies = []strategy{
+		rangeStrategy{},
+		roundrobinStrategy{},
+	}
+)
+
+// rangeStrategy groups consumers by partition
+//
+// Example: 5 partitions, 2 consumers
+// 		C0: [0, 1, 2]
+// 		C1: [3, 4]
+//
+// Example: 6 partitions, 3 consumers
+// 		C0: [0, 1]
+// 		C1: [2, 3]
+// 		C2: [4, 5]
+//
+type rangeStrategy struct{}
+
+func (r rangeStrategy) ProtocolName() string {
+	return "range"
+}
+
+func (r rangeStrategy) ProtocolMetadata(topics []string) (groupMetadata, error) {
+	return groupMetadata{
+		Version: 1,
+		Topics:  topics,
+	}, nil
+}
+
+func (r rangeStrategy) AssignGroups(members []memberGroupMetadata, topicPartitions []Partition) memberGroupAssignments {
+	groupAssignments := memberGroupAssignments{}
+	membersByTopic := findMembersByTopic(members)
+
+	for topic, members := range membersByTopic {
+		partitions := findPartitions(topic, topicPartitions)
+		partitionCount := len(partitions)
+		memberCount := len(members)
+
+		rangeSize := partitionCount / memberCount
+		if partitionCount%memberCount != 0 {
+			rangeSize++
+		}
+
+		for memberIndex, member := range members {
+			assignmentsByTopic, ok := groupAssignments[member.MemberID]
+			if !ok {
+				assignmentsByTopic = map[string][]int32{}
+				groupAssignments[member.MemberID] = assignmentsByTopic
+			}
+
+			for partitionIndex, partition := range partitions {
+				if (partitionIndex / rangeSize) == memberIndex {
+					assignmentsByTopic[topic] = append(assignmentsByTopic[topic], partition)
+				}
+			}
+		}
+	}
+
+	return groupAssignments
+}
+
+// roundrobinStrategy divides partitions evenly among consumers
+//
+// Example: 5 partitions, 2 consumers
+// 		C0: [0, 2, 4]
+// 		C1: [1, 3]
+//
+// Example: 6 partitions, 3 consumers
+// 		C0: [0, 3]
+// 		C1: [1, 4]
+// 		C2: [2, 5]
+//
+type roundrobinStrategy struct{}
+
+func (r roundrobinStrategy) ProtocolName() string {
+	return "roundrobin"
+}
+
+func (r roundrobinStrategy) ProtocolMetadata(topics []string) (groupMetadata, error) {
+	return groupMetadata{
+		Version: 1,
+		Topics:  topics,
+	}, nil
+}
+
+func (r roundrobinStrategy) AssignGroups(members []memberGroupMetadata, topicPartitions []Partition) memberGroupAssignments {
+	groupAssignments := memberGroupAssignments{}
+	membersByTopic := findMembersByTopic(members)
+	for topic, members := range membersByTopic {
+		partitionIDs := findPartitions(topic, topicPartitions)
+		memberCount := len(members)
+
+		for memberIndex, member := range members {
+			assignmentsByTopic, ok := groupAssignments[member.MemberID]
+			if !ok {
+				assignmentsByTopic = map[string][]int32{}
+				groupAssignments[member.MemberID] = assignmentsByTopic
+			}
+
+			for partitionIndex, partition := range partitionIDs {
+				if (partitionIndex % memberCount) == memberIndex {
+					assignmentsByTopic[topic] = append(assignmentsByTopic[topic], partition)
+				}
+			}
+		}
+	}
+
+	return groupAssignments
+}
+
+// findPartitions extracts the partition ids associated with the topic from the
+// list of Partitions provided
+func findPartitions(topic string, partitions []Partition) []int32 {
+	var ids []int32
+	for _, partition := range partitions {
+		if partition.Topic == topic {
+			ids = append(ids, int32(partition.ID))
+		}
+	}
+	return ids
+}
+
+// findMembersByTopic groups the memberGroupMetadata by topic
+func findMembersByTopic(members []memberGroupMetadata) map[string][]memberGroupMetadata {
+	membersByTopic := map[string][]memberGroupMetadata{}
+	for _, member := range members {
+		for _, topic := range member.Metadata.Topics {
+			membersByTopic[topic] = append(membersByTopic[topic], member)
+		}
+	}
+
+	// normalize ordering of members to enabling grouping across topics by partitions
+	//
+	// Want:
+	// 		C0 [T0/P0, T1/P0]
+	// 		C1 [T0/P1, T1/P1]
+	//
+	// Not:
+	// 		C0 [T0/P0, T1/P1]
+	// 		C1 [T0/P1, T1/P0]
+	//
+	// Even though the later is still round robin, the partitions are crossed
+	//
+	for _, members := range membersByTopic {
+		sort.Slice(members, func(i, j int) bool {
+			return members[i].MemberID < members[j].MemberID
+		})
+	}
+
+	return membersByTopic
+}
+
+// findStrategy returns the strategy with the specified protocolName from the
+// slice provided
+func findStrategy(protocolName string, strategies []strategy) (strategy, bool) {
+	for _, strategy := range strategies {
+		if strategy.ProtocolName() == protocolName {
+			return strategy, true
+		}
+	}
+	return nil, false
+}

--- a/strategy.go
+++ b/strategy.go
@@ -7,8 +7,13 @@ type strategy interface {
 	// ProtocolName of strategy
 	ProtocolName() string
 
-	// ProtocolMetadata returns the metadata for the protocol
-	ProtocolMetadata(topics []string) (groupMetadata, error)
+	// ProtocolMetadata provides the strategy an opportunity to embed custom
+	// UserData into the metadata.
+	//
+	// Will be used by JoinGroup to begin the consumer group handshake.
+	//
+	// See https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-JoinGroupRequest
+	GroupMetadata(topics []string) (groupMetadata, error)
 
 	// DefineMemberships returns which members will be consuming
 	// which topic partitions
@@ -40,7 +45,7 @@ func (r rangeStrategy) ProtocolName() string {
 	return "range"
 }
 
-func (r rangeStrategy) ProtocolMetadata(topics []string) (groupMetadata, error) {
+func (r rangeStrategy) GroupMetadata(topics []string) (groupMetadata, error) {
 	return groupMetadata{
 		Version: 1,
 		Topics:  topics,
@@ -96,7 +101,7 @@ func (r roundrobinStrategy) ProtocolName() string {
 	return "roundrobin"
 }
 
-func (r roundrobinStrategy) ProtocolMetadata(topics []string) (groupMetadata, error) {
+func (r roundrobinStrategy) GroupMetadata(topics []string) (groupMetadata, error) {
 	return groupMetadata{
 		Version: 1,
 		Topics:  topics,

--- a/strategy_test.go
+++ b/strategy_test.go
@@ -1,0 +1,350 @@
+package kafka
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestFindMembersByTopic(t *testing.T) {
+	a1 := memberGroupMetadata{
+		MemberID: "a",
+		Metadata: groupMetadata{
+			Topics: []string{"topic-1"},
+		},
+	}
+	a12 := memberGroupMetadata{
+		MemberID: "a",
+		Metadata: groupMetadata{
+			Topics: []string{"topic-1", "topic-2"},
+		},
+	}
+	b23 := memberGroupMetadata{
+		MemberID: "b",
+		Metadata: groupMetadata{
+			Topics: []string{"topic-2", "topic-3"},
+		},
+	}
+
+	tests := map[string]struct {
+		Members  []memberGroupMetadata
+		Expected map[string][]memberGroupMetadata
+	}{
+		"empty": {
+			Expected: map[string][]memberGroupMetadata{},
+		},
+		"one member, one topic": {
+			Members: []memberGroupMetadata{a1},
+			Expected: map[string][]memberGroupMetadata{
+				"topic-1": {
+					a1,
+				},
+			},
+		},
+		"one member, multiple topics": {
+			Members: []memberGroupMetadata{a12},
+			Expected: map[string][]memberGroupMetadata{
+				"topic-1": {
+					a12,
+				},
+				"topic-2": {
+					a12,
+				},
+			},
+		},
+		"multiple members, multiple topics": {
+			Members: []memberGroupMetadata{a12, b23},
+			Expected: map[string][]memberGroupMetadata{
+				"topic-1": {
+					a12,
+				},
+				"topic-2": {
+					a12,
+					b23,
+				},
+				"topic-3": {
+					b23,
+				},
+			},
+		},
+	}
+
+	for label, test := range tests {
+		t.Run(label, func(t *testing.T) {
+			membersByTopic := findMembersByTopic(test.Members)
+			if !reflect.DeepEqual(test.Expected, membersByTopic) {
+				t.Errorf("expected %#v; got %#v", test.Expected, membersByTopic)
+			}
+		})
+	}
+}
+
+func TestRangeAssignGroups(t *testing.T) {
+	newMeta := func(memberID string, topics ...string) memberGroupMetadata {
+		return memberGroupMetadata{
+			MemberID: memberID,
+			Metadata: groupMetadata{
+				Topics: topics,
+			},
+		}
+	}
+
+	newPartitions := func(partitionCount int, topics ...string) []Partition {
+		partitions := make([]Partition, 0, len(topics)*partitionCount)
+		for _, topic := range topics {
+			for partition := 0; partition < partitionCount; partition++ {
+				partitions = append(partitions, Partition{
+					Topic: topic,
+					ID:    partition,
+				})
+			}
+		}
+		return partitions
+	}
+
+	tests := map[string]struct {
+		Members    []memberGroupMetadata
+		Partitions []Partition
+		Expected   memberGroupAssignments
+	}{
+		"empty": {
+			Expected: memberGroupAssignments{},
+		},
+		"one member, one topic, one partition": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1"),
+			},
+			Partitions: newPartitions(1, "topic-1"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0},
+				},
+			},
+		},
+		"one member, one topic, multiple partitions": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1"),
+			},
+			Partitions: newPartitions(3, "topic-1"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0, 1, 2},
+				},
+			},
+		},
+		"multiple members, one topic, one partition": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1"),
+				newMeta("b", "topic-1"),
+			},
+			Partitions: newPartitions(1, "topic-1"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0},
+				},
+				"b": map[string][]int32{},
+			},
+		},
+		"multiple members, one topic, multiple partitions": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1"),
+				newMeta("b", "topic-1"),
+			},
+			Partitions: newPartitions(3, "topic-1"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0, 1},
+				},
+				"b": map[string][]int32{
+					"topic-1": {2},
+				},
+			},
+		},
+		"multiple members, multiple topics, multiple partitions": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1", "topic-2"),
+				newMeta("b", "topic-2", "topic-3"),
+			},
+			Partitions: newPartitions(3, "topic-1", "topic-2", "topic-3"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0, 1, 2},
+					"topic-2": {0, 1},
+				},
+				"b": map[string][]int32{
+					"topic-2": {2},
+					"topic-3": {0, 1, 2},
+				},
+			},
+		},
+	}
+
+	for label, test := range tests {
+		t.Run(label, func(t *testing.T) {
+			assignments := rangeStrategy{}.AssignGroups(test.Members, test.Partitions)
+			if !reflect.DeepEqual(test.Expected, assignments) {
+				buf := bytes.NewBuffer(nil)
+				encoder := json.NewEncoder(buf)
+				encoder.SetIndent("", "  ")
+
+				buf.WriteString("expected: ")
+				encoder.Encode(test.Expected)
+				buf.WriteString("got: ")
+				encoder.Encode(assignments)
+
+				t.Error(buf.String())
+			}
+		})
+	}
+}
+
+func TestRoundRobinAssignGroups(t *testing.T) {
+	newMeta := func(memberID string, topics ...string) memberGroupMetadata {
+		return memberGroupMetadata{
+			MemberID: memberID,
+			Metadata: groupMetadata{
+				Topics: topics,
+			},
+		}
+	}
+
+	newPartitions := func(partitionCount int, topics ...string) []Partition {
+		partitions := make([]Partition, 0, len(topics)*partitionCount)
+		for _, topic := range topics {
+			for partition := 0; partition < partitionCount; partition++ {
+				partitions = append(partitions, Partition{
+					Topic: topic,
+					ID:    partition,
+				})
+			}
+		}
+		return partitions
+	}
+
+	tests := map[string]struct {
+		Members    []memberGroupMetadata
+		Partitions []Partition
+		Expected   memberGroupAssignments
+	}{
+		"empty": {
+			Expected: memberGroupAssignments{},
+		},
+		"one member, one topic, one partition": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1"),
+			},
+			Partitions: newPartitions(1, "topic-1"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0},
+				},
+			},
+		},
+		"one member, one topic, multiple partitions": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1"),
+			},
+			Partitions: newPartitions(3, "topic-1"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0, 1, 2},
+				},
+			},
+		},
+		"multiple members, one topic, one partition": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1"),
+				newMeta("b", "topic-1"),
+			},
+			Partitions: newPartitions(1, "topic-1"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0},
+				},
+				"b": map[string][]int32{},
+			},
+		},
+		"multiple members, multiple topics, multiple partitions": {
+			Members: []memberGroupMetadata{
+				newMeta("a", "topic-1", "topic-2"),
+				newMeta("b", "topic-2", "topic-3"),
+			},
+			Partitions: newPartitions(3, "topic-1", "topic-2", "topic-3"),
+			Expected: memberGroupAssignments{
+				"a": map[string][]int32{
+					"topic-1": {0, 1, 2},
+					"topic-2": {0, 2},
+				},
+				"b": map[string][]int32{
+					"topic-2": {1},
+					"topic-3": {0, 1, 2},
+				},
+			},
+		},
+	}
+
+	for label, test := range tests {
+		t.Run(label, func(t *testing.T) {
+			assignments := roundrobinStrategy{}.AssignGroups(test.Members, test.Partitions)
+			if !reflect.DeepEqual(test.Expected, assignments) {
+				buf := bytes.NewBuffer(nil)
+				encoder := json.NewEncoder(buf)
+				encoder.SetIndent("", "  ")
+
+				buf.WriteString("expected: ")
+				encoder.Encode(test.Expected)
+				buf.WriteString("got: ")
+				encoder.Encode(assignments)
+
+				t.Error(buf.String())
+			}
+		})
+	}
+}
+
+func TestFindMembersByTopicSortsByMemberID(t *testing.T) {
+	topic := "topic-1"
+	a := memberGroupMetadata{
+		MemberID: "a",
+		Metadata: groupMetadata{
+			Topics: []string{topic},
+		},
+	}
+	b := memberGroupMetadata{
+		MemberID: "b",
+		Metadata: groupMetadata{
+			Topics: []string{topic},
+		},
+	}
+	c := memberGroupMetadata{
+		MemberID: "c",
+		Metadata: groupMetadata{
+			Topics: []string{topic},
+		},
+	}
+
+	testCases := map[string]struct {
+		Data     []memberGroupMetadata
+		Expected []memberGroupMetadata
+	}{
+		"in order": {
+			Data:     []memberGroupMetadata{a, b},
+			Expected: []memberGroupMetadata{a, b},
+		},
+		"out of order": {
+			Data:     []memberGroupMetadata{a, c, b},
+			Expected: []memberGroupMetadata{a, b, c},
+		},
+	}
+
+	for label, test := range testCases {
+		t.Run(label, func(t *testing.T) {
+			membersByTopic := findMembersByTopic(test.Data)
+
+			if actual := membersByTopic[topic]; !reflect.DeepEqual(test.Expected, actual) {
+				t.Errorf("expected %v; got %v", test.Expected, actual)
+			}
+		})
+	}
+}

--- a/syncgroup.go
+++ b/syncgroup.go
@@ -26,7 +26,7 @@ func (t groupAssignment) size() int32 {
 
 func (t groupAssignment) writeTo(w *bufio.Writer) {
 	writeInt16(w, t.Version)
-	writeInt16(w, int16(len(t.Topics)))
+	writeInt32(w, int32(len(t.Topics)))
 
 	for topic, partitions := range t.Topics {
 		writeString(w, topic)
@@ -37,6 +37,10 @@ func (t groupAssignment) writeTo(w *bufio.Writer) {
 }
 
 func (t *groupAssignment) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if size == 0 {
+		t.Topics = map[string][]int32{}
+		return 0, nil
+	}
 	if remain, err = readInt16(r, size, &t.Version); err != nil {
 		return
 	}

--- a/syncgroup.go
+++ b/syncgroup.go
@@ -37,10 +37,14 @@ func (t groupAssignment) writeTo(w *bufio.Writer) {
 }
 
 func (t *groupAssignment) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	// I came across this case when testing for compatibility with bsm/sarama-cluster. It
+	// appears in some cases, sarama-cluster can send a nil array entry. Admittedly, I
+	// didn't look too closely at it.
 	if size == 0 {
 		t.Topics = map[string][]int32{}
 		return 0, nil
 	}
+
 	if remain, err = readInt16(r, size, &t.Version); err != nil {
 		return
 	}

--- a/syncgroup_test.go
+++ b/syncgroup_test.go
@@ -39,6 +39,22 @@ func TestGroupAssignment(t *testing.T) {
 	}
 }
 
+func TestGroupAssignmentReadsFromZeroSize(t *testing.T) {
+	var item groupAssignment
+	remain, err := (&item).readFrom(bufio.NewReader(bytes.NewReader(nil)), 0)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if item.Topics == nil {
+		t.Error("expected non nil Topics to be assigned")
+	}
+}
+
 func TestSyncGroupResponseV1(t *testing.T) {
 	item := syncGroupResponseV1{
 		ThrottleTimeMS:    1,


### PR DESCRIPTION
I thought I would open a pull request early to get your initial feedback on the request.  This is a working version of consumer group support for the Reader.  I've manually verified interoperability with Sarama.  In addition, I've included an automated  compatibility test with sarama.

Almost all the changes are additive.  The main change was around (*Reader).start that now supports multiple readers and an initial offset.  That said, I tried to preserve the spirit of what I believe start was doing.

Would love to get your thoughts.

  