### PR TITLE
Increase timeout in a Conn test to avoid spurious test failure

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -867,7 +867,7 @@ func testConnReadEmptyWithDeadline(t *testing.T, conn *Conn) {
 	b := make([]byte, 100)
 
 	start := time.Now()
-	deadline := start.Add(100 * time.Millisecond)
+	deadline := start.Add(250 * time.Millisecond)
 
 	conn.SetReadDeadline(deadline)
 	n, err := conn.Read(b)


### PR DESCRIPTION
I think the reason the test was failing is that the max fetch time sent to Kafka could in certain cases be calculated as less than the connection's read timeout.  In that case, Kafka was returning with 0 bytes and no error (as it should).  Bumping up the timeout appears to fix the issue--I have run tests multiple times in CI w/out failures.  Though of course that's like trying to prove a negative. 😉 