### PR TITLE
Downgrade various api versions to be compatible with kafka 0.10.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,12 @@ jobs:
       - image: circleci/golang
       - image: wurstmeister/zookeeper
         ports: ['2181:2181']
-      - image: wurstmeister/kafka
+      - image: wurstmeister/kafka:0.11.0.1
         ports: ['9092:9092']
         environment:
           KAFKA_VERSION: '0.11.0.1'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+          KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'
           KAFKA_ADVERTISED_PORT: '9092'
           KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'

--- a/conn.go
+++ b/conn.go
@@ -175,12 +175,12 @@ func (c *Conn) describeGroups(request describeGroupsRequestV1) (describeGroupsRe
 // findCoordinator finds the coordinator for the specified group or transaction
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_FindCoordinator
-func (c *Conn) findCoordinator(request findCoordinatorRequestV1) (findCoordinatorResponseV1, error) {
-	var response findCoordinatorResponseV1
+func (c *Conn) findCoordinator(request findCoordinatorRequestV0) (findCoordinatorResponseV0, error) {
+	var response findCoordinatorResponseV0
 
 	err := c.readOperation(
 		func(deadline time.Time, id int32) error {
-			return c.writeRequest(groupCoordinatorRequest, v1, id, request)
+			return c.writeRequest(groupCoordinatorRequest, v0, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -189,10 +189,10 @@ func (c *Conn) findCoordinator(request findCoordinatorRequestV1) (findCoordinato
 		},
 	)
 	if err != nil {
-		return findCoordinatorResponseV1{}, err
+		return findCoordinatorResponseV0{}, err
 	}
 	if response.ErrorCode != 0 {
-		return findCoordinatorResponseV1{}, Error(response.ErrorCode)
+		return findCoordinatorResponseV0{}, Error(response.ErrorCode)
 	}
 
 	return response, nil
@@ -201,12 +201,12 @@ func (c *Conn) findCoordinator(request findCoordinatorRequestV1) (findCoordinato
 // heartbeat sends a heartbeat message required by consumer groups
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_Heartbeat
-func (c *Conn) heartbeat(request heartbeatRequestV1) (heartbeatResponseV1, error) {
-	var response heartbeatResponseV1
+func (c *Conn) heartbeat(request heartbeatRequestV0) (heartbeatResponseV0, error) {
+	var response heartbeatResponseV0
 
 	err := c.writeOperation(
 		func(deadline time.Time, id int32) error {
-			return c.writeRequest(heartbeatRequest, v1, id, request)
+			return c.writeRequest(heartbeatRequest, v0, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -215,10 +215,10 @@ func (c *Conn) heartbeat(request heartbeatRequestV1) (heartbeatResponseV1, error
 		},
 	)
 	if err != nil {
-		return heartbeatResponseV1{}, err
+		return heartbeatResponseV0{}, err
 	}
 	if response.ErrorCode != 0 {
-		return heartbeatResponseV1{}, Error(response.ErrorCode)
+		return heartbeatResponseV0{}, Error(response.ErrorCode)
 	}
 
 	return response, nil
@@ -227,12 +227,12 @@ func (c *Conn) heartbeat(request heartbeatRequestV1) (heartbeatResponseV1, error
 // joinGroup attempts to join a consumer group
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_JoinGroup
-func (c *Conn) joinGroup(request joinGroupRequestV2) (joinGroupResponseV2, error) {
-	var response joinGroupResponseV2
+func (c *Conn) joinGroup(request joinGroupRequestV1) (joinGroupResponseV1, error) {
+	var response joinGroupResponseV1
 
 	err := c.writeOperation(
 		func(deadline time.Time, id int32) error {
-			return c.writeRequest(joinGroupRequest, v2, id, request)
+			return c.writeRequest(joinGroupRequest, v1, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -241,10 +241,10 @@ func (c *Conn) joinGroup(request joinGroupRequestV2) (joinGroupResponseV2, error
 		},
 	)
 	if err != nil {
-		return joinGroupResponseV2{}, err
+		return joinGroupResponseV1{}, err
 	}
 	if response.ErrorCode != 0 {
-		return joinGroupResponseV2{}, Error(response.ErrorCode)
+		return joinGroupResponseV1{}, Error(response.ErrorCode)
 	}
 
 	return response, nil
@@ -253,12 +253,12 @@ func (c *Conn) joinGroup(request joinGroupRequestV2) (joinGroupResponseV2, error
 // leaveGroup leaves the consumer from the consumer group
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_LeaveGroup
-func (c *Conn) leaveGroup(request leaveGroupRequestV1) (leaveGroupResponseV1, error) {
-	var response leaveGroupResponseV1
+func (c *Conn) leaveGroup(request leaveGroupRequestV0) (leaveGroupResponseV0, error) {
+	var response leaveGroupResponseV0
 
 	err := c.writeOperation(
 		func(deadline time.Time, id int32) error {
-			return c.writeRequest(leaveGroupRequest, v1, id, request)
+			return c.writeRequest(leaveGroupRequest, v0, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -267,10 +267,10 @@ func (c *Conn) leaveGroup(request leaveGroupRequestV1) (leaveGroupResponseV1, er
 		},
 	)
 	if err != nil {
-		return leaveGroupResponseV1{}, err
+		return leaveGroupResponseV0{}, err
 	}
 	if response.ErrorCode != 0 {
-		return leaveGroupResponseV1{}, Error(response.ErrorCode)
+		return leaveGroupResponseV0{}, Error(response.ErrorCode)
 	}
 
 	return response, nil
@@ -335,12 +335,12 @@ func (c *Conn) offsetCommit(request offsetCommitRequestV3) (offsetCommitResponse
 // offsetFetch fetches the offsets for the specified topic partitions
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_OffsetFetch
-func (c *Conn) offsetFetch(request offsetFetchRequestV3) (offsetFetchResponseV3, error) {
-	var response offsetFetchResponseV3
+func (c *Conn) offsetFetch(request offsetFetchRequestV1) (offsetFetchResponseV1, error) {
+	var response offsetFetchResponseV1
 
 	err := c.readOperation(
 		func(deadline time.Time, id int32) error {
-			return c.writeRequest(offsetFetchRequest, v3, id, request)
+			return c.writeRequest(offsetFetchRequest, v1, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -349,15 +349,12 @@ func (c *Conn) offsetFetch(request offsetFetchRequestV3) (offsetFetchResponseV3,
 		},
 	)
 	if err != nil {
-		return offsetFetchResponseV3{}, err
-	}
-	if response.ErrorCode != 0 {
-		return offsetFetchResponseV3{}, Error(response.ErrorCode)
+		return offsetFetchResponseV1{}, err
 	}
 	for _, r := range response.Responses {
 		for _, pr := range r.PartitionResponses {
 			if pr.ErrorCode != 0 {
-				return offsetFetchResponseV3{}, Error(pr.ErrorCode)
+				return offsetFetchResponseV1{}, Error(pr.ErrorCode)
 			}
 		}
 	}
@@ -368,12 +365,12 @@ func (c *Conn) offsetFetch(request offsetFetchRequestV3) (offsetFetchResponseV3,
 // syncGroups completes the handshake to join a consumer group
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_SyncGroup
-func (c *Conn) syncGroups(request syncGroupRequestV1) (syncGroupResponseV1, error) {
-	var response syncGroupResponseV1
+func (c *Conn) syncGroups(request syncGroupRequestV0) (syncGroupResponseV0, error) {
+	var response syncGroupResponseV0
 
 	err := c.readOperation(
 		func(deadline time.Time, id int32) error {
-			return c.writeRequest(syncGroupRequest, v1, id, request)
+			return c.writeRequest(syncGroupRequest, v0, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -382,10 +379,10 @@ func (c *Conn) syncGroups(request syncGroupRequestV1) (syncGroupResponseV1, erro
 		},
 	)
 	if err != nil {
-		return syncGroupResponseV1{}, err
+		return syncGroupResponseV0{}, err
 	}
 	if response.ErrorCode != 0 {
-		return syncGroupResponseV1{}, Error(response.ErrorCode)
+		return syncGroupResponseV0{}, Error(response.ErrorCode)
 	}
 
 	return response, nil

--- a/conn.go
+++ b/conn.go
@@ -305,12 +305,12 @@ func (c *Conn) listGroups(request listGroupsRequestV1) (listGroupsResponseV1, er
 // offsetCommit commits the specified topic partition offsets
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_OffsetCommit
-func (c *Conn) offsetCommit(request offsetCommitRequestV3) (offsetCommitResponseV3, error) {
-	var response offsetCommitResponseV3
+func (c *Conn) offsetCommit(request offsetCommitRequestV2) (offsetCommitResponseV2, error) {
+	var response offsetCommitResponseV2
 
 	err := c.writeOperation(
 		func(deadline time.Time, id int32) error {
-			return c.writeRequest(offsetCommitRequest, v3, id, request)
+			return c.writeRequest(offsetCommitRequest, v2, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -319,12 +319,12 @@ func (c *Conn) offsetCommit(request offsetCommitRequestV3) (offsetCommitResponse
 		},
 	)
 	if err != nil {
-		return offsetCommitResponseV3{}, err
+		return offsetCommitResponseV2{}, err
 	}
 	for _, r := range response.Responses {
 		for _, pr := range r.PartitionResponses {
 			if pr.ErrorCode != 0 {
-				return offsetCommitResponseV3{}, Error(pr.ErrorCode)
+				return offsetCommitResponseV2{}, Error(pr.ErrorCode)
 			}
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -64,8 +64,6 @@ func (c *connPipe) Write(b []byte) (int, error) {
 	if t := c.wconn.writeDeadline(); !t.IsZero() {
 		return 0, &timeout{}
 	}
-		return 0, &timeout{}
-	}
 
 	return c.wconn.Write(b)
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -731,15 +731,15 @@ func testConnFetchAndCommitOffsets(t *testing.T, conn *Conn) {
 	}
 
 	committedOffset := int64(N - 1)
-	_, err = conn.offsetCommit(offsetCommitRequestV3{
+	_, err = conn.offsetCommit(offsetCommitRequestV2{
 		GroupID:       groupID,
 		GenerationID:  generationID,
 		MemberID:      memberID,
 		RetentionTime: int64(time.Hour / time.Millisecond),
-		Topics: []offsetCommitRequestV3Topic{
+		Topics: []offsetCommitRequestV2Topic{
 			{
 				Topic: conn.topic,
-				Partitions: []offsetCommitRequestV3Partition{
+				Partitions: []offsetCommitRequestV2Partition{
 					{
 						Partition: 0,
 						Offset:    committedOffset,

--- a/conn_test.go
+++ b/conn_test.go
@@ -38,7 +38,7 @@ func (c *connPipe) Close() error {
 func (c *connPipe) Read(b []byte) (int, error) {
 	// See comments in Write.
 	time.Sleep(time.Millisecond)
-	if t := c.rconn.readDeadline(); !t.IsZero() && t.Sub(time.Now()) <= (10*time.Millisecond) {
+	if t := c.rconn.readDeadline(); !t.IsZero() {
 		return 0, &timeout{}
 	}
 	n, err := c.rconn.Read(b)
@@ -58,10 +58,12 @@ func (c *connPipe) Write(b []byte) (int, error) {
 	// goroutines a chance to start and set the deadline.
 	time.Sleep(time.Millisecond)
 
-	// Some tests set very short deadlines which end up aborting requests and
-	// closing the connection. To prevent this from happening we check how far
-	// the deadline is and if it's too close we timeout.
-	if t := c.wconn.writeDeadline(); !t.IsZero() && t.Sub(time.Now()) <= (10*time.Millisecond) {
+	// The nettest code only sets deadlines when it expects the write to time
+	// out.  The broker connection is alive and able to accept data, so we need
+	// to simulate the timeout in order to get the tests to pass.
+	if t := c.wconn.writeDeadline(); !t.IsZero() {
+		return 0, &timeout{}
+	}
 		return 0, &timeout{}
 	}
 

--- a/createtopics.go
+++ b/createtopics.go
@@ -10,24 +10,24 @@ type ConfigEntry struct {
 	ConfigValue string
 }
 
-func (c ConfigEntry) toCreateTopicsRequestV2ConfigEntry() createTopicsRequestV2ConfigEntry {
-	return createTopicsRequestV2ConfigEntry{
+func (c ConfigEntry) toCreateTopicsRequestV0ConfigEntry() createTopicsRequestV0ConfigEntry {
+	return createTopicsRequestV0ConfigEntry{
 		ConfigName:  c.ConfigName,
 		ConfigValue: c.ConfigValue,
 	}
 }
 
-type createTopicsRequestV2ConfigEntry struct {
+type createTopicsRequestV0ConfigEntry struct {
 	ConfigName  string
 	ConfigValue string
 }
 
-func (t createTopicsRequestV2ConfigEntry) size() int32 {
+func (t createTopicsRequestV0ConfigEntry) size() int32 {
 	return sizeofString(t.ConfigName) +
 		sizeofString(t.ConfigValue)
 }
 
-func (t createTopicsRequestV2ConfigEntry) writeTo(w *bufio.Writer) {
+func (t createTopicsRequestV0ConfigEntry) writeTo(w *bufio.Writer) {
 	writeString(w, t.ConfigName)
 	writeString(w, t.ConfigValue)
 }
@@ -37,24 +37,24 @@ type ReplicaAssignment struct {
 	Replicas  int
 }
 
-func (a ReplicaAssignment) toCreateTopicsRequestV2ReplicaAssignment() createTopicsRequestV2ReplicaAssignment {
-	return createTopicsRequestV2ReplicaAssignment{
+func (a ReplicaAssignment) toCreateTopicsRequestV0ReplicaAssignment() createTopicsRequestV0ReplicaAssignment {
+	return createTopicsRequestV0ReplicaAssignment{
 		Partition: int32(a.Partition),
 		Replicas:  int32(a.Replicas),
 	}
 }
 
-type createTopicsRequestV2ReplicaAssignment struct {
+type createTopicsRequestV0ReplicaAssignment struct {
 	Partition int32
 	Replicas  int32
 }
 
-func (t createTopicsRequestV2ReplicaAssignment) size() int32 {
+func (t createTopicsRequestV0ReplicaAssignment) size() int32 {
 	return sizeofInt32(t.Partition) +
 		sizeofInt32(t.Replicas)
 }
 
-func (t createTopicsRequestV2ReplicaAssignment) writeTo(w *bufio.Writer) {
+func (t createTopicsRequestV0ReplicaAssignment) writeTo(w *bufio.Writer) {
 	writeInt32(w, t.Partition)
 	writeInt32(w, t.Replicas)
 }
@@ -77,30 +77,30 @@ type TopicConfig struct {
 	ConfigEntries []ConfigEntry
 }
 
-func (t TopicConfig) toCreateTopicsRequestV2Topic() createTopicsRequestV2Topic {
-	var requestV2ReplicaAssignments []createTopicsRequestV2ReplicaAssignment
+func (t TopicConfig) toCreateTopicsRequestV0Topic() createTopicsRequestV0Topic {
+	var requestV0ReplicaAssignments []createTopicsRequestV0ReplicaAssignment
 	for _, a := range t.ReplicaAssignments {
-		requestV2ReplicaAssignments = append(
-			requestV2ReplicaAssignments,
-			a.toCreateTopicsRequestV2ReplicaAssignment())
+		requestV0ReplicaAssignments = append(
+			requestV0ReplicaAssignments,
+			a.toCreateTopicsRequestV0ReplicaAssignment())
 	}
-	var requestV2ConfigEntries []createTopicsRequestV2ConfigEntry
+	var requestV0ConfigEntries []createTopicsRequestV0ConfigEntry
 	for _, c := range t.ConfigEntries {
-		requestV2ConfigEntries = append(
-			requestV2ConfigEntries,
-			c.toCreateTopicsRequestV2ConfigEntry())
+		requestV0ConfigEntries = append(
+			requestV0ConfigEntries,
+			c.toCreateTopicsRequestV0ConfigEntry())
 	}
 
-	return createTopicsRequestV2Topic{
+	return createTopicsRequestV0Topic{
 		Topic:              t.Topic,
 		NumPartitions:      int32(t.NumPartitions),
 		ReplicationFactor:  int16(t.ReplicationFactor),
-		ReplicaAssignments: requestV2ReplicaAssignments,
-		ConfigEntries:      requestV2ConfigEntries,
+		ReplicaAssignments: requestV0ReplicaAssignments,
+		ConfigEntries:      requestV0ConfigEntries,
 	}
 }
 
-type createTopicsRequestV2Topic struct {
+type createTopicsRequestV0Topic struct {
 	// Topic name
 	Topic string
 
@@ -112,13 +112,13 @@ type createTopicsRequestV2Topic struct {
 
 	// ReplicaAssignments among kafka brokers for this topic partitions. If this
 	// is set num_partitions and replication_factor must be unset.
-	ReplicaAssignments []createTopicsRequestV2ReplicaAssignment
+	ReplicaAssignments []createTopicsRequestV0ReplicaAssignment
 
 	// ConfigEntries holds topic level configuration for topic to be set.
-	ConfigEntries []createTopicsRequestV2ConfigEntry
+	ConfigEntries []createTopicsRequestV0ConfigEntry
 }
 
-func (t createTopicsRequestV2Topic) size() int32 {
+func (t createTopicsRequestV0Topic) size() int32 {
 	return sizeofString(t.Topic) +
 		sizeofInt32(t.NumPartitions) +
 		sizeofInt16(t.ReplicationFactor) +
@@ -126,7 +126,7 @@ func (t createTopicsRequestV2Topic) size() int32 {
 		sizeofArray(len(t.ConfigEntries), func(i int) int32 { return t.ConfigEntries[i].size() })
 }
 
-func (t createTopicsRequestV2Topic) writeTo(w *bufio.Writer) {
+func (t createTopicsRequestV0Topic) writeTo(w *bufio.Writer) {
 	writeString(w, t.Topic)
 	writeInt32(w, t.NumPartitions)
 	writeInt16(w, t.ReplicationFactor)
@@ -135,106 +135,85 @@ func (t createTopicsRequestV2Topic) writeTo(w *bufio.Writer) {
 }
 
 // See http://kafka.apache.org/protocol.html#The_Messages_CreateTopics
-type createTopicsRequestV2 struct {
+type createTopicsRequestV0 struct {
 	// Topics contains n array of single topic creation requests. Can not
 	// have multiple entries for the same topic.
-	Topics []createTopicsRequestV2Topic
+	Topics []createTopicsRequestV0Topic
 
 	// Timeout ms to wait for a topic to be completely created on the
 	// controller node. Values <= 0 will trigger topic creation and return immediately
 	Timeout int32
-
-	// ValidateOnly if true, the request will be validated, but the topic won
-	// 't be created.
-	ValidateOnly bool
 }
 
-func (t createTopicsRequestV2) size() int32 {
+func (t createTopicsRequestV0) size() int32 {
 	return sizeofArray(len(t.Topics), func(i int) int32 { return t.Topics[i].size() }) +
-		sizeofInt32(t.Timeout) +
-		sizeofBool(t.ValidateOnly)
+		sizeofInt32(t.Timeout)
 }
 
-func (t createTopicsRequestV2) writeTo(w *bufio.Writer) {
+func (t createTopicsRequestV0) writeTo(w *bufio.Writer) {
 	writeArray(w, len(t.Topics), func(i int) { t.Topics[i].writeTo(w) })
 	writeInt32(w, t.Timeout)
-	writeBool(w, t.ValidateOnly)
 }
 
-type createTopicsResponseV2TopicError struct {
+type createTopicsResponseV0TopicError struct {
 	// Topic name
 	Topic string
 
 	// ErrorCode holds response error code
 	ErrorCode int16
-
-	// ErrorMessage holds the response error message
-	ErrorMessage string
 }
 
-func (t createTopicsResponseV2TopicError) size() int32 {
+func (t createTopicsResponseV0TopicError) size() int32 {
 	return sizeofString(t.Topic) +
-		sizeofInt16(t.ErrorCode) +
-		sizeofString(t.ErrorMessage)
+		sizeofInt16(t.ErrorCode)
 }
 
-func (t createTopicsResponseV2TopicError) writeTo(w *bufio.Writer) {
+func (t createTopicsResponseV0TopicError) writeTo(w *bufio.Writer) {
 	writeString(w, t.Topic)
 	writeInt16(w, t.ErrorCode)
-	writeString(w, t.ErrorMessage)
 }
 
-func (t *createTopicsResponseV2TopicError) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+func (t *createTopicsResponseV0TopicError) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	if remain, err = readString(r, size, &t.Topic); err != nil {
 		return
 	}
 	if remain, err = readInt16(r, remain, &t.ErrorCode); err != nil {
 		return
 	}
-	if remain, err = readString(r, remain, &t.ErrorMessage); err != nil {
-		return
-	}
 	return
 }
 
 // See http://kafka.apache.org/protocol.html#The_Messages_CreateTopics
-type createTopicsResponseV2 struct {
-	ThrottleTimeMS int32
-	TopicErrors    []createTopicsResponseV2TopicError
+type createTopicsResponseV0 struct {
+	TopicErrors []createTopicsResponseV0TopicError
 }
 
-func (t createTopicsResponseV2) size() int32 {
-	return sizeofInt32(t.ThrottleTimeMS) +
-		sizeofArray(len(t.TopicErrors), func(i int) int32 { return t.TopicErrors[i].size() })
+func (t createTopicsResponseV0) size() int32 {
+	return sizeofArray(len(t.TopicErrors), func(i int) int32 { return t.TopicErrors[i].size() })
 }
 
-func (t createTopicsResponseV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
+func (t createTopicsResponseV0) writeTo(w *bufio.Writer) {
 	writeArray(w, len(t.TopicErrors), func(i int) { t.TopicErrors[i].writeTo(w) })
 }
 
-func (t *createTopicsResponseV2) readFrom(r *bufio.Reader, size int) (remain int, err error) {
-	if remain, err = readInt32(r, size, &t.ThrottleTimeMS); err != nil {
-		return
-	}
-
+func (t *createTopicsResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	fn := func(r *bufio.Reader, size int) (fnRemain int, fnErr error) {
-		var topic createTopicsResponseV2TopicError
+		var topic createTopicsResponseV0TopicError
 		if fnRemain, fnErr = (&topic).readFrom(r, size); err != nil {
 			return
 		}
 		t.TopicErrors = append(t.TopicErrors, topic)
 		return
 	}
-	if remain, err = readArrayWith(r, remain, fn); err != nil {
+	if remain, err = readArrayWith(r, size, fn); err != nil {
 		return
 	}
 
 	return
 }
 
-func (c *Conn) createTopics(request createTopicsRequestV2) (createTopicsResponseV2, error) {
-	var response createTopicsResponseV2
+func (c *Conn) createTopics(request createTopicsRequestV0) (createTopicsResponseV0, error) {
+	var response createTopicsResponseV0
 
 	err := c.writeOperation(
 		func(deadline time.Time, id int32) error {
@@ -243,7 +222,7 @@ func (c *Conn) createTopics(request createTopicsRequestV2) (createTopicsResponse
 				deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
 				request.Timeout = milliseconds(deadlineToTimeout(deadline, now))
 			}
-			return c.writeRequest(createTopicsRequest, v2, id, request)
+			return c.writeRequest(createTopicsRequest, v0, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {
@@ -267,15 +246,15 @@ func (c *Conn) createTopics(request createTopicsRequestV2) (createTopicsResponse
 // operational semantics. In other words, if CreateTopics is invoked with a
 // configuration for an existing topic, it will have no effect.
 func (c *Conn) CreateTopics(topics ...TopicConfig) error {
-	var requestV2Topics []createTopicsRequestV2Topic
+	var requestV0Topics []createTopicsRequestV0Topic
 	for _, t := range topics {
-		requestV2Topics = append(
-			requestV2Topics,
-			t.toCreateTopicsRequestV2Topic())
+		requestV0Topics = append(
+			requestV0Topics,
+			t.toCreateTopicsRequestV0Topic())
 	}
 
-	_, err := c.createTopics(createTopicsRequestV2{
-		Topics: requestV2Topics,
+	_, err := c.createTopics(createTopicsRequestV0{
+		Topics: requestV0Topics,
 	})
 
 	switch err {

--- a/createtopics_test.go
+++ b/createtopics_test.go
@@ -7,14 +7,12 @@ import (
 	"testing"
 )
 
-func TestCreateTopicsResponseV2(t *testing.T) {
-	item := createTopicsResponseV2{
-		ThrottleTimeMS: 1,
-		TopicErrors: []createTopicsResponseV2TopicError{
+func TestCreateTopicsResponseV0(t *testing.T) {
+	item := createTopicsResponseV0{
+		TopicErrors: []createTopicsResponseV0TopicError{
 			{
-				Topic:        "topic",
-				ErrorCode:    2,
-				ErrorMessage: "topic error",
+				Topic:     "topic",
+				ErrorCode: 2,
 			},
 		},
 	}
@@ -24,7 +22,7 @@ func TestCreateTopicsResponseV2(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found createTopicsResponseV2
+	var found createTopicsResponseV0
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 kafka:
-  image: wurstmeister/kafka:0.10.2.1
+  image: wurstmeister/kafka:0.11.0.1
   links:
     - zookeeper
   ports:
     - "9092:9092"
   environment:
     KAFKA_CREATE_TOPICS: "test-writer-0:3:1,test-writer-1:3:1"
+    KAFKA_DELETE_TOPIC_ENABLE: 'true'
     KAFKA_ADVERTISED_HOST_NAME: "localhost"
     KAFKA_ADVERTISED_PORT: "9092"
     KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"

--- a/findcoordinator.go
+++ b/findcoordinator.go
@@ -4,28 +4,24 @@ import (
 	"bufio"
 )
 
-// FindCoordinatorRequestV1 requests the coordinator for the specified group or transaction
+// FindCoordinatorRequestV0 requests the coordinator for the specified group or transaction
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_FindCoordinator
-type findCoordinatorRequestV1 struct {
+type findCoordinatorRequestV0 struct {
 	// CoordinatorKey holds id to use for finding the coordinator (for groups, this is
 	// the groupId, for transactional producers, this is the transactional id)
 	CoordinatorKey string
-
-	// CoordinatorType indicates type of coordinator to find (0 = group, 1 = transaction)
-	CoordinatorType int8
 }
 
-func (t findCoordinatorRequestV1) size() int32 {
-	return sizeofString(t.CoordinatorKey) + sizeof(t.CoordinatorType)
+func (t findCoordinatorRequestV0) size() int32 {
+	return sizeofString(t.CoordinatorKey)
 }
 
-func (t findCoordinatorRequestV1) writeTo(w *bufio.Writer) {
+func (t findCoordinatorRequestV0) writeTo(w *bufio.Writer) {
 	writeString(w, t.CoordinatorKey)
-	writeInt8(w, t.CoordinatorType)
 }
 
-type findCoordinatorResponseCoordinatorV1 struct {
+type findCoordinatorResponseCoordinatorV0 struct {
 	// NodeID holds the broker id.
 	NodeID int32
 
@@ -36,19 +32,19 @@ type findCoordinatorResponseCoordinatorV1 struct {
 	Port int32
 }
 
-func (t findCoordinatorResponseCoordinatorV1) size() int32 {
+func (t findCoordinatorResponseCoordinatorV0) size() int32 {
 	return sizeofInt32(t.NodeID) +
 		sizeofString(t.Host) +
 		sizeofInt32(t.Port)
 }
 
-func (t findCoordinatorResponseCoordinatorV1) writeTo(w *bufio.Writer) {
+func (t findCoordinatorResponseCoordinatorV0) writeTo(w *bufio.Writer) {
 	writeInt32(w, t.NodeID)
 	writeString(w, t.Host)
 	writeInt32(w, t.Port)
 }
 
-func (t *findCoordinatorResponseCoordinatorV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+func (t *findCoordinatorResponseCoordinatorV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	if remain, err = readInt32(r, size, &t.NodeID); err != nil {
 		return
 	}
@@ -61,44 +57,26 @@ func (t *findCoordinatorResponseCoordinatorV1) readFrom(r *bufio.Reader, size in
 	return
 }
 
-type findCoordinatorResponseV1 struct {
-	// ThrottleTimeMS holds the duration in milliseconds for which the request
-	// was throttled due to quota violation (Zero if the request did not violate
-	// any quota)
-	ThrottleTimeMS int32
-
+type findCoordinatorResponseV0 struct {
 	// ErrorCode holds response error code
 	ErrorCode int16
 
-	// ErrorMessage holds response error message
-	ErrorMessage string
-
 	// Coordinator holds host and port information for the coordinator
-	Coordinator findCoordinatorResponseCoordinatorV1
+	Coordinator findCoordinatorResponseCoordinatorV0
 }
 
-func (t findCoordinatorResponseV1) size() int32 {
-	return sizeofInt32(t.ThrottleTimeMS) +
-		sizeofInt16(t.ErrorCode) +
-		sizeofString(t.ErrorMessage) +
+func (t findCoordinatorResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode) +
 		t.Coordinator.size()
 }
 
-func (t findCoordinatorResponseV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
+func (t findCoordinatorResponseV0) writeTo(w *bufio.Writer) {
 	writeInt16(w, t.ErrorCode)
-	writeString(w, t.ErrorMessage)
 	t.Coordinator.writeTo(w)
 }
 
-func (t *findCoordinatorResponseV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {
-	if remain, err = readInt32(r, size, &t.ThrottleTimeMS); err != nil {
-		return
-	}
-	if remain, err = readInt16(r, remain, &t.ErrorCode); err != nil {
-		return
-	}
-	if remain, err = readString(r, remain, &t.ErrorMessage); err != nil {
+func (t *findCoordinatorResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt16(r, size, &t.ErrorCode); err != nil {
 		return
 	}
 	if remain, err = (&t.Coordinator).readFrom(r, remain); err != nil {

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -7,12 +7,10 @@ import (
 	"testing"
 )
 
-func TestFindCoordinatorResponseV1(t *testing.T) {
-	item := findCoordinatorResponseV1{
-		ThrottleTimeMS: 1,
-		ErrorCode:      2,
-		ErrorMessage:   "a",
-		Coordinator: findCoordinatorResponseCoordinatorV1{
+func TestFindCoordinatorResponseV0(t *testing.T) {
+	item := findCoordinatorResponseV0{
+		ErrorCode: 2,
+		Coordinator: findCoordinatorResponseCoordinatorV0{
 			NodeID: 3,
 			Host:   "b",
 			Port:   4,
@@ -24,7 +22,7 @@ func TestFindCoordinatorResponseV1(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found findCoordinatorResponseV1
+	var found findCoordinatorResponseV0
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -2,7 +2,7 @@ package kafka
 
 import "bufio"
 
-type heartbeatRequestV1 struct {
+type heartbeatRequestV0 struct {
 	// GroupID holds the unique group identifier
 	GroupID string
 
@@ -13,43 +13,33 @@ type heartbeatRequestV1 struct {
 	MemberID string
 }
 
-func (t heartbeatRequestV1) size() int32 {
+func (t heartbeatRequestV0) size() int32 {
 	return sizeofString(t.GroupID) +
 		sizeofInt32(t.GenerationID) +
 		sizeofString(t.MemberID)
 }
 
-func (t heartbeatRequestV1) writeTo(w *bufio.Writer) {
+func (t heartbeatRequestV0) writeTo(w *bufio.Writer) {
 	writeString(w, t.GroupID)
 	writeInt32(w, t.GenerationID)
 	writeString(w, t.MemberID)
 }
 
-type heartbeatResponseV1 struct {
-	// ThrottleTimeMS holds the duration in milliseconds for which the request
-	// was throttled due to quota violation (Zero if the request did not violate
-	// any quota)
-	ThrottleTimeMS int32
-
+type heartbeatResponseV0 struct {
 	// ErrorCode holds response error code
 	ErrorCode int16
 }
 
-func (t heartbeatResponseV1) size() int32 {
-	return sizeofInt32(t.ThrottleTimeMS) +
-		sizeofInt16(t.ErrorCode)
+func (t heartbeatResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode)
 }
 
-func (t heartbeatResponseV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
+func (t heartbeatResponseV0) writeTo(w *bufio.Writer) {
 	writeInt16(w, t.ErrorCode)
 }
 
-func (t *heartbeatResponseV1) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
-	if remain, err = readInt32(r, sz, &t.ThrottleTimeMS); err != nil {
-		return
-	}
-	if remain, err = readInt16(r, remain, &t.ErrorCode); err != nil {
+func (t *heartbeatResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
 		return
 	}
 	return

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 )
 
-func TestHeartbeatRequestV1(t *testing.T) {
-	item := heartbeatResponseV1{
-		ThrottleTimeMS: 1,
-		ErrorCode:      2,
+func TestHeartbeatRequestV0(t *testing.T) {
+	item := heartbeatResponseV0{
+		ErrorCode: 2,
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -18,7 +17,7 @@ func TestHeartbeatRequestV1(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found heartbeatResponseV1
+	var found heartbeatResponseV0
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)

--- a/joingroup_test.go
+++ b/joingroup_test.go
@@ -102,14 +102,13 @@ func TestMemberMetadata(t *testing.T) {
 }
 
 func TestJoinGroupResponseV1(t *testing.T) {
-	item := joinGroupResponseV2{
-		ThrottleTimeMS: 1,
-		ErrorCode:      2,
-		GenerationID:   3,
-		GroupProtocol:  "a",
-		LeaderID:       "b",
-		MemberID:       "c",
-		Members: []joinGroupResponseMemberV2{
+	item := joinGroupResponseV1{
+		ErrorCode:     2,
+		GenerationID:  3,
+		GroupProtocol: "a",
+		LeaderID:      "b",
+		MemberID:      "c",
+		Members: []joinGroupResponseMemberV1{
 			{
 				MemberID:       "d",
 				MemberMetadata: []byte("blah"),
@@ -122,7 +121,7 @@ func TestJoinGroupResponseV1(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found joinGroupResponseV2
+	var found joinGroupResponseV1
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)

--- a/leavegroup.go
+++ b/leavegroup.go
@@ -2,7 +2,7 @@ package kafka
 
 import "bufio"
 
-type leaveGroupRequestV1 struct {
+type leaveGroupRequestV0 struct {
 	// GroupID holds the unique group identifier
 	GroupID string
 
@@ -11,41 +11,31 @@ type leaveGroupRequestV1 struct {
 	MemberID string
 }
 
-func (t leaveGroupRequestV1) size() int32 {
+func (t leaveGroupRequestV0) size() int32 {
 	return sizeofString(t.GroupID) +
 		sizeofString(t.MemberID)
 }
 
-func (t leaveGroupRequestV1) writeTo(w *bufio.Writer) {
+func (t leaveGroupRequestV0) writeTo(w *bufio.Writer) {
 	writeString(w, t.GroupID)
 	writeString(w, t.MemberID)
 }
 
-type leaveGroupResponseV1 struct {
-	// ThrottleTimeMS holds the duration in milliseconds for which the request
-	// was throttled due to quota violation (Zero if the request did not violate
-	// any quota)
-	ThrottleTimeMS int32
-
+type leaveGroupResponseV0 struct {
 	// ErrorCode holds response error code
 	ErrorCode int16
 }
 
-func (t leaveGroupResponseV1) size() int32 {
-	return sizeofInt32(t.ThrottleTimeMS) +
-		sizeofInt16(t.ErrorCode)
+func (t leaveGroupResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode)
 }
 
-func (t leaveGroupResponseV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
+func (t leaveGroupResponseV0) writeTo(w *bufio.Writer) {
 	writeInt16(w, t.ErrorCode)
 }
 
-func (t *leaveGroupResponseV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {
-	if remain, err = readInt32(r, size, &t.ThrottleTimeMS); err != nil {
-		return
-	}
-	if remain, err = readInt16(r, remain, &t.ErrorCode); err != nil {
+func (t *leaveGroupResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt16(r, size, &t.ErrorCode); err != nil {
 		return
 	}
 	return

--- a/leavegroup_test.go
+++ b/leavegroup_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 )
 
-func TestLeaveGroupResponseV1(t *testing.T) {
-	item := leaveGroupResponseV1{
-		ThrottleTimeMS: 1,
-		ErrorCode:      2,
+func TestLeaveGroupResponseV0(t *testing.T) {
+	item := leaveGroupResponseV0{
+		ErrorCode: 2,
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -18,7 +17,7 @@ func TestLeaveGroupResponseV1(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found leaveGroupResponseV1
+	var found leaveGroupResponseV0
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)

--- a/offsetcommit.go
+++ b/offsetcommit.go
@@ -2,7 +2,7 @@ package kafka
 
 import "bufio"
 
-type offsetCommitRequestV3Partition struct {
+type offsetCommitRequestV2Partition struct {
 	// Partition ID
 	Partition int32
 
@@ -13,37 +13,37 @@ type offsetCommitRequestV3Partition struct {
 	Metadata string
 }
 
-func (t offsetCommitRequestV3Partition) size() int32 {
+func (t offsetCommitRequestV2Partition) size() int32 {
 	return sizeofInt32(t.Partition) +
 		sizeofInt64(t.Offset) +
 		sizeofString(t.Metadata)
 }
 
-func (t offsetCommitRequestV3Partition) writeTo(w *bufio.Writer) {
+func (t offsetCommitRequestV2Partition) writeTo(w *bufio.Writer) {
 	writeInt32(w, t.Partition)
 	writeInt64(w, t.Offset)
 	writeString(w, t.Metadata)
 }
 
-type offsetCommitRequestV3Topic struct {
+type offsetCommitRequestV2Topic struct {
 	// Topic name
 	Topic string
 
 	// Partitions to commit offsets
-	Partitions []offsetCommitRequestV3Partition
+	Partitions []offsetCommitRequestV2Partition
 }
 
-func (t offsetCommitRequestV3Topic) size() int32 {
+func (t offsetCommitRequestV2Topic) size() int32 {
 	return sizeofString(t.Topic) +
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t offsetCommitRequestV3Topic) writeTo(w *bufio.Writer) {
+func (t offsetCommitRequestV2Topic) writeTo(w *bufio.Writer) {
 	writeString(w, t.Topic)
 	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
 }
 
-type offsetCommitRequestV3 struct {
+type offsetCommitRequestV2 struct {
 	// GroupID holds the unique group identifier
 	GroupID string
 
@@ -57,10 +57,10 @@ type offsetCommitRequestV3 struct {
 	RetentionTime int64
 
 	// Topics to commit offsets
-	Topics []offsetCommitRequestV3Topic
+	Topics []offsetCommitRequestV2Topic
 }
 
-func (t offsetCommitRequestV3) size() int32 {
+func (t offsetCommitRequestV2) size() int32 {
 	return sizeofString(t.GroupID) +
 		sizeofInt32(t.GenerationID) +
 		sizeofString(t.MemberID) +
@@ -68,7 +68,7 @@ func (t offsetCommitRequestV3) size() int32 {
 		sizeofArray(len(t.Topics), func(i int) int32 { return t.Topics[i].size() })
 }
 
-func (t offsetCommitRequestV3) writeTo(w *bufio.Writer) {
+func (t offsetCommitRequestV2) writeTo(w *bufio.Writer) {
 	writeString(w, t.GroupID)
 	writeInt32(w, t.GenerationID)
 	writeString(w, t.MemberID)
@@ -76,24 +76,24 @@ func (t offsetCommitRequestV3) writeTo(w *bufio.Writer) {
 	writeArray(w, len(t.Topics), func(i int) { t.Topics[i].writeTo(w) })
 }
 
-type offsetCommitResponseV3PartitionResponse struct {
+type offsetCommitResponseV2PartitionResponse struct {
 	Partition int32
 
 	// ErrorCode holds response error code
 	ErrorCode int16
 }
 
-func (t offsetCommitResponseV3PartitionResponse) size() int32 {
+func (t offsetCommitResponseV2PartitionResponse) size() int32 {
 	return sizeofInt32(t.Partition) +
 		sizeofInt16(t.ErrorCode)
 }
 
-func (t offsetCommitResponseV3PartitionResponse) writeTo(w *bufio.Writer) {
+func (t offsetCommitResponseV2PartitionResponse) writeTo(w *bufio.Writer) {
 	writeInt32(w, t.Partition)
 	writeInt16(w, t.ErrorCode)
 }
 
-func (t *offsetCommitResponseV3PartitionResponse) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+func (t *offsetCommitResponseV2PartitionResponse) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	if remain, err = readInt32(r, size, &t.Partition); err != nil {
 		return
 	}
@@ -103,28 +103,28 @@ func (t *offsetCommitResponseV3PartitionResponse) readFrom(r *bufio.Reader, size
 	return
 }
 
-type offsetCommitResponseV3Response struct {
+type offsetCommitResponseV2Response struct {
 	Topic              string
-	PartitionResponses []offsetCommitResponseV3PartitionResponse
+	PartitionResponses []offsetCommitResponseV2PartitionResponse
 }
 
-func (t offsetCommitResponseV3Response) size() int32 {
+func (t offsetCommitResponseV2Response) size() int32 {
 	return sizeofString(t.Topic) +
 		sizeofArray(len(t.PartitionResponses), func(i int) int32 { return t.PartitionResponses[i].size() })
 }
 
-func (t offsetCommitResponseV3Response) writeTo(w *bufio.Writer) {
+func (t offsetCommitResponseV2Response) writeTo(w *bufio.Writer) {
 	writeString(w, t.Topic)
 	writeArray(w, len(t.PartitionResponses), func(i int) { t.PartitionResponses[i].writeTo(w) })
 }
 
-func (t *offsetCommitResponseV3Response) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+func (t *offsetCommitResponseV2Response) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	if remain, err = readString(r, size, &t.Topic); err != nil {
 		return
 	}
 
 	fn := func(r *bufio.Reader, withSize int) (fnRemain int, fnErr error) {
-		item := offsetCommitResponseV3PartitionResponse{}
+		item := offsetCommitResponseV2PartitionResponse{}
 		if fnRemain, fnErr = (&item).readFrom(r, withSize); fnErr != nil {
 			return
 		}
@@ -138,38 +138,28 @@ func (t *offsetCommitResponseV3Response) readFrom(r *bufio.Reader, size int) (re
 	return
 }
 
-type offsetCommitResponseV3 struct {
-	// ThrottleTimeMS holds the duration in milliseconds for which the request
-	// was throttled due to quota violation (Zero if the request did not violate
-	// any quota)
-	ThrottleTimeMS int32
-	Responses      []offsetCommitResponseV3Response
+type offsetCommitResponseV2 struct {
+	Responses []offsetCommitResponseV2Response
 }
 
-func (t offsetCommitResponseV3) size() int32 {
-	return sizeofInt32(t.ThrottleTimeMS) +
-		sizeofArray(len(t.Responses), func(i int) int32 { return t.Responses[i].size() })
+func (t offsetCommitResponseV2) size() int32 {
+	return sizeofArray(len(t.Responses), func(i int) int32 { return t.Responses[i].size() })
 }
 
-func (t offsetCommitResponseV3) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
+func (t offsetCommitResponseV2) writeTo(w *bufio.Writer) {
 	writeArray(w, len(t.Responses), func(i int) { t.Responses[i].writeTo(w) })
 }
 
-func (t *offsetCommitResponseV3) readFrom(r *bufio.Reader, size int) (remain int, err error) {
-	if remain, err = readInt32(r, size, &t.ThrottleTimeMS); err != nil {
-		return
-	}
-
+func (t *offsetCommitResponseV2) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	fn := func(r *bufio.Reader, withSize int) (fnRemain int, fnErr error) {
-		item := offsetCommitResponseV3Response{}
+		item := offsetCommitResponseV2Response{}
 		if fnRemain, fnErr = (&item).readFrom(r, withSize); fnErr != nil {
 			return
 		}
 		t.Responses = append(t.Responses, item)
 		return
 	}
-	if remain, err = readArrayWith(r, remain, fn); err != nil {
+	if remain, err = readArrayWith(r, size, fn); err != nil {
 		return
 	}
 

--- a/offsetcommit_test.go
+++ b/offsetcommit_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 )
 
-func TestOffsetCommitResponseV3(t *testing.T) {
-	item := offsetCommitResponseV3{
-		ThrottleTimeMS: 1,
-		Responses: []offsetCommitResponseV3Response{
+func TestOffsetCommitResponseV2(t *testing.T) {
+	item := offsetCommitResponseV2{
+		Responses: []offsetCommitResponseV2Response{
 			{
 				Topic: "a",
-				PartitionResponses: []offsetCommitResponseV3PartitionResponse{
+				PartitionResponses: []offsetCommitResponseV2PartitionResponse{
 					{
 						Partition: 1,
 						ErrorCode: 2,
@@ -28,7 +27,7 @@ func TestOffsetCommitResponseV3(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found offsetCommitResponseV3
+	var found offsetCommitResponseV2
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)

--- a/offsetfetch.go
+++ b/offsetfetch.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 )
 
-type offsetFetchRequestV3Topic struct {
+type offsetFetchRequestV1Topic struct {
 	// Topic name
 	Topic string
 
@@ -12,35 +12,35 @@ type offsetFetchRequestV3Topic struct {
 	Partitions []int32
 }
 
-func (t offsetFetchRequestV3Topic) size() int32 {
+func (t offsetFetchRequestV1Topic) size() int32 {
 	return sizeofString(t.Topic) +
 		sizeofInt32Array(t.Partitions)
 }
 
-func (t offsetFetchRequestV3Topic) writeTo(w *bufio.Writer) {
+func (t offsetFetchRequestV1Topic) writeTo(w *bufio.Writer) {
 	writeString(w, t.Topic)
 	writeInt32Array(w, t.Partitions)
 }
 
-type offsetFetchRequestV3 struct {
+type offsetFetchRequestV1 struct {
 	// GroupID holds the unique group identifier
 	GroupID string
 
 	// Topics to fetch offsets.
-	Topics []offsetFetchRequestV3Topic
+	Topics []offsetFetchRequestV1Topic
 }
 
-func (t offsetFetchRequestV3) size() int32 {
+func (t offsetFetchRequestV1) size() int32 {
 	return sizeofString(t.GroupID) +
 		sizeofArray(len(t.Topics), func(i int) int32 { return t.Topics[i].size() })
 }
 
-func (t offsetFetchRequestV3) writeTo(w *bufio.Writer) {
+func (t offsetFetchRequestV1) writeTo(w *bufio.Writer) {
 	writeString(w, t.GroupID)
 	writeArray(w, len(t.Topics), func(i int) { t.Topics[i].writeTo(w) })
 }
 
-type offsetFetchResponseV3PartitionResponse struct {
+type offsetFetchResponseV1PartitionResponse struct {
 	// Partition ID
 	Partition int32
 
@@ -54,21 +54,21 @@ type offsetFetchResponseV3PartitionResponse struct {
 	ErrorCode int16
 }
 
-func (t offsetFetchResponseV3PartitionResponse) size() int32 {
+func (t offsetFetchResponseV1PartitionResponse) size() int32 {
 	return sizeofInt32(t.Partition) +
 		sizeofInt64(t.Offset) +
 		sizeofString(t.Metadata) +
 		sizeofInt16(t.ErrorCode)
 }
 
-func (t offsetFetchResponseV3PartitionResponse) writeTo(w *bufio.Writer) {
+func (t offsetFetchResponseV1PartitionResponse) writeTo(w *bufio.Writer) {
 	writeInt32(w, t.Partition)
 	writeInt64(w, t.Offset)
 	writeString(w, t.Metadata)
 	writeInt16(w, t.ErrorCode)
 }
 
-func (t *offsetFetchResponseV3PartitionResponse) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+func (t *offsetFetchResponseV1PartitionResponse) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	if remain, err = readInt32(r, size, &t.Partition); err != nil {
 		return
 	}
@@ -84,31 +84,31 @@ func (t *offsetFetchResponseV3PartitionResponse) readFrom(r *bufio.Reader, size 
 	return
 }
 
-type offsetFetchResponseV3Response struct {
+type offsetFetchResponseV1Response struct {
 	// Topic name
 	Topic string
 
 	// PartitionResponses holds offsets by partition
-	PartitionResponses []offsetFetchResponseV3PartitionResponse
+	PartitionResponses []offsetFetchResponseV1PartitionResponse
 }
 
-func (t offsetFetchResponseV3Response) size() int32 {
+func (t offsetFetchResponseV1Response) size() int32 {
 	return sizeofString(t.Topic) +
 		sizeofArray(len(t.PartitionResponses), func(i int) int32 { return t.PartitionResponses[i].size() })
 }
 
-func (t offsetFetchResponseV3Response) writeTo(w *bufio.Writer) {
+func (t offsetFetchResponseV1Response) writeTo(w *bufio.Writer) {
 	writeString(w, t.Topic)
 	writeArray(w, len(t.PartitionResponses), func(i int) { t.PartitionResponses[i].writeTo(w) })
 }
 
-func (t *offsetFetchResponseV3Response) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+func (t *offsetFetchResponseV1Response) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	if remain, err = readString(r, size, &t.Topic); err != nil {
 		return
 	}
 
 	fn := func(r *bufio.Reader, size int) (fnRemain int, fnErr error) {
-		item := offsetFetchResponseV3PartitionResponse{}
+		item := offsetFetchResponseV1PartitionResponse{}
 		if fnRemain, fnErr = (&item).readFrom(r, size); err != nil {
 			return
 		}
@@ -122,56 +122,36 @@ func (t *offsetFetchResponseV3Response) readFrom(r *bufio.Reader, size int) (rem
 	return
 }
 
-type offsetFetchResponseV3 struct {
-	// ThrottleTimeMS holds the duration in milliseconds for which the request
-	// was throttled due to quota violation (Zero if the request did not violate
-	// any quota)
-	ThrottleTimeMS int32
-
+type offsetFetchResponseV1 struct {
 	// Responses holds topic partition offsets
-	Responses []offsetFetchResponseV3Response
-
-	// ErrorCode holds response error code
-	ErrorCode int16
+	Responses []offsetFetchResponseV1Response
 }
 
-func (t offsetFetchResponseV3) size() int32 {
-	return sizeofInt32(t.ThrottleTimeMS) +
-		sizeofArray(len(t.Responses), func(i int) int32 { return t.Responses[i].size() }) +
-		sizeofInt16(t.ErrorCode)
+func (t offsetFetchResponseV1) size() int32 {
+	return sizeofArray(len(t.Responses), func(i int) int32 { return t.Responses[i].size() })
 }
 
-func (t offsetFetchResponseV3) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
+func (t offsetFetchResponseV1) writeTo(w *bufio.Writer) {
 	writeArray(w, len(t.Responses), func(i int) { t.Responses[i].writeTo(w) })
-	writeInt16(w, t.ErrorCode)
 }
 
-func (t *offsetFetchResponseV3) readFrom(r *bufio.Reader, size int) (remain int, err error) {
-	if remain, err = readInt32(r, size, &t.ThrottleTimeMS); err != nil {
-		return
-	}
-
+func (t *offsetFetchResponseV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {
 	fn := func(r *bufio.Reader, withSize int) (fnRemain int, fnErr error) {
-		item := offsetFetchResponseV3Response{}
+		item := offsetFetchResponseV1Response{}
 		if fnRemain, fnErr = (&item).readFrom(r, withSize); fnErr != nil {
 			return
 		}
 		t.Responses = append(t.Responses, item)
 		return
 	}
-	if remain, err = readArrayWith(r, remain, fn); err != nil {
-		return
-	}
-
-	if remain, err = readInt16(r, remain, &t.ErrorCode); err != nil {
+	if remain, err = readArrayWith(r, size, fn); err != nil {
 		return
 	}
 
 	return
 }
 
-func findOffset(topic string, partition int32, response offsetFetchResponseV3) (int64, bool) {
+func findOffset(topic string, partition int32, response offsetFetchResponseV1) (int64, bool) {
 	for _, r := range response.Responses {
 		if r.Topic != topic {
 			continue

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 )
 
-func TestOffsetFetchResponseV3(t *testing.T) {
-	item := offsetFetchResponseV3{
-		ThrottleTimeMS: 1,
-		Responses: []offsetFetchResponseV3Response{
+func TestOffsetFetchResponseV1(t *testing.T) {
+	item := offsetFetchResponseV1{
+		Responses: []offsetFetchResponseV1Response{
 			{
 				Topic: "a",
-				PartitionResponses: []offsetFetchResponseV3PartitionResponse{
+				PartitionResponses: []offsetFetchResponseV1PartitionResponse{
 					{
 						Partition: 2,
 						Offset:    3,
@@ -23,7 +22,6 @@ func TestOffsetFetchResponseV3(t *testing.T) {
 				},
 			},
 		},
-		ErrorCode: 5,
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -31,7 +29,7 @@ func TestOffsetFetchResponseV3(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found offsetFetchResponseV3
+	var found offsetFetchResponseV1
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)

--- a/reader.go
+++ b/reader.go
@@ -604,7 +604,7 @@ func (r *Reader) heartbeatLoop(conn *Conn) func(stop <-chan struct{}) {
 }
 
 type offsetCommitter interface {
-	offsetCommit(request offsetCommitRequestV3) (offsetCommitResponseV3, error)
+	offsetCommit(request offsetCommitRequestV2) (offsetCommitResponseV2, error)
 }
 
 func (r *Reader) commitOffsets(conn offsetCommitter, offsetStash offsetStash) error {
@@ -613,7 +613,7 @@ func (r *Reader) commitOffsets(conn offsetCommitter, offsetStash offsetStash) er
 	}
 
 	generationID, memberID := r.membership()
-	request := offsetCommitRequestV3{
+	request := offsetCommitRequestV2{
 		GroupID:       r.config.GroupID,
 		GenerationID:  generationID,
 		MemberID:      memberID,
@@ -621,9 +621,9 @@ func (r *Reader) commitOffsets(conn offsetCommitter, offsetStash offsetStash) er
 	}
 
 	for topic, partitions := range offsetStash {
-		t := offsetCommitRequestV3Topic{Topic: topic}
+		t := offsetCommitRequestV2Topic{Topic: topic}
 		for partition, offset := range partitions {
-			t.Partitions = append(t.Partitions, offsetCommitRequestV3Partition{
+			t.Partitions = append(t.Partitions, offsetCommitRequestV2Partition{
 				Partition: int32(partition),
 				Offset:    offset,
 			})

--- a/reader.go
+++ b/reader.go
@@ -540,7 +540,7 @@ func (r *Reader) coordinator() (*Conn, error) {
 
 	conn, err := r.config.Dialer.DialContext(r.stctx, "tcp", address)
 	if err != nil {
-		return nil, fmt.Errorf("unable to connect to coordinator, %v", address)
+		return nil, fmt.Errorf("unable to connect to coordinator, %v: %v", address, err)
 	}
 
 	return conn, nil

--- a/reader.go
+++ b/reader.go
@@ -268,6 +268,12 @@ func (r *Reader) leaveGroup(conn *Conn) error {
 		return fmt.Errorf("leave group failed for group, %v, and member, %v: %v", r.config.GroupID, memberID, err)
 	}
 
+	// Clear the member ID and generation ID on leave
+	r.mutex.Lock()
+	r.memberID = ""
+	r.generationID = 0
+	r.mutex.Unlock()
+
 	return nil
 }
 

--- a/reader.go
+++ b/reader.go
@@ -372,6 +372,10 @@ func (r *Reader) makesyncGroupRequestV0(memberAssignments memberGroupAssignments
 				}.bytes(),
 			})
 		}
+
+		r.withErrorLogger(func(logger *log.Logger) {
+			logger.Printf("Syncing %d assignments for generation %d as member %s", len(request.GroupAssignments), generationID, memberID)
+		})
 	}
 
 	return request
@@ -423,7 +427,8 @@ func (r *Reader) syncGroup(memberAssignments memberGroupAssignments) (map[string
 	}
 
 	if len(assignments.Topics) == 0 {
-		return nil, fmt.Errorf("received empty assignments for group, %v", r.config.GroupID)
+		generation, memberID := r.membership()
+		return nil, fmt.Errorf("received empty assignments for group, %v as member %s for generation %d", r.config.GroupID, memberID, generation)
 	}
 
 	r.withLogger(func(l *log.Logger) {

--- a/reader.go
+++ b/reader.go
@@ -336,7 +336,7 @@ func (r *Reader) joinGroup() (memberGroupAssignments, error) {
 		}
 		assignments = v
 
-		r.withLogger(func(l *log.Logger) {
+		r.withErrorLogger(func(l *log.Logger) {
 			for memberID, assignment := range assignments {
 				for topic, partitions := range assignment {
 					l.Printf("assigned member/topic/partitions %v/%v/%v\n", memberID, topic, partitions)

--- a/reader.go
+++ b/reader.go
@@ -268,12 +268,6 @@ func (r *Reader) leaveGroup(conn *Conn) error {
 		return fmt.Errorf("leave group failed for group, %v, and member, %v: %v", r.config.GroupID, memberID, err)
 	}
 
-	// Clear the member ID and generation ID on leave
-	r.mutex.Lock()
-	r.memberID = ""
-	r.generationID = 0
-	r.mutex.Unlock()
-
 	return nil
 }
 
@@ -429,7 +423,6 @@ func (r *Reader) syncGroup(memberAssignments memberGroupAssignments) (map[string
 	}
 
 	if len(assignments.Topics) == 0 {
-		_ = r.leaveGroup(conn)
 		return nil, fmt.Errorf("received empty assignments for group, %v", r.config.GroupID)
 	}
 
@@ -547,7 +540,7 @@ func (r *Reader) coordinator() (*Conn, error) {
 
 	conn, err := r.config.Dialer.DialContext(r.stctx, "tcp", address)
 	if err != nil {
-		return nil, fmt.Errorf("unable to connect to coordinator, %v: %v", address, err)
+		return nil, fmt.Errorf("unable to connect to coordinator, %v", address)
 	}
 
 	return conn, nil

--- a/reader.go
+++ b/reader.go
@@ -339,7 +339,7 @@ func (r *Reader) joinGroup() (memberGroupAssignments, error) {
 		}
 		assignments = v
 
-		r.withErrorLogger(func(l *log.Logger) {
+		r.withLogger(func(l *log.Logger) {
 			for memberID, assignment := range assignments {
 				for topic, partitions := range assignment {
 					l.Printf("assigned member/topic/partitions %v/%v/%v\n", memberID, topic, partitions)

--- a/reader.go
+++ b/reader.go
@@ -250,6 +250,9 @@ func (r *Reader) assignTopicPartitions(conn partitionReader, group joinGroupResp
 
 	r.withLogger(func(l *log.Logger) {
 		l.Printf("using '%v' strategy to assign group, %v\n", group.GroupProtocol, r.config.GroupID)
+		for _, member := range members {
+			l.Printf("found member: %v/%#v", member.MemberID, member.Metadata)
+		}
 		for _, partition := range partitions {
 			l.Printf("found topic/partition: %v/%v", partition.Topic, partition.ID)
 		}

--- a/reader.go
+++ b/reader.go
@@ -422,6 +422,10 @@ func (r *Reader) syncGroup(memberAssignments memberGroupAssignments) (map[string
 		return nil, fmt.Errorf("unable to read SyncGroup response for group, %v: %v\n", r.config.GroupID, err)
 	}
 
+	if len(assignments.Topics) == 0 {
+		return nil, fmt.Errorf("received empty assignments for group, %v", r.config.GroupID)
+	}
+
 	r.withLogger(func(l *log.Logger) {
 		l.Printf("sync group finished for group, %v\n", r.config.GroupID)
 	})

--- a/reader.go
+++ b/reader.go
@@ -1063,7 +1063,7 @@ func NewReader(config ReaderConfig) *Reader {
 		msgs:    make(chan readerMessage, config.QueueCapacity),
 		cancel:  func() {},
 		done:    make(chan struct{}),
-		commits: make(chan commitRequest),
+		commits: make(chan commitRequest, config.QueueCapacity),
 		stop:    stop,
 		offset:  firstOffset,
 		stctx:   stctx,

--- a/reader.go
+++ b/reader.go
@@ -336,7 +336,7 @@ func (r *Reader) joinGroup() (memberGroupAssignments, error) {
 		}
 		assignments = v
 
-		r.withErrorLogger(func(l *log.Logger) {
+		r.withLogger(func(l *log.Logger) {
 			for memberID, assignment := range assignments {
 				for topic, partitions := range assignment {
 					l.Printf("assigned member/topic/partitions %v/%v/%v\n", memberID, topic, partitions)
@@ -423,6 +423,7 @@ func (r *Reader) syncGroup(memberAssignments memberGroupAssignments) (map[string
 	}
 
 	if len(assignments.Topics) == 0 {
+		_ = r.leaveGroup(conn)
 		return nil, fmt.Errorf("received empty assignments for group, %v", r.config.GroupID)
 	}
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -1162,15 +1162,15 @@ type mockOffsetCommitter struct {
 	err         error
 }
 
-func (m *mockOffsetCommitter) offsetCommit(request offsetCommitRequestV3) (offsetCommitResponseV3, error) {
+func (m *mockOffsetCommitter) offsetCommit(request offsetCommitRequestV2) (offsetCommitResponseV2, error) {
 	m.invocations++
 
 	if m.failCount > 0 {
 		m.failCount--
-		return offsetCommitResponseV3{}, io.EOF
+		return offsetCommitResponseV2{}, io.EOF
 	}
 
-	return offsetCommitResponseV3{}, nil
+	return offsetCommitResponseV2{}, nil
 }
 
 func TestCommitOffsetsWithRetry(t *testing.T) {

--- a/reader_test.go
+++ b/reader_test.go
@@ -264,8 +264,8 @@ func createTopic(t *testing.T, topic string, partitions int) {
 	}
 	defer conn.Close()
 
-	_, err = conn.createTopics(createTopicsRequestV2{
-		Topics: []createTopicsRequestV2Topic{
+	_, err = conn.createTopics(createTopicsRequestV0{
+		Topics: []createTopicsRequestV0Topic{
 			{
 				Topic:             topic,
 				NumPartitions:     int32(partitions),
@@ -619,13 +619,13 @@ func TestReaderAssignTopicPartitions(t *testing.T) {
 		},
 	}
 
-	newJoinGroupResponseV2 := func(topicsByMemberID map[string][]string) joinGroupResponseV2 {
-		resp := joinGroupResponseV2{
+	newJoinGroupResponseV1 := func(topicsByMemberID map[string][]string) joinGroupResponseV1 {
+		resp := joinGroupResponseV1{
 			GroupProtocol: roundrobinStrategy{}.ProtocolName(),
 		}
 
 		for memberID, topics := range topicsByMemberID {
-			resp.Members = append(resp.Members, joinGroupResponseMemberV2{
+			resp.Members = append(resp.Members, joinGroupResponseMemberV1{
 				MemberID: memberID,
 				MemberMetadata: groupMetadata{
 					Topics: topics,
@@ -637,15 +637,15 @@ func TestReaderAssignTopicPartitions(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		Members     joinGroupResponseV2
+		Members     joinGroupResponseV1
 		Assignments memberGroupAssignments
 	}{
 		"nil": {
-			Members:     newJoinGroupResponseV2(nil),
+			Members:     newJoinGroupResponseV1(nil),
 			Assignments: memberGroupAssignments{},
 		},
 		"one member, one topic": {
-			Members: newJoinGroupResponseV2(map[string][]string{
+			Members: newJoinGroupResponseV1(map[string][]string{
 				"member-1": {"topic-1"},
 			}),
 			Assignments: memberGroupAssignments{
@@ -655,7 +655,7 @@ func TestReaderAssignTopicPartitions(t *testing.T) {
 			},
 		},
 		"one member, two topics": {
-			Members: newJoinGroupResponseV2(map[string][]string{
+			Members: newJoinGroupResponseV1(map[string][]string{
 				"member-1": {"topic-1", "topic-2"},
 			}),
 			Assignments: memberGroupAssignments{
@@ -666,7 +666,7 @@ func TestReaderAssignTopicPartitions(t *testing.T) {
 			},
 		},
 		"two members, one topic": {
-			Members: newJoinGroupResponseV2(map[string][]string{
+			Members: newJoinGroupResponseV1(map[string][]string{
 				"member-1": {"topic-1"},
 				"member-2": {"topic-1"},
 			}),
@@ -680,7 +680,7 @@ func TestReaderAssignTopicPartitions(t *testing.T) {
 			},
 		},
 		"two members, two unshared topics": {
-			Members: newJoinGroupResponseV2(map[string][]string{
+			Members: newJoinGroupResponseV1(map[string][]string{
 				"member-1": {"topic-1"},
 				"member-2": {"topic-2"},
 			}),

--- a/strategy.go
+++ b/strategy.go
@@ -61,11 +61,6 @@ func (r rangeStrategy) AssignGroups(members []memberGroupMetadata, topicPartitio
 		partitionCount := len(partitions)
 		memberCount := len(members)
 
-		rangeSize := partitionCount / memberCount
-		if partitionCount%memberCount != 0 {
-			rangeSize++
-		}
-
 		for memberIndex, member := range members {
 			assignmentsByTopic, ok := groupAssignments[member.MemberID]
 			if !ok {
@@ -73,8 +68,11 @@ func (r rangeStrategy) AssignGroups(members []memberGroupMetadata, topicPartitio
 				groupAssignments[member.MemberID] = assignmentsByTopic
 			}
 
+			min := memberIndex * partitionCount / memberCount
+			max := (memberIndex + 1) * partitionCount / memberCount
+
 			for partitionIndex, partition := range partitions {
-				if (partitionIndex / rangeSize) == memberIndex {
+				if partitionIndex >= min && partitionIndex < max {
 					assignmentsByTopic[topic] = append(assignmentsByTopic[topic], partition)
 				}
 			}

--- a/syncgroup.go
+++ b/syncgroup.go
@@ -66,7 +66,7 @@ func (t groupAssignment) bytes() []byte {
 	return buf.Bytes()
 }
 
-type syncGroupRequestGroupAssignmentV1 struct {
+type syncGroupRequestGroupAssignmentV0 struct {
 	// MemberID assigned by the group coordinator
 	MemberID string
 
@@ -76,17 +76,17 @@ type syncGroupRequestGroupAssignmentV1 struct {
 	MemberAssignments []byte
 }
 
-func (t syncGroupRequestGroupAssignmentV1) size() int32 {
+func (t syncGroupRequestGroupAssignmentV0) size() int32 {
 	return sizeofString(t.MemberID) +
 		sizeofBytes(t.MemberAssignments)
 }
 
-func (t syncGroupRequestGroupAssignmentV1) writeTo(w *bufio.Writer) {
+func (t syncGroupRequestGroupAssignmentV0) writeTo(w *bufio.Writer) {
 	writeString(w, t.MemberID)
 	writeBytes(w, t.MemberAssignments)
 }
 
-type syncGroupRequestV1 struct {
+type syncGroupRequestV0 struct {
 	// GroupID holds the unique group identifier
 	GroupID string
 
@@ -96,29 +96,24 @@ type syncGroupRequestV1 struct {
 	// MemberID assigned by the group coordinator
 	MemberID string
 
-	GroupAssignments []syncGroupRequestGroupAssignmentV1
+	GroupAssignments []syncGroupRequestGroupAssignmentV0
 }
 
-func (t syncGroupRequestV1) size() int32 {
+func (t syncGroupRequestV0) size() int32 {
 	return sizeofString(t.GroupID) +
 		sizeofInt32(t.GenerationID) +
 		sizeofString(t.MemberID) +
 		sizeofArray(len(t.GroupAssignments), func(i int) int32 { return t.GroupAssignments[i].size() })
 }
 
-func (t syncGroupRequestV1) writeTo(w *bufio.Writer) {
+func (t syncGroupRequestV0) writeTo(w *bufio.Writer) {
 	writeString(w, t.GroupID)
 	writeInt32(w, t.GenerationID)
 	writeString(w, t.MemberID)
 	writeArray(w, len(t.GroupAssignments), func(i int) { t.GroupAssignments[i].writeTo(w) })
 }
 
-type syncGroupResponseV1 struct {
-	// ThrottleTimeMS holds the duration in milliseconds for which the request
-	// was throttled due to quota violation (Zero if the request did not violate
-	// any quota)
-	ThrottleTimeMS int32
-
+type syncGroupResponseV0 struct {
 	// ErrorCode holds response error code
 	ErrorCode int16
 
@@ -128,23 +123,18 @@ type syncGroupResponseV1 struct {
 	MemberAssignments []byte
 }
 
-func (t syncGroupResponseV1) size() int32 {
-	return sizeofInt32(t.ThrottleTimeMS) +
-		sizeofInt16(t.ErrorCode) +
+func (t syncGroupResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode) +
 		sizeofBytes(t.MemberAssignments)
 }
 
-func (t syncGroupResponseV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
+func (t syncGroupResponseV0) writeTo(w *bufio.Writer) {
 	writeInt16(w, t.ErrorCode)
 	writeBytes(w, t.MemberAssignments)
 }
 
-func (t *syncGroupResponseV1) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
-	if remain, err = readInt32(r, sz, &t.ThrottleTimeMS); err != nil {
-		return
-	}
-	if remain, err = readInt16(r, remain, &t.ErrorCode); err != nil {
+func (t *syncGroupResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
 		return
 	}
 	if remain, err = readBytes(r, remain, &t.MemberAssignments); err != nil {

--- a/syncgroup_test.go
+++ b/syncgroup_test.go
@@ -55,9 +55,8 @@ func TestGroupAssignmentReadsFromZeroSize(t *testing.T) {
 	}
 }
 
-func TestSyncGroupResponseV1(t *testing.T) {
-	item := syncGroupResponseV1{
-		ThrottleTimeMS:    1,
+func TestsyncGroupResponseV0(t *testing.T) {
+	item := syncGroupResponseV0{
 		ErrorCode:         2,
 		MemberAssignments: []byte(`blah`),
 	}
@@ -67,7 +66,7 @@ func TestSyncGroupResponseV1(t *testing.T) {
 	item.writeTo(w)
 	w.Flush()
 
-	var found syncGroupResponseV1
+	var found syncGroupResponseV0
 	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
 	if err != nil {
 		t.Error(err)
@@ -83,9 +82,8 @@ func TestSyncGroupResponseV1(t *testing.T) {
 	}
 }
 
-func BenchmarkSyncGroupResponseV1(t *testing.B) {
-	item := syncGroupResponseV1{
-		ThrottleTimeMS:    1,
+func BenchmarkSyncGroupResponseV0(t *testing.B) {
+	item := syncGroupResponseV0{
 		ErrorCode:         2,
 		MemberAssignments: []byte(`blah`),
 	}
@@ -101,7 +99,7 @@ func BenchmarkSyncGroupResponseV1(t *testing.B) {
 
 	for i := 0; i < t.N; i++ {
 		r.Seek(0, io.SeekStart)
-		var found syncGroupResponseV1
+		var found syncGroupResponseV0
 		remain, err := (&found).readFrom(reader, size)
 		if err != nil {
 			t.Error(err)

--- a/syncgroup_test.go
+++ b/syncgroup_test.go
@@ -55,7 +55,7 @@ func TestGroupAssignmentReadsFromZeroSize(t *testing.T) {
 	}
 }
 
-func TestsyncGroupResponseV0(t *testing.T) {
+func TestSyncGroupResponseV0(t *testing.T) {
 	item := syncGroupResponseV0{
 		ErrorCode:         2,
 		MemberAssignments: []byte(`blah`),


### PR DESCRIPTION
The versions of many api calls made aren't compatible with kafka 0.10.1. These changes downgrade them for compatibility. This likely isn't the full set of changes needed for support, but can be a good starting point.