### PR TITLE
Reader nows allows setting offset with timestamp

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1388,6 +1388,32 @@ func (r *Reader) SetOffset(offset int64) error {
 	return err
 }
 
+// SetOffsetWithTimestamp changes the offset from which the next batch of messages will be
+// read given the timestamp t.
+//
+// The method fails if the unable to connect to the coordinator, or unable to read the offset
+// given the ts, or if the reader has been closed.
+func (r *Reader) SetOffsetWithTimestamp(t time.Time) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.closed {
+		return io.ErrClosedPipe
+	}
+
+	conn, err := r.coordinator()
+	if err != nil {
+		return err
+	}
+
+	offset, err := conn.ReadOffset(t)
+	if err != nil {
+		return err
+	}
+
+	return r.SetOffset(offset)
+}
+
 // Stats returns a snapshot of the reader stats since the last time the method
 // was called, or since the reader was created if it is called for the first
 // time.


### PR DESCRIPTION
Previously the library allowed to set the offset given the offset number. However the reader does not allow setting the offset by finding the next available offset by timestamp.

This change will allow you to change the reader's offset by specifying the timestamp.