### PR TITLE
Fix full buffer errors.

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -120,8 +120,11 @@ func (batch *Batch) Read(b []byte) (int, error) {
 				return size, nil
 			}
 			n = nbytes // return value
+			if nbytes > cap(b) {
+				nbytes = cap(b)
+			}
 			if nbytes > len(b) {
-				nbytes = len(b)
+				b = b[:nbytes]
 			}
 			nbytes, err := io.ReadFull(r, b[:nbytes])
 			if err != nil {

--- a/message.go
+++ b/message.go
@@ -463,6 +463,7 @@ func (r *messageSetReaderV2) readMessage(min int64,
 				err = errShortRead
 				return
 			}
+			r.reader = bufio.NewReaderSize(r.reader, batchRemain)
 			var b []byte
 			if b, err = r.reader.Peek(batchRemain); err != nil {
 				return

--- a/message.go
+++ b/message.go
@@ -463,7 +463,6 @@ func (r *messageSetReaderV2) readMessage(min int64,
 				err = errShortRead
 				return
 			}
-			r.reader = bufio.NewReaderSize(r.reader, batchRemain)
 			var b []byte
 			if b, err = r.reader.Peek(batchRemain); err != nil {
 				return


### PR DESCRIPTION
bufio.Reader.Peek() returns ErrBufferFull if the peek size is larger than the buffer size. Grow the provided slice up to cap.