### PR TITLE
fix max commit retention time

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1042,7 +1042,7 @@ func NewReader(config ReaderConfig) *Reader {
 			panic(fmt.Sprintf("RebalanceTimeout out of bounds: %d", config.RebalanceTimeout))
 		}
 
-		if config.RetentionTime < 0 || (config.RetentionTime/time.Millisecond) >= math.MaxInt32 {
+		if config.RetentionTime < 0 {
 			panic(fmt.Sprintf("RetentionTime out of bounds: %d", config.RetentionTime))
 		}
 


### PR DESCRIPTION
Fixes https://github.com/segmentio/kafka-go/issues/99

The value is a `int64` in the `OffsetCommit` v2/v3 types that we use, we shouldn't check against the max value of a int32.