### PR TITLE
Isolation level

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -675,10 +675,10 @@ func (c *Conn) ReadBatch(minBytes, maxBytes int) *Batch {
 		MinBytes: minBytes,
 		MaxBytes: maxBytes,
 	}
-	return c.ReadBatchWithConfig(cfg)
+	return c.ReadBatchWith(cfg)
 }
 
-func (c *Conn) ReadBatchWithConfig(cfg BatchReadConfig) *Batch {
+func (c *Conn) ReadBatchWith(cfg BatchReadConfig) *Batch {
 
 	var adjustedDeadline time.Time
 	var maxFetch = int(c.fetchMaxBytes)

--- a/conn.go
+++ b/conn.go
@@ -671,11 +671,10 @@ func (c *Conn) ReadMessage(maxBytes int) (Message, error) {
 // gives the minimum and maximum number of bytes that it wants to receive from
 // the kafka server.
 func (c *Conn) ReadBatch(minBytes, maxBytes int) *Batch {
-	cfg := ReadBatchConfig{
+	return c.ReadBatchWith(ReadBatchConfig{
 		MinBytes: minBytes,
 		MaxBytes: maxBytes,
-	}
-	return c.ReadBatchWith(cfg)
+	})
 }
 
 func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {

--- a/conn.go
+++ b/conn.go
@@ -82,9 +82,14 @@ type ConnConfig struct {
 	Partition int
 }
 
+// ReadBatchConfig is a configuration object used for reading batches of messages.
 type ReadBatchConfig struct {
-	MinBytes       int
-	MaxBytes       int
+	MinBytes int
+	MaxBytes int
+
+	// IsolationLevel controls the visibility of transactional records.
+	// ReadUncommitted makes all records visible. With ReadCommitted only
+	// non-transactional and committed records are visible.
 	IsolationLevel IsolationLevel
 }
 
@@ -677,6 +682,8 @@ func (c *Conn) ReadBatch(minBytes, maxBytes int) *Batch {
 	})
 }
 
+// ReadBatchWith in every way is similar to ReadBatch. ReadBatch is configured
+// with the default values in ReadBatchConfig except for minBytes and maxBytes.
 func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var adjustedDeadline time.Time

--- a/conn.go
+++ b/conn.go
@@ -82,7 +82,7 @@ type ConnConfig struct {
 	Partition int
 }
 
-type BatchReadConfig struct {
+type ReadBatchConfig struct {
 	MinBytes       int
 	MaxBytes       int
 	IsolationLevel IsolationLevel
@@ -671,14 +671,14 @@ func (c *Conn) ReadMessage(maxBytes int) (Message, error) {
 // gives the minimum and maximum number of bytes that it wants to receive from
 // the kafka server.
 func (c *Conn) ReadBatch(minBytes, maxBytes int) *Batch {
-	cfg := BatchReadConfig{
+	cfg := ReadBatchConfig{
 		MinBytes: minBytes,
 		MaxBytes: maxBytes,
 	}
 	return c.ReadBatchWith(cfg)
 }
 
-func (c *Conn) ReadBatchWith(cfg BatchReadConfig) *Batch {
+func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var adjustedDeadline time.Time
 	var maxFetch = int(c.fetchMaxBytes)

--- a/conn.go
+++ b/conn.go
@@ -91,8 +91,8 @@ type BatchReadConfig struct {
 type IsolationLevel int8
 
 const (
-	READ_UNCOMMITTED IsolationLevel = 0
-	READ_COMMITTED   IsolationLevel = 1
+	ReadUncommitted IsolationLevel = 0
+	ReadCommitted   IsolationLevel = 1
 )
 
 var (

--- a/conn.go
+++ b/conn.go
@@ -83,9 +83,17 @@ type ConnConfig struct {
 }
 
 type BatchReadConfig struct {
-	MinBytes int
-	MaxBytes int
+	MinBytes       int
+	MaxBytes       int
+	IsolationLevel IsolationLevel
 }
+
+type IsolationLevel int8
+
+const (
+	READ_UNCOMMITTED IsolationLevel = 0
+	READ_COMMITTED   IsolationLevel = 1
+)
 
 var (
 	// DefaultClientID is the default value used as ClientID of kafka
@@ -706,6 +714,7 @@ func (c *Conn) ReadBatchWithConfig(cfg BatchReadConfig) *Batch {
 				cfg.MinBytes,
 				cfg.MaxBytes+int(c.fetchMinSize),
 				deadlineToTimeout(deadline, now),
+				int8(cfg.IsolationLevel),
 			)
 		default:
 			return writeFetchRequestV2(

--- a/write.go
+++ b/write.go
@@ -170,7 +170,7 @@ func writeFetchRequestV2(w *bufio.Writer, correlationID int32, clientID, topic s
 	return w.Flush()
 }
 
-func writeFetchRequestV5(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration) error {
+func writeFetchRequestV5(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
 	h := requestHeader{
 		ApiKey:        int16(fetchRequest),
 		ApiVersion:    int16(v5),
@@ -196,7 +196,7 @@ func writeFetchRequestV5(w *bufio.Writer, correlationID int32, clientID, topic s
 	writeInt32(w, milliseconds(maxWait))
 	writeInt32(w, int32(minBytes))
 	writeInt32(w, int32(maxBytes))
-	writeInt8(w, int8(0)) // isolation level 0 - read uncommitted
+	writeInt8(w, isolationLevel) // isolation level 0 - read uncommitted
 
 	// topic array
 	writeArrayLen(w, 1)


### PR DESCRIPTION
This PR is for configuring isolation level in batch reading. It's also one of the steps in this story: #216.
There are two variants to configure isolation level either through configuring batch reading, as it's done here, or by configuring connection.