### PR TITLE
Add SASL support

### DIFF
--- a/apiversions.go
+++ b/apiversions.go
@@ -1,0 +1,88 @@
+package kafka
+
+import (
+	"bufio"
+)
+
+type apiVersionsRequestV1 struct {
+}
+
+func (t apiVersionsRequestV1) size() int32 {
+	return 0
+}
+
+func (t apiVersionsRequestV1) writeTo(w *bufio.Writer) {}
+
+type apiVersionsResponseV1Range struct {
+	APIKey int16
+
+	MinVersion int16
+	MaxVersion int16
+}
+
+func (t *apiVersionsResponseV1Range) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.APIKey); err != nil {
+		return
+	}
+	if remain, err = readInt16(r, remain, &t.MinVersion); err != nil {
+		return
+	}
+	if remain, err = readInt16(r, remain, &t.MaxVersion); err != nil {
+		return
+	}
+	return
+}
+
+func (t apiVersionsResponseV1Range) writeTo(w *bufio.Writer) {
+	writeInt16(w, t.APIKey)
+	writeInt16(w, t.MinVersion)
+	writeInt16(w, t.MaxVersion)
+}
+
+func (t *apiVersionsResponseV1Range) size() int32 { return 6 }
+
+type apiVersionsResponseV1 struct {
+	// ErrorCode holds response error code
+	ErrorCode int16
+
+	// Responses holds api versions per api key
+	APIVersions []apiVersionsResponseV1Range
+
+	// ThrottleTimeMS holds the duration in milliseconds for which the request
+	// was throttled due to quota violation (Zero if the request did not violate
+	// any quota)
+	ThrottleTimeMS int32
+}
+
+func (t apiVersionsResponseV1) size() int32 {
+	return sizeofInt16(t.ErrorCode) +
+		sizeofArray(len(t.APIVersions), func(i int) int32 { return t.APIVersions[i].size() }) +
+		sizeofInt32(t.ThrottleTimeMS)
+}
+
+func (t apiVersionsResponseV1) writeTo(w *bufio.Writer) {
+	writeInt16(w, t.ErrorCode)
+	writeArray(w, len(t.APIVersions), func(i int) { t.APIVersions[i].writeTo(w) })
+	writeInt32(w, t.ThrottleTimeMS)
+}
+
+func (t *apiVersionsResponseV1) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
+		return
+	}
+	fn := func(r *bufio.Reader, withSize int) (fnRemain int, fnErr error) {
+		item := apiVersionsResponseV1Range{}
+		if fnRemain, fnErr = (&item).readFrom(r, withSize); fnErr != nil {
+			return
+		}
+		t.APIVersions = append(t.APIVersions, item)
+		return
+	}
+	if remain, err = readArrayWith(r, remain, fn); err != nil {
+		return
+	}
+	if remain, err = readInt32(r, remain, &t.ThrottleTimeMS); err != nil {
+		return
+	}
+	return
+}

