### PR TITLE
Run tests for kafka 0.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,33 @@
 version: 2
 jobs:
+  kafka-010:
+    working_directory: /go/src/github.com/segmentio/kafka-go
+    environment:
+      KAFKA_VERSION: "0.10.1"
+    docker:
+      - image: circleci/golang
+      - image: wurstmeister/zookeeper
+        ports: ['2181:2181']
+      - image: wurstmeister/kafka:0.10.1.0
+        ports: ['9092:9092']
+        environment:
+          KAFKA_BROKER_ID: '1'
+          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+          KAFKA_DELETE_TOPIC_ENABLE: 'true'
+          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+          KAFKA_ADVERTISED_PORT: '9092'
+          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    steps:
+      - checkout
+      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
+      - run: go get -v -t ./...
+      - run: go vet ./...
+      - run: go test -v -race ./...
   kafka-011:
     working_directory: /go/src/github.com/segmentio/kafka-go
+    environment:
+      KAFKA_VERSION: "0.11.0"
     docker:
       - image: circleci/golang
       - image: wurstmeister/zookeeper
@@ -24,6 +50,8 @@ jobs:
       - run: go test -v -race ./...
   kafka-111:
     working_directory: /go/src/github.com/segmentio/kafka-go
+    environment:
+      KAFKA_VERSION: "1.1.1"
     docker:
       - image: circleci/golang
       - image: wurstmeister/zookeeper
@@ -46,6 +74,8 @@ jobs:
       - run: go test -v -race ./...
   kafka-210:
     working_directory: /go/src/github.com/segmentio/kafka-go
+    environment:
+      KAFKA_VERSION: "2.1.0"
     docker:
       - image: circleci/golang
       - image: wurstmeister/zookeeper
@@ -70,6 +100,7 @@ workflows:
   version: 2
   run:
     jobs:
+      - kafka-010
       - kafka-011
       - kafka-111
       - kafka-210

--- a/conn_test.go
+++ b/conn_test.go
@@ -106,8 +106,9 @@ func TestConn(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		scenario string
-		function func(*testing.T, *Conn)
+		scenario   string
+		function   func(*testing.T, *Conn)
+		minVersion string
 	}{
 		{
 			scenario: "close right away",
@@ -180,8 +181,9 @@ func TestConn(t *testing.T) {
 		},
 
 		{
-			scenario: "describe groups retrieves all groups when no groupID specified",
-			function: testConnDescribeGroupRetrievesAllGroups,
+			scenario:   "describe groups retrieves all groups when no groupID specified",
+			function:   testConnDescribeGroupRetrievesAllGroups,
+			minVersion: "0.11.0",
 		},
 
 		{
@@ -220,8 +222,9 @@ func TestConn(t *testing.T) {
 		},
 
 		{
-			scenario: "test list groups",
-			function: testConnListGroupsReturnsGroups,
+			scenario:   "test list groups",
+			function:   testConnListGroupsReturnsGroups,
+			minVersion: "0.11.0",
 		},
 
 		{
@@ -230,13 +233,15 @@ func TestConn(t *testing.T) {
 		},
 
 		{
-			scenario: "test delete topics",
-			function: testDeleteTopics,
+			scenario:   "test delete topics",
+			function:   testDeleteTopics,
+			minVersion: "0.11.0",
 		},
 
 		{
-			scenario: "test delete topics with an invalid topic",
-			function: testDeleteTopicsInvalidTopic,
+			scenario:   "test delete topics with an invalid topic",
+			function:   testDeleteTopicsInvalidTopic,
+			minVersion: "0.11.0",
 		},
 	}
 
@@ -246,6 +251,11 @@ func TestConn(t *testing.T) {
 	)
 
 	for _, test := range tests {
+		if !KafkaIsAtLeast(test.minVersion) {
+			t.Log("skipping " + test.scenario + " because broker is not at least version " + test.minVersion)
+			continue
+		}
+
 		testFunc := test.function
 		t.Run(test.scenario, func(t *testing.T) {
 			t.Parallel()

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,53 @@
+package kafka
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+type semver []int
+
+func (v semver) atLeast(other semver) bool {
+	for i := range v {
+		if i >= len(other) {
+			break
+		}
+		if v[i] < other[i] {
+			return false
+		}
+		if v[i] > other[i] {
+			return true
+		}
+	}
+	return true
+}
+
+// kafkaVersion is set in the circle config.  It can also be provided on the
+// command line in order to target a particular kafka version.
+var kafkaVersion = parseVersion(os.Getenv("KAFKA_VERSION"))
+
+// KafkaIsAtLeast returns true when the test broker is running a protocol
+// version that is semver or newer.  It determines the broker's version using
+// the `KAFKA_VERSION` environment variable.  If the var is unset, then this
+// function will return true.
+func KafkaIsAtLeast(semver string) bool {
+	return kafkaVersion.atLeast(parseVersion(semver))
+}
+
+func parseVersion(semver string) semver {
+	if semver == "" {
+		return nil
+	}
+	parts := strings.Split(semver, ".")
+	version := make([]int, len(parts))
+	for i := range version {
+		v, err := strconv.Atoi(parts[i])
+		if err != nil {
+			// panic-ing because tests should be using hard-coded version values
+			panic("invalid version string: " + semver)
+		}
+		version[i] = v
+	}
+	return version
+}


### PR DESCRIPTION
Added a utility method to check broker version so that tests for
newer functionality can be skipped.