### PR TITLE
Fix retry mechanism when a failure occurs on the push to kafka

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -430,7 +430,7 @@ func (w *Writer) run() {
 					err = fmt.Errorf("failed to find any partitions for topic %s", w.config.Topic)
 				}
 
-				wm.res <- err
+				wm.res <- &writerError{msg: wm.msg, err: err}
 			}
 
 		case <-ticker.C:


### PR DESCRIPTION
When there is no existing partition or an error occurs writing to Kafka, the `run` routine returns a classic error.
But `WriteMessage` only retries if the error is a `writerError`  (https://github.com/segmentio/kafka-go/blob/master/writer.go#L288). This PR converts the errors returned by the `run` method during the write to the partition to `writeError` errors, allowing the retry mechanism to function as expected.

Closes: #74