### PR TITLE
Make topic and partition read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ for higher level abstractions, like the `Reader` for example.
 
 A `Reader` is another concept exposed by the `kafka-go` package, which intends
 to make it simpler to implement the typical use case of consuming from a single
-topic-partition pair.  
+topic-partition pair.
 A `Reader` also automatically handles reconnections and offset management, and
 exposes an API that supports asynchronous cancellations and timeouts using Go
 contexts.
@@ -157,7 +157,7 @@ for {
     if err != nil {
         break
     }
-    fmt.Printf("message at topic/partition/offset %v/%v/%v: %s = %s\n", m.Topic, m.Partition, m.Offset, string(m.Key), string(m.Value))
+    fmt.Printf("message at topic/partition/offset %v/%v/%v: %s = %s\n", m.Topic(), m.Partition(), m.Offset, string(m.Key), string(m.Value))
     m.CommitMessages(ctx, m)
 }
 ```
@@ -219,9 +219,6 @@ w.WriteMessages(context.Background(),
 w.Close()
 ```
 
-**Note:** Even though kafka.Message contain ```Topic``` and ```Partition``` fields, they **MUST NOT** be 
-set when writing messages.  They are intended for read use only.
-
 ### Compatibility with Sarama
 
 If you're switching from Sarama and need/want to use the same algorithm for message
