### PR TITLE
Add constants for Seek's whence and introduce a fourth strategy

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -463,21 +463,21 @@ func (c *Conn) Offset() (offset int64, whence int) {
 }
 
 const (
-	SeekRelativeStart   = 0 // Seek relative to the first offset available in the partition.
-	SeekAbsolute        = 1 // Seek to an absolute offset.
-	SeekRelativeEnd     = 2 // Seek relative to the last offset available in the partition.
-	SeekRelativeCurrent = 3 // Seek relative to the current offset.
+	SeekStart    = 0 // Seek relative to the first offset available in the partition.
+	SeekAbsolute = 1 // Seek to an absolute offset.
+	SeekEnd      = 2 // Seek relative to the last offset available in the partition.
+	SeekCurrent  = 3 // Seek relative to the current offset.
 )
 
 // Seek sets the offset for the next read or write operation according to whence, which
-// should be one of SeekRelativeStart, SeekAbsolute, SeekRelativeEnd, or SeekRelativeCurrent.
+// should be one of SeekStart, SeekAbsolute, SeekEnd, or SeekCurrent.
 // When seeking relative to the end, the offset is subtracted from the current offset.
 // Note that for historical reasons, these do not align with the usual whence constants
 // as in lseek(2) or os.Seek.
 // The method returns the new absolute offset of the connection.
 func (c *Conn) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
-	case SeekRelativeStart, SeekAbsolute, SeekRelativeEnd, SeekRelativeCurrent:
+	case SeekStart, SeekAbsolute, SeekEnd, SeekCurrent:
 	default:
 		return 0, fmt.Errorf("whence must be one of 0, 1, 2, 3, or 4. (whence = %d)", whence)
 	}
@@ -490,7 +490,7 @@ func (c *Conn) Seek(offset int64, whence int) (int64, error) {
 			return offset, nil
 		}
 	}
-	if whence == SeekRelativeCurrent {
+	if whence == SeekCurrent {
 		c.mutex.Lock()
 		offset = c.offset + offset
 		c.mutex.Unlock()
@@ -502,9 +502,9 @@ func (c *Conn) Seek(offset int64, whence int) (int64, error) {
 	}
 
 	switch whence {
-	case SeekRelativeStart:
+	case SeekStart:
 		offset = first + offset
-	case SeekRelativeEnd:
+	case SeekEnd:
 		offset = last - offset
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -462,24 +462,38 @@ func (c *Conn) Offset() (offset int64, whence int) {
 	return
 }
 
-// Seek changes the offset of the connection to offset, interpreted according to
-// whence: 0 means relative to the first offset, 1 means relative to the current
-// offset, and 2 means relative to the last offset.
-// The method returns the new absoluate offset of the connection.
+const (
+	SeekRelativeStart   = 0 // Seek relative to the first offset available in the partition.
+	SeekAbsolute        = 1 // Seek to an absolute offset.
+	SeekRelativeEnd     = 2 // Seek relative to the last offset available in the partition.
+	SeekRelativeCurrent = 3 // Seek relative to the current offset.
+)
+
+// Seek sets the offset for the next read or write operation according to whence, which
+// should be one of SeekRelativeStart, SeekAbsolute, SeekRelativeEnd, or SeekRelativeCurrent.
+// When seeking relative to the end, the offset is subtracted from the current offset.
+// Note that for historical reasons, these do not align with the usual whence constants
+// as in lseek(2) or os.Seek.
+// The method returns the new absolute offset of the connection.
 func (c *Conn) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
-	case 0, 1, 2:
+	case SeekRelativeStart, SeekAbsolute, SeekRelativeEnd, SeekRelativeCurrent:
 	default:
-		return 0, fmt.Errorf("the whence value has to be 0, 1, or 2 (whence = %d)", whence)
+		return 0, fmt.Errorf("whence must be one of 0, 1, 2, 3, or 4. (whence = %d)", whence)
 	}
 
-	if whence == 1 {
+	if whence == SeekAbsolute {
 		c.mutex.Lock()
 		unchanged := offset == c.offset
 		c.mutex.Unlock()
 		if unchanged {
 			return offset, nil
 		}
+	}
+	if whence == SeekRelativeCurrent {
+		c.mutex.Lock()
+		offset = c.offset + offset
+		c.mutex.Unlock()
 	}
 
 	first, last, err := c.ReadOffsets()
@@ -488,9 +502,9 @@ func (c *Conn) Seek(offset int64, whence int) (int64, error) {
 	}
 
 	switch whence {
-	case 0:
+	case SeekRelativeStart:
 		offset = first + offset
-	case 2:
+	case SeekRelativeEnd:
 		offset = last - offset
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -1711,7 +1711,7 @@ func (r *reader) initialize(ctx context.Context, offset int64) (conn *Conn, star
 			log.Printf("the kafka reader for partition %d of %s is seeking to offset %d", r.partition, r.topic, offset)
 		})
 
-		if start, err = conn.Seek(offset, 1); err != nil {
+		if start, err = conn.Seek(offset, SeekAbsolute); err != nil {
 			conn.Close()
 			conn = nil
 			break

--- a/writer_test.go
+++ b/writer_test.go
@@ -171,7 +171,7 @@ func readPartition(topic string, partition int, offset int64) (msgs []Message, e
 	}
 	defer conn.Close()
 
-	conn.Seek(offset, 1)
+	conn.Seek(offset, SeekAbsolute)
 	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
 	batch := conn.ReadBatch(0, 1000000000)
 	defer batch.Close()


### PR DESCRIPTION
This change is intended to be non-breaking.

Since the meaning of `whence` differs subtly from `os.Seek`, name them to make the meanings obvious. Also, add the missing "seek relative to current offset" (previously whence=1 was documented as doing this, but it actually seeks to an absolute offset, whereas 0 is relative to the beginning of the partition.