### PR TITLE
Small fix to Dialer to set the ServerName in tls.Config if it is empty.

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -297,7 +297,7 @@ func TestDialerConnectTLSHonorsContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*25)
 	defer cancel()
 
-	_, err := d.connectTLS(ctx, conn)
+	_, err := d.connectTLS(ctx, conn, d.TLS)
 	if context.DeadlineExceeded != err {
 		t.Errorf("expected err to be %v; got %v", context.DeadlineExceeded, err)
 		t.FailNow()


### PR DESCRIPTION
Without this tweak, I was seeing the TLS client handshake error below.

```
tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config
```

I added same approach to inferring the ServerName from the address that is in `DialWithDialer` of `tls.go`.