### PR TITLE
 Fix range strategy uneven assignments when partition count not divisible by worker count

### DIFF
--- a/strategy.go
+++ b/strategy.go
@@ -61,11 +61,6 @@ func (r rangeStrategy) AssignGroups(members []memberGroupMetadata, topicPartitio
 		partitionCount := len(partitions)
 		memberCount := len(members)
 
-		rangeSize := partitionCount / memberCount
-		if partitionCount%memberCount != 0 {
-			rangeSize++
-		}
-
 		for memberIndex, member := range members {
 			assignmentsByTopic, ok := groupAssignments[member.MemberID]
 			if !ok {
@@ -73,8 +68,11 @@ func (r rangeStrategy) AssignGroups(members []memberGroupMetadata, topicPartitio
 				groupAssignments[member.MemberID] = assignmentsByTopic
 			}
 
+			minIndex := memberIndex * partitionCount / memberCount
+			maxIndex := (memberIndex + 1) * partitionCount / memberCount
+
 			for partitionIndex, partition := range partitions {
-				if (partitionIndex / rangeSize) == memberIndex {
+				if partitionIndex >= minIndex && partitionIndex < maxIndex {
 					assignmentsByTopic[topic] = append(assignmentsByTopic[topic], partition)
 				}
 			}

--- a/strategy_test.go
+++ b/strategy_test.go
@@ -141,10 +141,10 @@ func TestRangeAssignGroups(t *testing.T) {
 			},
 			Partitions: newPartitions(1, "topic-1"),
 			Expected: memberGroupAssignments{
-				"a": map[string][]int32{
+				"a": map[string][]int32{},
+				"b": map[string][]int32{
 					"topic-1": {0},
 				},
-				"b": map[string][]int32{},
 			},
 		},
 		"multiple members, one topic, multiple partitions": {
@@ -155,10 +155,10 @@ func TestRangeAssignGroups(t *testing.T) {
 			Partitions: newPartitions(3, "topic-1"),
 			Expected: memberGroupAssignments{
 				"a": map[string][]int32{
-					"topic-1": {0, 1},
+					"topic-1": {0},
 				},
 				"b": map[string][]int32{
-					"topic-1": {2},
+					"topic-1": {1, 2},
 				},
 			},
 		},
@@ -171,10 +171,10 @@ func TestRangeAssignGroups(t *testing.T) {
 			Expected: memberGroupAssignments{
 				"a": map[string][]int32{
 					"topic-1": {0, 1, 2},
-					"topic-2": {0, 1},
+					"topic-2": {0},
 				},
 				"b": map[string][]int32{
-					"topic-2": {2},
+					"topic-2": {1, 2},
 					"topic-3": {0, 1, 2},
 				},
 			},


### PR DESCRIPTION
In the current implementation, when attempting to assign 213 partitions to 66 members, the range strategy decides each member gets 3.22, rounded up to 4 partitions, each. This gives the first 53 members 4 partitions, one member a single partition, and the remaining 12 workers 0 partitions each. This causes almost 20% of the members to be idle.

This PR switches the strategy to instead spread the start indexes of each member evenly over the partitions, causing the difference between the min and max partition count assigned to each member to be at most 1.

Many of the existing tests for the range strategy had their output changed to different, but still valid values.