### PR TITLE
Allow user to configure kafka request timeout

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -72,7 +72,7 @@ type Conn struct {
 	// number of replica acks required when publishing to a partition
 	requiredAcks int32
 
-	kafkaTimeout kafkaTimeoutOption
+	kafkaTimeout KafkaTimeoutOption
 }
 
 // ConnConfig is a configuration object used to create new instances of Conn.
@@ -80,7 +80,7 @@ type ConnConfig struct {
 	ClientID     string
 	Topic        string
 	Partition    int
-	KafkaTimeout kafkaTimeoutOption
+	KafkaTimeout KafkaTimeoutOption
 }
 
 var (
@@ -436,6 +436,11 @@ func (c *Conn) SetDeadline(t time.Time) error {
 // A zero value for t means Read will not time out.
 func (c *Conn) SetReadDeadline(t time.Time) error {
 	c.rdeadline.setDeadline(t)
+	return nil
+}
+
+func (c *Conn) SetKafkaTimeout(kafkaTimeout KafkaTimeoutOption) error {
+	c.kafkaTimeout = kafkaTimeout
 	return nil
 }
 

--- a/createtopics.go
+++ b/createtopics.go
@@ -219,7 +219,7 @@ func (c *Conn) createTopics(request createTopicsRequestV0) (createTopicsResponse
 		func(deadline time.Time, id int32) error {
 			if request.Timeout == 0 {
 				now := time.Now()
-				timeout := adjustDeadlineForRTT(deadline, now, defaultRTT)
+				timeout := c.kafkaTimeout(deadline, now, defaultRTT)
 				request.Timeout = milliseconds(timeout)
 			}
 			return c.writeRequest(createTopicsRequest, v0, id, request)

--- a/createtopics.go
+++ b/createtopics.go
@@ -219,8 +219,8 @@ func (c *Conn) createTopics(request createTopicsRequestV0) (createTopicsResponse
 		func(deadline time.Time, id int32) error {
 			if request.Timeout == 0 {
 				now := time.Now()
-				deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
-				request.Timeout = milliseconds(deadlineToTimeout(deadline, now))
+				timeout := adjustDeadlineForRTT(deadline, now, defaultRTT)
+				request.Timeout = milliseconds(timeout)
 			}
 			return c.writeRequest(createTopicsRequest, v0, id, request)
 		},

--- a/deletetopics.go
+++ b/deletetopics.go
@@ -101,8 +101,8 @@ func (c *Conn) deleteTopics(request deleteTopicsRequestV1) (deleteTopicsResponse
 		func(deadline time.Time, id int32) error {
 			if request.Timeout == 0 {
 				now := time.Now()
-				deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
-				request.Timeout = milliseconds(deadlineToTimeout(deadline, now))
+				timeout := adjustDeadlineForRTT(deadline, now, defaultRTT)
+				request.Timeout = milliseconds(timeout)
 			}
 			return c.writeRequest(deleteTopicsRequest, v1, id, request)
 		},

--- a/deletetopics.go
+++ b/deletetopics.go
@@ -101,7 +101,7 @@ func (c *Conn) deleteTopics(request deleteTopicsRequestV1) (deleteTopicsResponse
 		func(deadline time.Time, id int32) error {
 			if request.Timeout == 0 {
 				now := time.Now()
-				timeout := adjustDeadlineForRTT(deadline, now, defaultRTT)
+				timeout := c.kafkaTimeout(deadline, now, defaultRTT)
 				request.Timeout = milliseconds(timeout)
 			}
 			return c.writeRequest(deleteTopicsRequest, v1, id, request)

--- a/time.go
+++ b/time.go
@@ -43,6 +43,14 @@ func deadlineToTimeout(deadline time.Time, now time.Time) time.Duration {
 	return deadline.Sub(now)
 }
 
+type kafkaTimeoutOption func(time.Time, time.Time, time.Duration) time.Duration
+
+func SpecificKafkaTimeout(timeout time.Duration) kafkaTimeoutOption {
+	return func(deadline time.Time, now time.Time, rtt time.Duration) time.Duration {
+		return timeout
+	}
+}
+
 func adjustDeadlineForRTT(deadline time.Time, now time.Time, rtt time.Duration) time.Duration {
 	if !deadline.IsZero() {
 		timeout := deadline.Sub(now)

--- a/time.go
+++ b/time.go
@@ -43,7 +43,7 @@ func deadlineToTimeout(deadline time.Time, now time.Time) time.Duration {
 	return deadline.Sub(now)
 }
 
-func adjustDeadlineForRTT(deadline time.Time, now time.Time, rtt time.Duration) time.Time {
+func adjustDeadlineForRTT(deadline time.Time, now time.Time, rtt time.Duration) time.Duration {
 	if !deadline.IsZero() {
 		timeout := deadline.Sub(now)
 		if timeout < rtt {
@@ -51,5 +51,5 @@ func adjustDeadlineForRTT(deadline time.Time, now time.Time, rtt time.Duration) 
 		}
 		deadline = deadline.Add(-rtt)
 	}
-	return deadline
+	return deadlineToTimeout(deadline, now)
 }

--- a/time.go
+++ b/time.go
@@ -43,12 +43,16 @@ func deadlineToTimeout(deadline time.Time, now time.Time) time.Duration {
 	return deadline.Sub(now)
 }
 
-type kafkaTimeoutOption func(time.Time, time.Time, time.Duration) time.Duration
+type KafkaTimeoutOption func(time.Time, time.Time, time.Duration) time.Duration
 
-func SpecificKafkaTimeout(timeout time.Duration) kafkaTimeoutOption {
+func SpecificKafkaTimeout(timeout time.Duration) KafkaTimeoutOption {
 	return func(deadline time.Time, now time.Time, rtt time.Duration) time.Duration {
 		return timeout
 	}
+}
+
+func DefaultKafkaTimeout() KafkaTimeoutOption {
+	return adjustDeadlineForRTT
 }
 
 func adjustDeadlineForRTT(deadline time.Time, now time.Time, rtt time.Duration) time.Duration {


### PR DESCRIPTION
Sometime I would like to control kafka request timeout independently of connection timeout.
This refactoring extract kafka timeout calculation into an option and provides another option for exact timeout value of kafka operations.