### PR TITLE
Retrieve the current controller from any broker

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -138,6 +138,30 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 	return c
 }
 
+// GetController requests kafka for the current controller and returns its URL
+func (c *Conn) GetController() (controller string, err error) {
+	err = c.readOperation(
+		func(deadline time.Time, id int32) error {
+			return c.writeRequest(metadataRequest, v1, id, topicMetadataRequestV1([]string{}))
+		},
+		func(deadline time.Time, size int) error {
+			var res metadataResponseV1
+
+			if err := c.readResponse(size, &res); err != nil {
+				return err
+			}
+			for _, broker := range res.Brokers {
+				if broker.NodeID == res.ControllerID {
+					controller = fmt.Sprintf("%s:%d", broker.Host, broker.Port)
+					break
+				}
+			}
+			return nil
+		},
+	)
+	return controller, err
+}
+
 // DeleteTopics deletes the specified topics.
 func (c *Conn) DeleteTopics(topics ...string) error {
 	_, err := c.deleteTopics(deleteTopicsRequestV1{


### PR DESCRIPTION
Hi,

at first, thank you very much for your great library. It's inspiring and I would like to contribute. I have little experience with Kafka though.

I have the requirement to create a topic in Kafka explicitly. So I've found the `*Conn.CreateTopics(...TopicConf) error```. I've started using this function and it worked like a charm until I've added some more broker to my Cluster. After startup, it wasn't deterministic which broker would have gotten elected to be the controller and NotController errors started to occur. 

After some research I've found the MetaData Request, which has the information I needed. So I've implemented a method to retrieve the ControllerURL from the current connection. I'm not sure how the API should look like or the implementation. This is just a first version without a unit test, because I'm not very experienced in Kafka and I've developed it with an integration test locally. 

So this ends up in me having theses questions:

- Is this the way to go, if I want to implement the topic creation explicitly with segmentio/kafka-go?
- Are you interested in having a function implemented, which returns the controller URL?
- How should the API should look like?
- Should I change the implementation?

After theses questions are answered I would be more than happy to implement it (with one or more tests).

Thanks in advance,
Fredi