### PR TITLE
Handling `0` as possible required ack value and `InvalidRequiredAcks` errors

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -636,7 +636,8 @@ func (w *writer) dial() (conn *Conn, err error) {
 			t1 := time.Now()
 			w.stats.dials.observe(1)
 			w.stats.dialTime.observeDuration(t1.Sub(t0))
-			conn.SetRequiredAcks(w.requiredAcks)
+			// set the error for a potential invalid requiredAcks value
+			err = conn.SetRequiredAcks(w.requiredAcks)
 			break
 		}
 	}


### PR DESCRIPTION
This PR fixes #174 and #175.

It first adds handling the `0` value as a possible valid required ack and the handling of a potential `InvalidRequiredAcks` when required ack is set to a value different from allowed -1, 0, 1.

Because required ack = 0 means that the producer doesn't have to expect any response from the broker because it means "no ack", the `waitResponse` doesn't need to be called otherwise it drives to a timeout error having the producer waiting for a response which will never come.