### PR TITLE
fixed bug with unknown topic/partition

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -159,9 +159,9 @@ func (d *Dialer) LookupLeader(ctx context.Context, network string, address strin
 					return
 				}
 			}
+			errch <- UnknownTopicOrPartition
+			return
 		}
-
-		errch <- UnknownTopicOrPartition
 	}()
 
 	var brk Broker


### PR DESCRIPTION
If you try to connect to unexistent partition/topic, you will get stuck into infinite retry loop with
ReadPartitions result [], nil
seems like error should be on other place