### PR TITLE
writer: make the force flush timer accurate

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -568,14 +568,15 @@ func (w *writer) withErrorLogger(do func(*log.Logger)) {
 func (w *writer) run() {
 	defer w.join.Done()
 
-	ticker := time.NewTicker(w.batchTimeout / 10)
-	defer ticker.Stop()
+	batchTimer := time.NewTimer(0)
+	<-batchTimer.C
+	batchTimerRunning := false
+	defer batchTimer.Stop()
 
 	var conn *Conn
 	var done bool
 	var batch = make([]Message, 0, w.batchSize)
 	var resch = make([](chan<- error), 0, w.batchSize)
-	var lastFlushAt = time.Now()
 
 	defer func() {
 		if conn != nil {
@@ -595,13 +596,23 @@ func (w *writer) run() {
 				resch = append(resch, wm.res)
 				mustFlush = len(batch) >= w.batchSize
 			}
+			if !batchTimerRunning {
+				batchTimer.Reset(w.batchTimeout)
+				batchTimerRunning = true
+			}
 
-		case now := <-ticker.C:
-			mustFlush = now.Sub(lastFlushAt) > w.batchTimeout
+		case <-batchTimer.C:
+			mustFlush = true
+			batchTimerRunning = false
 		}
 
 		if mustFlush {
-			lastFlushAt = time.Now()
+			if batchTimerRunning {
+				if stopped := batchTimer.Stop(); !stopped {
+					<-batchTimer.C
+				}
+				batchTimerRunning = false
+			}
 
 			if len(batch) == 0 {
 				continue


### PR DESCRIPTION
Prior, every writer to a partition had its own timer that ticked at
1/10th the BatchTimeout interval. Each tick, the code would check
whether BatchTimeout has elapsed since the prior flush and, if so,
trigger a flush.

This change makes the timer more accurate so that it only needs to tick
once every BatchTimeout interval, and only needs to begin a timeout
on the first message for a batch.