### PR TITLE
Add ApiVersions request

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -22,10 +22,11 @@ func TestBatchDontExpectEOF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot connect to partition leader at %s:%d: %s", broker.Host, broker.Port, err)
 	}
-	nc.(*net.TCPConn).CloseRead()
 
 	conn := NewConn(nc, topic, 0)
 	defer conn.Close()
+
+	nc.(*net.TCPConn).CloseRead()
 
 	batch := conn.ReadBatch(1024, 8192)
 

--- a/conn.go
+++ b/conn.go
@@ -71,6 +71,7 @@ type Conn struct {
 
 	// number of replica acks required when publishing to a partition
 	requiredAcks int32
+	apiVersions  []ApiVersion
 }
 
 // ConnConfig is a configuration object used to create new instances of Conn.
@@ -135,6 +136,11 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 		}},
 	}).size()
 	c.fetchMaxBytes = math.MaxInt32 - c.fetchMinSize
+	var err error
+	c.apiVersions, err = c.ApiVersions()
+	if err != nil {
+		c.apiVersions = nil
+	}
 	return c
 }
 
@@ -183,6 +189,7 @@ func (c *Conn) findCoordinator(request findCoordinatorRequestV0) (findCoordinato
 	err := c.readOperation(
 		func(deadline time.Time, id int32) error {
 			return c.writeRequest(groupCoordinatorRequest, v0, id, request)
+
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {

--- a/conn.go
+++ b/conn.go
@@ -139,7 +139,7 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 	var err error
 	apiVersions, err := c.ApiVersions()
 	if err != nil {
-		c.apiVersions = nil // TODO use currently supported versions
+		c.apiVersions = defaultApiVersions
 	} else {
 		c.apiVersions = make(map[apiKey]ApiVersion)
 		for _, v := range apiVersions {
@@ -1028,6 +1028,25 @@ type ApiVersion struct {
 	ApiKey     int16
 	MinVersion int16
 	MaxVersion int16
+}
+
+var defaultApiVersions map[apiKey]ApiVersion = map[apiKey]ApiVersion{
+	produceRequest:          ApiVersion{int16(produceRequest), int16(v2), int16(v2)},
+	fetchRequest:            ApiVersion{int16(fetchRequest), int16(v2), int16(v2)},
+	listOffsetRequest:       ApiVersion{int16(listOffsetRequest), int16(v1), int16(v1)},
+	metadataRequest:         ApiVersion{int16(metadataRequest), int16(v1), int16(v1)},
+	offsetCommitRequest:     ApiVersion{int16(offsetCommitRequest), int16(v2), int16(v2)},
+	offsetFetchRequest:      ApiVersion{int16(offsetFetchRequest), int16(v1), int16(v1)},
+	groupCoordinatorRequest: ApiVersion{int16(groupCoordinatorRequest), int16(v0), int16(v0)},
+	joinGroupRequest:        ApiVersion{int16(joinGroupRequest), int16(v1), int16(v1)},
+	heartbeatRequest:        ApiVersion{int16(heartbeatRequest), int16(v0), int16(v0)},
+	leaveGroupRequest:       ApiVersion{int16(leaveGroupRequest), int16(v0), int16(v0)},
+	syncGroupRequest:        ApiVersion{int16(syncGroupRequest), int16(v0), int16(v0)},
+	describeGroupsRequest:   ApiVersion{int16(describeGroupsRequest), int16(v1), int16(v1)},
+	listGroupsRequest:       ApiVersion{int16(listGroupsRequest), int16(v1), int16(v1)},
+	apiVersionsRequest:      ApiVersion{int16(apiVersionsRequest), int16(v0), int16(v0)},
+	createTopicsRequest:     ApiVersion{int16(createTopicsRequest), int16(v0), int16(v0)},
+	deleteTopicsRequest:     ApiVersion{int16(deleteTopicsRequest), int16(v1), int16(v1)},
 }
 
 func (c *Conn) ApiVersions() ([]ApiVersion, error) {

--- a/conn.go
+++ b/conn.go
@@ -71,7 +71,7 @@ type Conn struct {
 
 	// number of replica acks required when publishing to a partition
 	requiredAcks int32
-	apiVersions  []ApiVersion
+	apiVersions  map[apiKey]ApiVersion
 }
 
 // ConnConfig is a configuration object used to create new instances of Conn.
@@ -137,9 +137,14 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 	}).size()
 	c.fetchMaxBytes = math.MaxInt32 - c.fetchMinSize
 	var err error
-	c.apiVersions, err = c.ApiVersions()
+	apiVersions, err := c.ApiVersions()
 	if err != nil {
-		c.apiVersions = nil
+		c.apiVersions = nil // TODO use currently supported versions
+	} else {
+		c.apiVersions = make(map[apiKey]ApiVersion)
+		for _, v := range apiVersions {
+			c.apiVersions[apiKey(v.ApiKey)] = v
+		}
 	}
 	return c
 }

--- a/protocol.go
+++ b/protocol.go
@@ -22,6 +22,7 @@ const (
 	syncGroupRequest        apiKey = 14
 	describeGroupsRequest   apiKey = 15
 	listGroupsRequest       apiKey = 16
+	apiVersionsRequest      apiKey = 18
 	createTopicsRequest     apiKey = 19
 	deleteTopicsRequest     apiKey = 20
 )


### PR DESCRIPTION
I would like to merge this as a separate PR for easier review. I will need this change is implementing v2 message reader: https://github.com/segmentio/kafka-go/pull/146
I'll be using this request right after connecting to kafka cluster in order to determine which fetch requests I'm allowed to send. 
So far the plan is to implement fetch request v5. Fetch request v5 seems to have been introduced in kafka 0.11.0.0. And presumably this is the first version where server returns message sets in v2 format.
So, if fetch request v5 is available I'll be sending v5 otherwise v2.