### PR TITLE
Retrieve controller

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -139,7 +139,7 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 }
 
 // GetController requests kafka for the current controller and returns its URL
-func (c *Conn) GetController() (controller string, err error) {
+func (c *Conn) Controller() (broker Broker, err error) {
 	err = c.readOperation(
 		func(deadline time.Time, id int32) error {
 			return c.writeRequest(metadataRequest, v1, id, topicMetadataRequestV1([]string{}))
@@ -150,16 +150,19 @@ func (c *Conn) GetController() (controller string, err error) {
 			if err := c.readResponse(size, &res); err != nil {
 				return err
 			}
-			for _, broker := range res.Brokers {
-				if broker.NodeID == res.ControllerID {
-					controller = fmt.Sprintf("%s:%d", broker.Host, broker.Port)
+			for _, brokerMeta := range res.Brokers {
+				if brokerMeta.NodeID == res.ControllerID {
+					broker = Broker{ID: int(brokerMeta.NodeID),
+						Port: int(brokerMeta.Port),
+						Host: brokerMeta.Host,
+						Rack: brokerMeta.Rack}
 					break
 				}
 			}
 			return nil
 		},
 	)
-	return controller, err
+	return broker, err
 }
 
 // DeleteTopics deletes the specified topics.

--- a/conn.go
+++ b/conn.go
@@ -138,6 +138,30 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 	return c
 }
 
+// GetController requests kafka for the current controller and returns its URL
+func (c *Conn) GetController() (controller string, err error) {
+	err = c.readOperation(
+		func(deadline time.Time, id int32) error {
+			return c.writeRequest(metadataRequest, v1, id, topicMetadataRequestV1([]string{}))
+		},
+		func(deadline time.Time, size int) error {
+			var res metadataResponseV1
+
+			if err := c.readResponse(size, &res); err != nil {
+				return err
+			}
+			for _, broker := range res.Brokers {
+				if broker.NodeID == res.ControllerID {
+					controller = fmt.Sprintf("%s:%d", broker.Host, broker.Port)
+					break
+				}
+			}
+			return nil
+		},
+	)
+	return controller, err
+}
+
 // DeleteTopics deletes the specified topics.
 func (c *Conn) DeleteTopics(topics ...string) error {
 	_, err := c.deleteTopics(deleteTopicsRequestV1{

--- a/conn_test.go
+++ b/conn_test.go
@@ -238,6 +238,10 @@ func TestConn(t *testing.T) {
 			scenario: "test delete topics with an invalid topic",
 			function: testDeleteTopicsInvalidTopic,
 		},
+		{
+			scenario: "test retrieve controller",
+			function: testController,
+		},
 	}
 
 	const (
@@ -926,6 +930,26 @@ func testDeleteTopicsInvalidTopic(t *testing.T, conn *Conn) {
 	}
 	if len(partitions) != 0 {
 		t.Fatal("exepected partitions to be empty")
+	}
+}
+
+func testController(t *testing.T, conn *Conn) {
+	b, err := conn.Controller()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if b.Host != "localhost" {
+		t.Errorf("expected localhost received %s", b.Host)
+	}
+	if b.Port != 9092 {
+		t.Errorf("expected 9092 received %d", b.Port)
+	}
+	if b.ID != 1 {
+		t.Errorf("expected 0 received %d", b.ID)
+	}
+	if b.Rack != "" {
+		t.Errorf("expected empty string for rack received %s", b.Rack)
 	}
 }
 


### PR DESCRIPTION
This PR is in reference to the feedback on the inactive PR https://github.com/segmentio/kafka-go/pull/153. Here we're changing the name of the func to `Controller` and returning a `Broker` as requested.