### PR TITLE
handle empty list offset responses

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -1,0 +1,39 @@
+package kafka
+
+import (
+	"context"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+)
+
+func TestBatchDontExpectEOF(t *testing.T) {
+	topic := makeTopic()
+
+	broker, err := (&Dialer{
+		Resolver: &net.Resolver{},
+	}).LookupLeader(context.Background(), "tcp", "localhost:9092", topic, 0)
+	if err != nil {
+		t.Fatal("failed to open a new kafka connection:", err)
+	}
+
+	nc, err := net.Dial("tcp", net.JoinHostPort(broker.Host, strconv.Itoa(broker.Port)))
+	if err != nil {
+		t.Fatalf("cannot connect to partition leader at %s:%d: %s", broker.Host, broker.Port, err)
+	}
+	nc.(*net.TCPConn).CloseRead()
+
+	conn := NewConn(nc, topic, 0)
+	defer conn.Close()
+
+	batch := conn.ReadBatch(1024, 8192)
+
+	if _, err := batch.ReadMessage(); err != io.ErrUnexpectedEOF {
+		t.Error("bad error when reading message:", err)
+	}
+
+	if err := batch.Close(); err != io.ErrUnexpectedEOF {
+		t.Error("bad error when closing the batch:", err)
+	}
+}

--- a/error.go
+++ b/error.go
@@ -343,6 +343,13 @@ func silentEOF(err error) error {
 	return err
 }
 
+func dontExpectEOF(err error) error {
+	if err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return err
+}
+
 func coalesceErrors(errs ...error) error {
 	for _, err := range errs {
 		if err != nil {


### PR DESCRIPTION
_Work In Progress_

Testing the hypothesis, if it is the case we should get `kafka.UnknownTopicOrPartition` when a kafka cluster goes down.