### PR TITLE
Pool gzip and lz4 readers and writers

### DIFF
--- a/compression_test.go
+++ b/compression_test.go
@@ -82,6 +82,7 @@ func testCompressedMessages(t *testing.T, codec kafka.CompressionCodec) {
 			Brokers:          []string{"127.0.0.1:9092"},
 			Topic:            topic,
 			CompressionCodec: codec,
+			BatchTimeout:     10 * time.Millisecond,
 		})
 		defer w.Close()
 

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -94,13 +94,11 @@ func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
 // Decode implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
 	reader := readerPool.Get().(*gzip.Reader)
-	res, err := func() ([]byte, error) {
-		err := reader.Reset(bytes.NewReader(src))
-		if err != nil {
-			return nil, err
-		}
-		return ioutil.ReadAll(reader)
-	}()
+	err := reader.Reset(bytes.NewReader(src))
+	if err != nil {
+		return nil, err
+	}
+	res, err := ioutil.ReadAll(reader)
 	// only return the reader to pool if the read was a success.
 	if err == nil {
 		readerPool.Put(reader)

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -4,11 +4,39 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io/ioutil"
+	"sync"
 
 	"github.com/segmentio/kafka-go"
 )
 
+var (
+	readerPool sync.Pool
+	writerPool sync.Pool
+
+	// emptyGzipBytes is the binary value for an empty file that has been
+	// gzipped.  It is used to initialize gzip.Reader before adding it to the
+	// readerPool.
+	emptyGzipBytes = []byte{
+		0x1f, 0x8b, 0x08, 0x08, 0x0d, 0x0c, 0x67, 0x5c, 0x00, 0x03, 0x66, 0x6f,
+		0x6f, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+)
+
 func init() {
+	readerPool = sync.Pool{
+		New: func() interface{} {
+			// if the reader doesn't get valid gzip at initialization time,
+			// it will not be valid and will fail on Reset.
+			reader, _ := gzip.NewReader(bytes.NewBuffer(emptyGzipBytes))
+			return reader
+		},
+	}
+	writerPool = sync.Pool{
+		New: func() interface{} {
+			return gzip.NewWriter(bytes.NewBuffer(nil))
+		},
+	}
+
 	kafka.RegisterCompressionCodec(func() kafka.CompressionCodec {
 		return NewCompressionCodec()
 	})
@@ -40,25 +68,42 @@ func (c CompressionCodec) Code() int8 {
 func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
 	buf := bytes.Buffer{}
 	buf.Grow(len(src)) // guess a size to avoid repeat allocations.
-	writer := gzip.NewWriter(&buf)
+	writer := writerPool.Get().(*gzip.Writer)
+	writer.Reset(&buf)
 
 	_, err := writer.Write(src)
 	if err != nil {
+		// don't return writer to pool on error.
 		return nil, err
 	}
 
+	// note that the gzip reader must be closed in order for it to write
+	// out trailing contents.  Flush is insufficient.  it is okay to re-use
+	// the writer even after it's closed by Resetting it.
 	err = writer.Close()
 	if err != nil {
+		// don't return writer to pool on error.
 		return nil, err
 	}
+
+	writerPool.Put(writer)
+
 	return buf.Bytes(), err
 }
 
 // Decode implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
-	reader, err := gzip.NewReader(bytes.NewReader(src))
-	if err != nil {
-		return nil, err
+	reader := readerPool.Get().(*gzip.Reader)
+	res, err := func() ([]byte, error) {
+		err := reader.Reset(bytes.NewReader(src))
+		if err != nil {
+			return nil, err
+		}
+		return ioutil.ReadAll(reader)
+	}()
+	// only return the reader to pool if the read was a success.
+	if err == nil {
+		readerPool.Put(reader)
 	}
-	return ioutil.ReadAll(reader)
+	return res, err
 }

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -3,12 +3,29 @@ package lz4
 import (
 	"bytes"
 	"io/ioutil"
+	"sync"
 
 	"github.com/pierrec/lz4"
 	"github.com/segmentio/kafka-go"
 )
 
+var (
+	readerPool sync.Pool
+	writerPool sync.Pool
+)
+
 func init() {
+	readerPool = sync.Pool{
+		New: func() interface{} {
+			return lz4.NewReader(nil)
+		},
+	}
+	writerPool = sync.Pool{
+		New: func() interface{} {
+			return lz4.NewWriter(nil)
+		},
+	}
+
 	kafka.RegisterCompressionCodec(func() kafka.CompressionCodec {
 		return NewCompressionCodec()
 	})
@@ -31,23 +48,34 @@ func (c CompressionCodec) Code() int8 {
 func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
 	buf := bytes.Buffer{}
 	buf.Grow(len(src)) // guess a size to avoid repeat allocations.
-	writer := lz4.NewWriter(&buf)
+	writer := writerPool.Get().(*lz4.Writer)
+	writer.Reset(&buf)
 
 	_, err := writer.Write(src)
 	if err != nil {
+		// don't return writer to pool on error.
 		return nil, err
 	}
 
-	err = writer.Close()
+	err = writer.Flush()
 	if err != nil {
+		// don't return writer to pool on error.
 		return nil, err
 	}
+
+	writerPool.Put(writer)
 
 	return buf.Bytes(), err
 }
 
 // Decode implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
-	reader := lz4.NewReader(bytes.NewReader(src))
-	return ioutil.ReadAll(reader)
+	reader := readerPool.Get().(*lz4.Reader)
+	reader.Reset(bytes.NewReader(src))
+	res, err := ioutil.ReadAll(reader)
+	// only return the reader to pool if the read was a success.
+	if err == nil {
+		readerPool.Put(reader)
+	}
+	return res, err
 }

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -57,7 +57,7 @@ func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	err = writer.Flush()
+	err = writer.Close()
 	if err != nil {
 		// don't return writer to pool on error.
 		return nil, err


### PR DESCRIPTION
Benchmarks indicate that gzip gets ~20-100% throughput increase
while lz4 goes up ~600-1000%.