### PR TITLE
Automatically set Time when publishing the messages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -762,14 +762,19 @@ func (c *Conn) WriteMessages(msgs ...Message) (int, error) {
 		return 0, nil
 	}
 
-	// users may believe they can set the Topic and/or Partition
-	// on the kafka message.
+	writeTime := time.Now()
 	for _, msg := range msgs {
+		// users may believe they can set the Topic and/or Partition
+		// on the kafka message.
 		if msg.Topic != "" && msg.Topic != c.topic {
 			return 0, errInvalidWriteTopic
 		}
 		if msg.Partition != 0 {
 			return 0, errInvalidWritePartition
+		}
+
+		if msg.Time.IsZero() {
+			msg.Time = writeTime
 		}
 	}
 

--- a/message.go
+++ b/message.go
@@ -15,7 +15,10 @@ type Message struct {
 	Offset    int64
 	Key       []byte
 	Value     []byte
-	Time      time.Time
+
+	// If not set at the creation, Time will be automatically set when
+	// writing the message.
+	Time time.Time
 }
 
 func (msg Message) item() messageSetItem {


### PR DESCRIPTION
If not set at the creation of the message, we need to set the message timestamp.

By not setting this timestamp, messages will be deleted at the next log cleaner iteration.