### PR TITLE
Use the unMasked attributes for codec resolution

### DIFF
--- a/message.go
+++ b/message.go
@@ -143,7 +143,7 @@ func (r *messageSetReader) readMessage(min int64,
 		code := attributes & compressionCodecMask
 		if code != 0 {
 			var codec CompressionCodec
-			if codec, err = resolveCodec(attributes); err != nil {
+			if codec, err = resolveCodec(code); err != nil {
 				return
 			}
 


### PR DESCRIPTION
This is working for codecs registered as  0 and 1 as 0 and 1 in binary are 0 and 01. But for Snappy (2) this turns into a 10 and never finds the correct decoder codec.