### PR TITLE
Add CRC32 and Murmur2 balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,28 +222,57 @@ w.Close()
 **Note:** Even though kafka.Message contain ```Topic``` and ```Partition``` fields, they **MUST NOT** be
 set when writing messages.  They are intended for read use only.
 
-### Compatibility with Sarama
+### Compatibility with other clients
+
+#### Sarama
 
 If you're switching from Sarama and need/want to use the same algorithm for message
 partitioning, you can use the ```kafka.Hash``` balancer.  ```kafka.Hash``` routes
-messages to the same partitions that sarama's default partitioner would route to.
+messages to the same partitions that Sarama's default partitioner would route to.
 
 ```go
 w := kafka.NewWriter(kafka.WriterConfig{
-	Brokers: []string{"localhost:9092"},
-	Topic:   "topic-A",
+	Brokers:  []string{"localhost:9092"},
+	Topic:    "topic-A",
 	Balancer: &kafka.Hash{},
+})
+```
+
+#### librdkafka and confluent-kafka-go
+
+Use the ```kafka.CRC32Balancer``` balancer to get the same behaviour as librdkafka's
+default ```consistent_random``` partition strategy.
+
+```go
+w := kafka.NewWriter(kafka.WriterConfig{
+	Brokers:  []string{"localhost:9092"},
+	Topic:    "topic-A",
+	Balancer: &kafka.CRC32Balancer{},
+})
+```
+
+#### Java
+
+Use the ```kafka.Murmur2Balancer``` balancer to get the same behaviour as the canonical
+Java client's default partitioner.  Note: the Java class allows you to directly specify
+the partition which is not permitted.
+
+```go
+w := kafka.NewWriter(kafka.WriterConfig{
+	Brokers:  []string{"localhost:9092"},
+	Topic:    "topic-A",
+	Balancer: &kafka.Murmur2Balancer{},
 })
 ```
 
 ### Compression
 
-Compression can be enable on the writer :
+Compression can be enable on the writer:
 
 ```go
 w := kafka.NewWriter(kafka.WriterConfig{
-	Brokers: []string{"localhost:9092"},
-	Topic:   "topic-A",
+	Brokers:          []string{"localhost:9092"},
+	Topic:            "topic-A",
 	CompressionCodec: snappy.NewCompressionCodec(),
 })
 ```

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"fmt"
 	"hash"
 	"hash/crc32"
 	"testing"
@@ -48,6 +49,184 @@ func TestHashBalancer(t *testing.T) {
 				Hasher: test.Hasher,
 			}
 			partition := h.Balance(msg, test.Partitions...)