@@ -238,7 +235,7 @@ w := kafka.NewWriter(kafka.WriterConfig{
 
 ## TLS Support
 
-For a bare bones Conn type or in the Reader/Writer configs you can specify a dialer option for TLS support. If the TLS field is nil, it will not connect with TLS. 
+For a bare bones Conn type or in the Reader/Writer configs you can specify a dialer option for TLS support. If the TLS field is nil, it will not connect with TLS.
 
 ### Connection
 
@@ -269,7 +266,7 @@ r := kafka.NewReader(kafka.ReaderConfig{
 })
 ```
 
-### Writer 
+### Writer
 
 ```go
 dialer := &kafka.Dialer{

--- a/batch.go
+++ b/batch.go
@@ -161,8 +161,8 @@ func (batch *Batch) ReadMessage() (Message, error) {
 	)
 
 	batch.mutex.Unlock()
-	msg.Topic = batch.topic
-	msg.Partition = batch.partition
+	msg.topic = batch.topic
+	msg.partition = batch.partition
 	msg.Offset = offset
 	msg.Time = timestampToTime(timestamp)
 	return msg, err

--- a/commit.go
+++ b/commit.go
@@ -12,8 +12,8 @@ type commit struct {
 // its topic, partition, and offset from the message.
 func makeCommit(msg Message) commit {
 	return commit{
-		topic:     msg.Topic,
-		partition: msg.Partition,
+		topic:     msg.Topic(),
+		partition: msg.Partition(),
 		offset:    msg.Offset + 1,
 	}
 }

--- a/commit_test.go
+++ b/commit_test.go
@@ -4,17 +4,17 @@ import "testing"
 
 func TestMakeCommit(t *testing.T) {
 	msg := Message{
-		Topic:     "blah",
-		Partition: 1,
 		Offset:    2,
+		topic:     "blah",
+		partition: 1,
 	}
 
 	commit := makeCommit(msg)
-	if commit.topic != msg.Topic {
-		t.Errorf("bad topic: expected %v; got %v", msg.Topic, commit.topic)
+	if commit.topic != msg.Topic() {
+		t.Errorf("bad topic: expected %v; got %v", msg.Topic(), commit.topic)
 	}
-	if commit.partition != msg.Partition {
-		t.Errorf("bad partition: expected %v; got %v", msg.Partition, commit.partition)
+	if commit.partition != msg.Partition() {
+		t.Errorf("bad partition: expected %v; got %v", msg.Partition(), commit.partition)
 	}
 	if commit.offset != msg.Offset+1 {
 		t.Errorf("expected committed offset to be 1 greater than msg offset")

--- a/conn.go
+++ b/conn.go
@@ -775,10 +775,10 @@ func (c *Conn) WriteMessages(msgs ...Message) (int, error) {
 	for i, msg := range msgs {
 		// users may believe they can set the Topic and/or Partition
 		// on the kafka message.
-		if msg.Topic != "" && msg.Topic != c.topic {
+		if msg.Topic() != "" && msg.Topic() != c.topic {
 			return 0, errInvalidWriteTopic
 		}
-		if msg.Partition != 0 {
+		if msg.Partition() != 0 {
 			return 0, errInvalidWritePartition
 		}
 

--- a/message.go
+++ b/message.go
@@ -7,18 +7,26 @@ import (
 
 // Message is a data structure representing kafka messages.
 type Message struct {
-	// Topic is reads only and MUST NOT be set when writing messages
-	Topic string
-
-	// Partition is reads only and MUST NOT be set when writing messages
-	Partition int
-	Offset    int64
-	Key       []byte
-	Value     []byte
+	Offset int64
+	Key    []byte
+	Value  []byte
 
 	// If not set at the creation, Time will be automatically set when
 	// writing the message.
 	Time time.Time
+
+	topic     string
+	partition int
+}
+
+// Partition returns the partition used for this message.
+func (msg Message) Partition() int {
+	return msg.partition
+}
+
+// Topic returns the topic used for this message.
+func (msg Message) Topic() string {
+	return msg.topic
 }
 
 func (msg Message) item() messageSetItem {

--- a/reader_test.go
+++ b/reader_test.go
@@ -334,16 +334,16 @@ func testReaderSetsTopicAndPartition(t *testing.T, ctx context.Context, r *Reade
 			return
 		}
 
-		if m.Topic == "" {
+		if m.Topic() == "" {
 			t.Error("expected topic to be set")
 			return
 		}
-		if m.Topic != r.config.Topic {
-			t.Errorf("expected message to contain topic, %v; got %v", r.config.Topic, m.Topic)
+		if m.Topic() != r.config.Topic {
+			t.Errorf("expected message to contain topic, %v; got %v", r.config.Topic, m.Topic())
 			return
 		}
-		if m.Partition != r.config.Partition {
-			t.Errorf("expected partition to be set; expected 1, got %v", m.Partition)
+		if m.Partition() != r.config.Partition {
+			t.Errorf("expected partition to be set; expected 1, got %v", m.Partition())
 			return
 		}
 	}
@@ -804,7 +804,7 @@ func testReaderConsumerGroupHandshake(t *testing.T, ctx context.Context, r *Read
 	if err != nil {
 		t.Errorf("bad err: %v", err)
 	}
-	if m.Topic != r.config.Topic {
+	if m.Topic() != r.config.Topic {
 		t.Errorf("topic not set")
 	}
 	if m.Offset != 0 {
@@ -815,7 +815,7 @@ func testReaderConsumerGroupHandshake(t *testing.T, ctx context.Context, r *Read
 	if err != nil {
 		t.Errorf("bad err: %v", err)
 	}
-	if m.Topic != r.config.Topic {
+	if m.Topic() != r.config.Topic {
 		t.Errorf("topic not set")
 	}
 	if m.Offset != 1 {
@@ -944,7 +944,7 @@ func testReaderConsumerGroupReadContentAcrossPartitions(t *testing.T, ctx contex
 		if err != nil {
 			t.Errorf("bad error: %s", err)
 		}
-		partitions[m.Partition] = struct{}{}
+		partitions[m.Partition()] = struct{}{}
 	}
 
 	if v := len(partitions); v != 3 {
@@ -1089,9 +1089,9 @@ func TestOffsetStash(t *testing.T) {
 
 	newMessage := func(partition int, offset int64) Message {
 		return Message{
-			Topic:     topic,
-			Partition: partition,
 			Offset:    offset,
+			topic:     topic,
+			partition: partition,
 		}
 	}
 


### PR DESCRIPTION
This make `Topic` and `Partition` read-only by un-exporting the fields and exposing them only trough the `Topic()` and `Partition` methods.