### PR TITLE
Test against multiple Kafka versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  kafka-011:
     working_directory: /go/src/github.com/segmentio/kafka-go
     docker:
       - image: circleci/golang
@@ -9,7 +9,6 @@ jobs:
       - image: wurstmeister/kafka:0.11.0.1
         ports: ['9092:9092']
         environment:
-          KAFKA_VERSION: '0.11.0.1'
           KAFKA_BROKER_ID: '1'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
@@ -23,3 +22,54 @@ jobs:
       - run: go get -v -t ./...
       - run: go vet ./...
       - run: go test -v -race ./...
+  kafka-111:
+    working_directory: /go/src/github.com/segmentio/kafka-go
+    docker:
+      - image: circleci/golang
+      - image: wurstmeister/zookeeper
+        ports: ['2181:2181']
+      - image: wurstmeister/kafka:2.11-1.1.1
+        ports: ['9092:9092']
+        environment:
+          KAFKA_BROKER_ID: '1'
+          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+          KAFKA_DELETE_TOPIC_ENABLE: 'true'
+          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+          KAFKA_ADVERTISED_PORT: '9092'
+          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    steps:
+      - checkout
+      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
+      - run: go get -v -t ./...
+      - run: go vet ./...
+      - run: go test -v -race ./...
+  kafka-210:
+    working_directory: /go/src/github.com/segmentio/kafka-go
+    docker:
+      - image: circleci/golang
+      - image: wurstmeister/zookeeper
+        ports: ['2181:2181']
+      - image: wurstmeister/kafka:2.12-2.1.0
+        ports: ['9092:9092']
+        environment:
+          KAFKA_BROKER_ID: '1'
+          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+          KAFKA_DELETE_TOPIC_ENABLE: 'true'
+          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+          KAFKA_ADVERTISED_PORT: '9092'
+          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    steps:
+      - checkout
+      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
+      - run: go get -v -t ./...
+      - run: go vet ./...
+      - run: go test -v -race ./...
+workflows:
+  version: 2
+  run:
+    jobs:
+      - kafka-011
+      - kafka-111
+      - kafka-210


### PR DESCRIPTION
`kafka-go` is getting more and more contributors using multiple versions of Kafka. To ensure proper compatibility with the supported versions, we need to test against all of them.

This PR creates a CI job for Kafka 0.11.0.1, 1.1.1 and 2.1.0.