--- a/apiversions_test.go
+++ b/apiversions_test.go
@@ -1,0 +1,41 @@
+package kafka
+
+import (
+	"bufio"
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestAPIVersionsResponseV1(t *testing.T) {
+	item := apiVersionsResponseV1{
+		ErrorCode: 2,
+		APIVersions: []apiVersionsResponseV1Range{
+			{
+				APIKey:     1,
+				MinVersion: 1,
+				MaxVersion: 3,
+			},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	w := bufio.NewWriter(buf)
+	item.writeTo(w)
+	w.Flush()
+
+	var found apiVersionsResponseV1
+	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}

--- a/dialer.go
+++ b/dialer.go
@@ -60,6 +60,9 @@ type Dialer struct {
 	// TLS enables Dialer to open secure connections.  If nil, standard net.Conn
 	// will be used.
 	TLS *tls.Config
+
+	// SASLClient enables SASL authentication
+	SASLClient func() SASLClient
 }
 
 // Dial connects to the address on the named network.
@@ -97,7 +100,16 @@ func (d *Dialer) DialContext(ctx context.Context, network string, address string
 	if err != nil {
 		return nil, err
 	}
-	return NewConnWith(c, ConnConfig{ClientID: d.ClientID}), nil
+
+	conn := NewConnWith(c, ConnConfig{ClientID: d.ClientID})
+
+	if d.SASLClient != nil {
+		if err := d.authenticateSASL(ctx, conn); err != nil {
+			return nil, err
+		}
+	}
+
+	return conn, nil
 }
 
 // DialLeader opens a connection to the leader of the partition for a given
@@ -125,11 +137,19 @@ func (d *Dialer) DialPartition(ctx context.Context, network string, address stri
 		return nil, err
 	}
 
-	return NewConnWith(c, ConnConfig{
+	conn := NewConnWith(c, ConnConfig{
 		ClientID:  d.ClientID,
 		Topic:     partition.Topic,
 		Partition: partition.ID,
-	}), nil
+	})
+
+	if d.SASLClient != nil {
+		if err := d.authenticateSASL(ctx, conn); err != nil {
+			return nil, err
+		}
+	}
+
+	return conn, nil
 }
 
 // LookupLeader searches for the kafka broker that is the leader of the
@@ -238,6 +258,47 @@ func (d *Dialer) connectTLS(ctx context.Context, conn net.Conn) (tlsConn *tls.Co
 	return
 }
 
+func (d *Dialer) authenticateSASL(ctx context.Context, conn *Conn) error {
+	versions, err := conn.apiVersions()
+	if err != nil {
+		return err
+	}
+
+	saslVersion := versions[saslHandshakeRequest]
+	var handshakeVersion = v0
+	var opaque = true
+	if saslVersion.maxVersion >= v1 {
+		opaque = false
+		handshakeVersion = v1
+	}
+
+	client := d.SASLClient()
+	_, err = conn.saslHandshake(handshakeVersion, client.Mechanism())
+	if err != nil {
+		return err // TODO: allow mechanism negotiation by returning the list of supported mechanisms
+	}
+
+	bytes, err := client.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	var completed bool
+	for !completed {
+		challenge, err := conn.saslAuthenticate(opaque, bytes)
+		if err != nil {
+			return err
+		}
+
+		completed, bytes, err = client.Next(ctx, challenge)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (d *Dialer) dialContext(ctx context.Context, network string, address string) (net.Conn, error) {
 	if r := d.Resolver; r != nil {
 		host, port := splitHostPort(address)
@@ -313,6 +374,22 @@ type Resolver interface {
 	// LookupHost looks up the given host using the local resolver.
 	// It returns a slice of that host's addresses.
 	LookupHost(ctx context.Context, host string) (addrs []string, err error)
+}
+
+// The SASLClient interface is used to enable plugging in different
+// SASL implementations at compile time.
+type SASLClient interface {
+	// Mechanism returns the name of the mechanism (eg. SCRAM-SHA-256)
+	Mechanism() string
+
+	// Start returns the initial client response to send to the server
+	Start(ctx context.Context) (response []byte, err error)
+
+	// Next computes the response to the server challenge and may be
+	// called multiple times until completed is set.  Completed may be
+	// set either because the authentication exchange has failed or
+	// succeeded.  If the authentication failed, err must be non-nil.
+	Next(ctx context.Context, challenge []byte) (completed bool, response []byte, err error)
 }
 
 func sleep(ctx context.Context, duration time.Duration) bool {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,31 @@
 version: "3"
 services:
   kafka:
-    image: wurstmeister/kafka:0.11.0.1
+    image: wurstmeister/kafka:2.11-0.11.0.3
     restart: on-failure:3
     links:
       - zookeeper
     ports:
       - "9092:9092"
+      - "9094:9094"
     environment:
-      KAFKA_VERSION: '0.11.0.1'
+      KAFKA_VERSION: '0.11.0.3'
       KAFKA_BROKER_ID: 1
       KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-      KAFKA_ADVERTISED_PORT: '9092'
+      KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9094'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9094'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_SECURITY_PROTOCOL: SASL_PLAINTEXT
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL'
+      KAFKA_SASL_ENABLED_MECHANISMS: SCRAM-SHA-512,PLAIN
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+      CUSTOM_INIT_SCRIPT: |-
+          echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+          /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-512=[password=admin-secret]' --entity-type users --entity-name adminscram
+
 
   zookeeper:
     image: wurstmeister/zookeeper

--- a/error.go
+++ b/error.go
@@ -64,6 +64,7 @@ const (
 	TransactionalIDAuthorizationFailed Error = 53
 	SecurityDisabled                   Error = 54
 	BrokerAuthorizationFailed          Error = 55
+	SASLAuthenticationFailed           Error = 58
 )
 
 // Error satisfies the error interface.
@@ -201,6 +202,8 @@ func (e Error) Title() string {
 		return "Security Disabled"
 	case BrokerAuthorizationFailed:
 		return "Broker Authorization Failed"
+	case SASLAuthenticationFailed:
+		return "SASL Authentication Failed"
 	}
 	return ""
 }

--- a/protocol.go
+++ b/protocol.go
@@ -22,8 +22,11 @@ const (
 	syncGroupRequest        apiKey = 14
 	describeGroupsRequest   apiKey = 15
 	listGroupsRequest       apiKey = 16
+	saslHandshakeRequest    apiKey = 17
+	apiVersionsRequest      apiKey = 18
 	createTopicsRequest     apiKey = 19
 	deleteTopicsRequest     apiKey = 20
+	saslAuthenticateRequest apiKey = 36
 )
 
 type apiVersion int16

--- a/saslauthenticate.go
+++ b/saslauthenticate.go
@@ -1,0 +1,54 @@
+package kafka
+
+import (
+	"bufio"
+)
+
+type saslAuthenticateRequestV0 struct {
+	// Data holds the SASL payload
+	Data []byte
+}
+
+func (t saslAuthenticateRequestV0) size() int32 {
+	return sizeofBytes(t.Data)
+}
+
+func (t *saslAuthenticateRequestV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	return readBytes(r, sz, &t.Data)
+}
+
+func (t saslAuthenticateRequestV0) writeTo(w *bufio.Writer) {
+	writeBytes(w, t.Data)
+}
+
+type saslAuthenticateResponseV0 struct {
+	// ErrorCode holds response error code
+	ErrorCode int16
+
+	ErrorMessage string
+
+	Data []byte
+}
+
+func (t saslAuthenticateResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode) + sizeofString(t.ErrorMessage) + sizeofBytes(t.Data)
+}
+
+func (t saslAuthenticateResponseV0) writeTo(w *bufio.Writer) {
+	writeInt16(w, t.ErrorCode)
+	writeString(w, t.ErrorMessage)
+	writeBytes(w, t.Data)
+}
+
+func (t *saslAuthenticateResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ErrorMessage); err != nil {
+		return
+	}
+	if remain, err = readBytes(r, remain, &t.Data); err != nil {
+		return
+	}
+	return
+}

--- a/saslauthenticate_test.go
+++ b/saslauthenticate_test.go
@@ -1,0 +1,62 @@
+package kafka
+
+import (
+	"bufio"
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestSASLAuthenticateRequestV0(t *testing.T) {
+	item := saslAuthenticateRequestV0{
+		Data: []byte("\x00user\x00pass"),
+	}
+
+	buf := bytes.NewBuffer(nil)
+	w := bufio.NewWriter(buf)
+	item.writeTo(w)
+	w.Flush()
+
+	var found saslAuthenticateRequestV0
+	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}
+
+func TestSASLAuthenticateResponseV0(t *testing.T) {
+	item := saslAuthenticateResponseV0{
+		ErrorCode:    2,
+		ErrorMessage: "Message",
+		Data:         []byte("bytes"),
+	}
+
+	buf := bytes.NewBuffer(nil)
+	w := bufio.NewWriter(buf)
+	item.writeTo(w)
+	w.Flush()
+
+	var found saslAuthenticateResponseV0
+	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}

--- a/saslhandshake.go
+++ b/saslhandshake.go
@@ -1,0 +1,53 @@
+package kafka
+
+import (
+	"bufio"
+)
+
+// saslHandshakeRequestV0 implements the format for V0 and V1 SASL
+// requests (they are identical)
+type saslHandshakeRequestV0 struct {
+	// Mechanism holds the SASL Mechanism chosen by the client.
+	Mechanism string
+}
+
+func (t saslHandshakeRequestV0) size() int32 {
+	return sizeofString(t.Mechanism)
+}
+
+func (t *saslHandshakeRequestV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	return readString(r, sz, &t.Mechanism)
+}
+
+func (t saslHandshakeRequestV0) writeTo(w *bufio.Writer) {
+	writeString(w, t.Mechanism)
+}
+
+// saslHandshakeResponseV0 implements the format for V0 and V1 SASL
+// responses (they are identical)
+type saslHandshakeResponseV0 struct {
+	// ErrorCode holds response error code
+	ErrorCode int16
+
+	// Array of mechanisms enabled in the server
+	EnabledMechanisms []string
+}
+
+func (t saslHandshakeResponseV0) size() int32 {
+	return sizeofInt16(t.ErrorCode) + sizeofStringArray(t.EnabledMechanisms)
+}
+
+func (t saslHandshakeResponseV0) writeTo(w *bufio.Writer) {
+	writeInt16(w, t.ErrorCode)
+	writeStringArray(w, t.EnabledMechanisms)
+}
+
+func (t *saslHandshakeResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readStringArray(r, remain, &t.EnabledMechanisms); err != nil {
+		return
+	}
+	return
+}

--- a/saslhandshake_test.go
+++ b/saslhandshake_test.go
@@ -1,0 +1,61 @@
+package kafka
+
+import (
+	"bufio"
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestSASLHandshakeRequestV0(t *testing.T) {
+	item := saslHandshakeRequestV0{
+		Mechanism: "SCRAM-SHA-512",
+	}
+
+	buf := bytes.NewBuffer(nil)
+	w := bufio.NewWriter(buf)
+	item.writeTo(w)
+	w.Flush()
+
+	var found saslHandshakeRequestV0
+	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}
+
+func TestSASLHandshakeResponseV0(t *testing.T) {
+	item := saslHandshakeResponseV0{
+		ErrorCode:         2,
+		EnabledMechanisms: []string{"PLAIN", "SCRAM-SHA-512"},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	w := bufio.NewWriter(buf)
+	item.writeTo(w)
+	w.Flush()
+
+	var found saslHandshakeResponseV0
+	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
Add support for SASL authentication by allowing the user to set the
SASLClient field on the kafka.Dialer struct.

The user must provide its own implementation of kafka.SASLClient because
there is currently no SASL library for Go with support for all the
implementations Kafka supports, and this will allow kafka-go to support
more SASL mechanisms without changing the core library.

The tests have been updated to test PLAIN authentication against a live
server.  The implementation has also been tested using SCRAM-SHA-256
and SCRAM-SHA-512, against 0.11.0.3 and 2.0.1.

This commit introduces four new calls agains kafka, which will only be
used if SASLClient is set:

 - ApiVersionsRequest v1
 - SaslHandshakeRequest v0 and v1
 - SaslAuthenticateRequestV0
 - Raw SASL packets

For more information about the authentication sequence, please see
https://kafka.apache.org/protocol#sasl_handshake

TODO: For Kerberos and SCRAM-SHA-256-PLUS support the interface methods
for kafka.SASLClient might need to be extended.

Example using github.com/xdg/scram to implement SCRAM-SHA-512:

```go
import (
        "context"
        "crypto/sha512"
        "hash"
        "log"

        kafka "github.com/segmentio/kafka-go"
        "github.com/xdg/scram"
)

var SHA512 scram.HashGeneratorFcn = func() hash.Hash { return sha512.New() }

type SCRAMClient struct {
        client *scram.ClientConversation
}

func (s *SCRAMClient) Mechanism() string { return "SCRAM-SHA-512" }

func (s *SCRAMClient) Start(ctx context.Context) ([]byte, error) {
        str, err := s.client.Step("")
        return []byte(str), err
}

func (s *SCRAMClient) Next(ctx context.Context, challenge []byte) (bool, []byte, error) {
        str, err := s.client.Step(string(challenge))
        return s.client.Done(), []byte(str), err
}

func main() {
        scramClient, err := SHA512.NewClient("adminscram", "admin-secret", "")
        if err != nil {
                log.Fatal(err)
        }

        r := kafka.NewReader(kafka.ReaderConfig{
                Dialer: &kafka.Dialer{
                        SASLClient: func() kafka.SASLClient { return &SCRAMClient{scramClient.NewConversation()} },
                },
                Brokers: []string{"localhost:9094"},
                Topic:   "test-writer-1",
        })

```


Updates #109 