### PR TITLE
fix kafka.reader.fetch.count metric

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -260,6 +260,9 @@ func testReaderStats(t *testing.T, ctx context.Context, r *Reader) {
 		ClientID:      "",
 		Topic:         stats.Topic,
 		Partition:     "0",
+
+		// TODO: remove when we get rid of the deprecated field.
+		DeprecatedFetchesWithTypo: 1,
 	}
 
 	if stats != expect {


### PR DESCRIPTION
This PR attempts to provide a smooth transition towards fixing the typo in the `kafka.reader.fetch.count` metric.

The idea is to produce both `kafka.reader.fetch.count` and `kafak.reader.fetch.count` for a couple of versions, and eventually remove the deprecated field (the one with the typo).

Please take a look and let me know if you have any concerns about it.