### PR TITLE
Add new method ConsumerGroupOffsets to Reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1427,7 +1427,7 @@ func (r *Reader) ReadLag(ctx context.Context) (lag int64, err error) {
 	return
 }
 
-func (r *Reader) ConsumerGroupOffsets() (map[int]int64, error) {
+func (r *Reader) GroupOffsets() (map[int]int64, error) {
 	if !r.useConsumerGroup() {
 		return nil, fmt.Errorf("only supported for consumer groups")
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1214,7 +1214,7 @@ func testReaderConsumerGroupFetchOffsets(t *testing.T, ctx context.Context, r *R
 		t.Errorf("expected messages across 2 partitions; got messages across %v partitions", v)
 	}
 
-	offsets, err := r.ConsumerGroupOffsets()
+	offsets, err := r.GroupOffsets()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a reviewer first PR and can be read commit by commit. In summary we expose a new method on Reader called `ConsumerGroupOffsets` that returns `map[int]int64, error`. The map contains a mapping of partition to the last committed offset for the Readers consumer group ID.