+			if partition != test.Partition {
+				t.Errorf("expected %v; got %v", test.Partition, partition)
+			}
+		})
+	}
+}
+
+func TestCRC32Balancer(t *testing.T) {
+	// These tests are taken from the default "consistent_random" partitioner from
+	// https://github.com/edenhill/librdkafka/blob/master/tests/0048-partitioner.c
+	partitionCount := 17
+	var partitions []int
+	for i := 0; i < partitionCount; i++ {
+		partitions = append(partitions, i*i)
+	}
+
+	testCases := map[string]struct {
+		Key        []byte
+		Partitions []int
+		Partition  int
+	}{
+		"nil": {
+			Key:        nil,
+			Partitions: partitions,
+			Partition:  -1,
+		},
+		"empty": {
+			Key:        []byte{},
+			Partitions: partitions,
+			Partition:  -1,
+		},
+		"unaligned": {
+			Key:        []byte("23456"),
+			Partitions: partitions,
+			Partition:  partitions[0xb1b451d7%partitionCount],
+		},
+		"long key": {
+			Key:        []byte("this is another string with more length to it perhaps"),
+			Partitions: partitions,
+			Partition:  partitions[0xb0150df7%partitionCount],
+		},
+		"short key": {
+			Key:        []byte("hejsan"),
+			Partitions: partitions,
+			Partition:  partitions[0xd077037e%partitionCount],
+		},
+	}
+
+	for label, test := range testCases {
+		t.Run(label, func(t *testing.T) {
+			b := CRC32Balancer{
+				rb: randomBalancer{mock: -1},
+			}
+
+			msg := Message{Key: test.Key}
+			partition := b.Balance(msg, test.Partitions...)
+			if partition != test.Partition {
+				t.Errorf("expected %v; got %v", test.Partition, partition)
+			}
+		})
+	}
+}
+
+func TestMurmur2(t *testing.T) {
+	// These tests are taken from the "murmur2" implementation from
+	// https://github.com/edenhill/librdkafka/blob/master/src/rdmurmur2.c
+	testCases := []struct {
+		Key               []byte
+		JavaMurmur2Result uint32
+	}{
+		{Key: []byte("kafka"), JavaMurmur2Result: 0xd067cf64},
+		{Key: []byte("giberish123456789"), JavaMurmur2Result: 0x8f552b0c},
+		{Key: []byte("1234"), JavaMurmur2Result: 0x9fc97b14},
+		{Key: []byte("234"), JavaMurmur2Result: 0xe7c009ca},
+		{Key: []byte("34"), JavaMurmur2Result: 0x873930da},
+		{Key: []byte("4"), JavaMurmur2Result: 0x5a4b5ca1},
+		{Key: []byte("PreAmbleWillBeRemoved,ThePrePartThatIs"), JavaMurmur2Result: 0x78424f1c},
+		{Key: []byte("reAmbleWillBeRemoved,ThePrePartThatIs"), JavaMurmur2Result: 0x4a62b377},
+		{Key: []byte("eAmbleWillBeRemoved,ThePrePartThatIs"), JavaMurmur2Result: 0xe0e4e09e},
+		{Key: []byte("AmbleWillBeRemoved,ThePrePartThatIs"), JavaMurmur2Result: 0x62b8b43f},
+		{Key: []byte(""), JavaMurmur2Result: 0x106e08d9},
+		{Key: nil, JavaMurmur2Result: 0x106e08d9},
+	}
+
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("key:%s", test.Key), func(t *testing.T) {
+			got := murmur2(test.Key)
+			if got != test.JavaMurmur2Result {
+				t.Errorf("expected %v; got %v", test.JavaMurmur2Result, got)
+			}
+		})
+	}
+}
+
+func TestMurmur2Balancer(t *testing.T) {
+	// These tests are taken from the "murmur2_random" partitioner from
+	// https://github.com/edenhill/librdkafka/blob/master/tests/0048-partitioner.c
+	partitionCount := 17
+	librdkafkaPartitions := make([]int, partitionCount)
+	for i := 0; i < partitionCount; i++ {
+		librdkafkaPartitions[i] = i * i
+	}
+
+	// These tests are taken from the Murmur2Partitioner Python class from
+	// https://github.com/dpkp/kafka-python/blob/master/test/test_partitioner.py
+	pythonPartitions := make([]int, 1000)
+	for i := 0; i < 1000; i++ {
+		pythonPartitions[i] = i
+	}
+
+	testCases := map[string]struct {
+		Key        []byte
+		Partitions []int
+		Partition  int
+	}{
+		"librdkafka-nil": {
+			Key:        nil,
+			Partitions: librdkafkaPartitions,
+			Partition:  0,
+		},
+		"librdkafka-empty": {
+			Key:        []byte{},
+			Partitions: librdkafkaPartitions,
+			Partition:  librdkafkaPartitions[0x106e08d9%partitionCount],
+		},
+		"librdkafka-unaligned": {
+			Key:        []byte("23456"),
+			Partitions: librdkafkaPartitions,
+			Partition:  librdkafkaPartitions[0x058d780f%partitionCount],
+		},
+		"librdkafka-long key": {
+			Key:        []byte("this is another string with more length to it perhaps"),
+			Partitions: librdkafkaPartitions,
+			Partition:  librdkafkaPartitions[0x4f7703da%partitionCount],
+		},
+		"librdkafka-short key": {
+			Key:        []byte("hejsan"),
+			Partitions: librdkafkaPartitions,
+			Partition:  librdkafkaPartitions[0x5ec19395%partitionCount],
+		},
+		"python-empty": {
+			Key:        []byte(""),
+			Partitions: pythonPartitions,
+			Partition:  681,
+		},
+		"python-a": {
+			Key:        []byte("a"),
+			Partitions: pythonPartitions,
+			Partition:  524,
+		},
+		"python-ab": {
+			Key:        []byte("ab"),
+			Partitions: pythonPartitions,
+			Partition:  434,
+		},
+		"python-abc": {
+			Key:        []byte("abc"),
+			Partitions: pythonPartitions,
+			Partition:  107,
+		},
+		"python-123456789": {
+			Key:        []byte("123456789"),
+			Partitions: pythonPartitions,
+			Partition:  566,
+		},
+		"python-\x00 ": {
+			Key:        []byte{0, 32},
+			Partitions: pythonPartitions,
+			Partition:  742,
+		},
+	}
+
+	for label, test := range testCases {
+		t.Run(label, func(t *testing.T) {
+			b := Murmur2Balancer{}
+
+			msg := Message{Key: test.Key}
+			partition := b.Balance(msg, test.Partitions...)
 			if partition != test.Partition {
 				t.Errorf("expected %v; got %v", test.Partition, partition)
 			}


### PR DESCRIPTION
This PR adds the `CRC32Balancer` and `Murmur2Balancer` types that provides the same partitioning behaviour as the librdkafka and Java clients respectively.

The default partitioner strategy for librdkafka is the `consistent_random` strategy which uses CRC32 if the length of the key is not zero, otherwise it randomly selects a partition ([see here](https://github.com/edenhill/librdkafka/blob/95a56e160a3da2018e694dbd74d315163afe90b9/src/rdkafka_msg.c#L706-L725)). This is implemented by the `CRC32Balancer`.

The default partitioner strategy for the Java client is to first use the provided partition of the produced message if it exists. Otherwise, if the key is null then use a round robin strategy, and if the key is provided then use its murmur2 algorithm to calculate the partition. Using a user provided partition value doesn't seem permitted by this library (going by the warning in the readme) so it was not implemented, but the round robin and murmur2 hashing is implemented by the `Murmur2Balancer`.

I have taken unit tests from the librdkafka and [kafka-python](https://github.com/dpkp/kafka-python) libraries to verify that the implementations are consistent.