### PR TITLE
Add zstd compression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - checkout
       - setup_remote_docker: { reusable: true, docker_layer_caching: true }
       - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
-      - run: go test -v -race -cover -timeout 150s . ./gzip ./lz4 ./sasl ./snappy
+      - run: go test -v -race -cover -timeout 150s $(go list ./... | grep -v examples)
 
 workflows:
   version: 2

--- a/compression.go
+++ b/compression.go
@@ -47,6 +47,5 @@ type CompressionCodec interface {
 	Decode(src []byte) ([]byte, error)
 }
 
-const compressionCodecMask int8 = 0x03
-const DefaultCompressionLevel int = -1
+const compressionCodecMask int8 = 0x07
 const CompressionNoneCode = 0

--- a/compression_test.go
+++ b/compression_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/segmentio/kafka-go/gzip"
 	"github.com/segmentio/kafka-go/lz4"
 	"github.com/segmentio/kafka-go/snappy"
+	ktesting "github.com/segmentio/kafka-go/testing"
+	"github.com/segmentio/kafka-go/zstd"
 )
 
 func TestCompression(t *testing.T) {
@@ -22,6 +24,9 @@ func TestCompression(t *testing.T) {
 	testEncodeDecode(t, msg, gzip.NewCompressionCodec())
 	testEncodeDecode(t, msg, snappy.NewCompressionCodec())
 	testEncodeDecode(t, msg, lz4.NewCompressionCodec())
+	if ktesting.KafkaIsAtLeast("2.1.0") {
+		testEncodeDecode(t, msg, zstd.NewCompressionCodec())
+	}
 }
 
 func testEncodeDecode(t *testing.T, m kafka.Message, codec kafka.CompressionCodec) {
@@ -63,6 +68,8 @@ func codecToStr(codec int8) string {
 		return "snappy"
 	case lz4.Code:
 		return "lz4"
+	case zstd.Code:
+		return "zstd"
 	default:
 		return "unknown"
 	}
@@ -72,6 +79,10 @@ func TestCompressedMessages(t *testing.T) {
 	testCompressedMessages(t, gzip.NewCompressionCodec())
 	testCompressedMessages(t, snappy.NewCompressionCodec())
 	testCompressedMessages(t, lz4.NewCompressionCodec())
+
+	if ktesting.KafkaIsAtLeast("2.1.0") {
+		testCompressedMessages(t, zstd.NewCompressionCodec())
+	}
 }
 
 func testCompressedMessages(t *testing.T, codec kafka.CompressionCodec) {
@@ -253,6 +264,11 @@ func BenchmarkCompression(b *testing.B) {
 		{
 			scenario: "LZ4",
 			codec:    lz4.NewCompressionCodec(),
+			function: benchmarkCompression,
+		},
+		{
+			scenario: "zstd",
+			codec:    zstd.NewCompressionCodec(),
 			function: benchmarkCompression,
 		},
 	}

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -47,10 +47,13 @@ type CompressionCodec struct {
 	CompressionLevel int
 }
 
-const Code = 1
+const (
+	Code                    int8 = 1
+	DefaultCompressionLevel int  = -1
+)
 
 func NewCompressionCodec() CompressionCodec {
-	return NewCompressionCodecWith(kafka.DefaultCompressionLevel)
+	return NewCompressionCodecWith(DefaultCompressionLevel)
 }
 
 func NewCompressionCodecWith(level int) CompressionCodec {

--- a/produce.go
+++ b/produce.go
@@ -111,3 +111,42 @@ func (p *produceResponsePartitionV2) readFrom(r *bufio.Reader, sz int) (remain i
 	}
 	return
 }
+
+type produceResponsePartitionV7 struct {
+	Partition   int32
+	ErrorCode   int16
+	Offset      int64
+	Timestamp   int64
+	StartOffset int64
+}
+
+func (p produceResponsePartitionV7) size() int32 {
+	return 4 + 2 + 8 + 8 + 8
+}
+
+func (p produceResponsePartitionV7) writeTo(w *bufio.Writer) {
+	writeInt32(w, p.Partition)
+	writeInt16(w, p.ErrorCode)
+	writeInt64(w, p.Offset)
+	writeInt64(w, p.Timestamp)
+	writeInt64(w, p.StartOffset)
+}
+
+func (p *produceResponsePartitionV7) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+	if remain, err = readInt32(r, sz, &p.Partition); err != nil {
+		return
+	}
+	if remain, err = readInt16(r, remain, &p.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readInt64(r, remain, &p.Offset); err != nil {
+		return
+	}
+	if remain, err = readInt64(r, remain, &p.Timestamp); err != nil {
+		return
+	}
+	if remain, err = readInt64(r, remain, &p.StartOffset); err != nil {
+		return
+	}
+	return
+}

--- a/protocol.go
+++ b/protocol.go
@@ -32,11 +32,13 @@ const (
 type apiVersion int16
 
 const (
-	v0 apiVersion = 0
-	v1 apiVersion = 1
-	v2 apiVersion = 2
-	v3 apiVersion = 3
-	v5 apiVersion = 5
+	v0  apiVersion = 0
+	v1  apiVersion = 1
+	v2  apiVersion = 2
+	v3  apiVersion = 3
+	v5  apiVersion = 5
+	v7  apiVersion = 7
+	v10 apiVersion = 10
 )
 
 type requestHeader struct {

--- a/read.go
+++ b/read.go
@@ -459,6 +459,110 @@ func readFetchResponseHeaderV5(r *bufio.Reader, size int) (throttle int32, water
 
 }
 
+func readFetchResponseHeaderV10(r *bufio.Reader, size int) (throttle int32, watermark int64, remain int, err error) {
+	var n int32
+	var errorCode int16
+	type AbortedTransaction struct {
+		ProducerId  int64
+		FirstOffset int64
+	}
+	var p struct {
+		Partition           int32
+		ErrorCode           int16
+		HighwaterMarkOffset int64
+		LastStableOffset    int64
+		LogStartOffset      int64
+	}
+	var messageSetSize int32
+	var abortedTransactions []AbortedTransaction
+
+	if remain, err = readInt32(r, size, &throttle); err != nil {
+		return
+	}
+
+	if remain, err = readInt16(r, remain, &errorCode); err != nil {
+		return
+	}
+	if errorCode != 0 {
+		err = Error(errorCode)
+		return
+	}
+
+	if remain, err = discardInt32(r, remain); err != nil {
+		return
+	}
+
+	if remain, err = readInt32(r, remain, &n); err != nil {
+		return
+	}
+
+	// This error should never trigger, unless there's a bug in the kafka client
+	// or server.
+	if n != 1 {
+		err = fmt.Errorf("1 kafka topic was expected in the fetch response but the client received %d", n)
+		return
+	}
+
+	// We ignore the topic name because we've requests messages for a single
+	// topic, unless there's a bug in the kafka server we will have received
+	// the name of the topic that we requested.
+	if remain, err = discardString(r, remain); err != nil {
+		return
+	}
+
+	if remain, err = readInt32(r, remain, &n); err != nil {
+		return
+	}
+
+	// This error should never trigger, unless there's a bug in the kafka client
+	// or server.
+	if n != 1 {
+		err = fmt.Errorf("1 kafka partition was expected in the fetch response but the client received %d", n)
+		return
+	}
+
+	if remain, err = read(r, remain, &p); err != nil {
+		return
+	}
+
+	var abortedTransactionLen int
+	if remain, err = readArrayLen(r, remain, &abortedTransactionLen); err != nil {
+		return
+	}
+
+	if abortedTransactionLen == -1 {
+		abortedTransactions = nil
+	} else {
+		abortedTransactions = make([]AbortedTransaction, abortedTransactionLen)
+		for i := 0; i < abortedTransactionLen; i++ {
+			if remain, err = read(r, remain, &abortedTransactions[i]); err != nil {
+				return
+			}
+		}
+	}
+
+	if p.ErrorCode != 0 {
+		err = Error(p.ErrorCode)
+		return
+	}
+
+	remain, err = readInt32(r, remain, &messageSetSize)
+	if err != nil {
+		return
+	}
+
+	// This error should never trigger, unless there's a bug in the kafka client
+	// or server.
+	if remain != int(messageSetSize) {
+		err = fmt.Errorf("the size of the message set in a fetch response doesn't match the number of remaining bytes (message set size = %d, remaining bytes = %d)", messageSetSize, remain)
+		return
+	}
+
+	watermark = p.HighwaterMarkOffset
+	return
+
+}
+
 func readMessageHeader(r *bufio.Reader, sz int) (offset int64, attributes int8, timestamp int64, remain int, err error) {
 	var version int8
 

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -1,0 +1,50 @@
+// +build cgo
+
+package zstd
+
+import (
+	"github.com/DataDog/zstd"
+	"github.com/segmentio/kafka-go"
+)
+
+func init() {
+	kafka.RegisterCompressionCodec(func() kafka.CompressionCodec {
+		return NewCompressionCodec()
+	})
+}
+
+type CompressionCodec struct {
+	// CompressionLevel is the level of compression to use on messages.
+	CompressionLevel int
+}
+
+const (
+	Code int8 = 4
+	// https://github.com/DataDog/zstd/blob/1e382f59b41eebd6f592c5db4fd1958ec38a0eba/zstd.go#L33
+	DefaultCompressionLevel int = 5
+)
+
+func NewCompressionCodec() CompressionCodec {
+	return NewCompressionCodecWith(DefaultCompressionLevel)
+}
+
+func NewCompressionCodecWith(level int) CompressionCodec {
+	return CompressionCodec{
+		CompressionLevel: level,
+	}
+}
+
+// Code implements the kafka.CompressionCodec interface.
+func (c CompressionCodec) Code() int8 {
+	return Code
+}
+
+// Encode implements the kafka.CompressionCodec interface.
+func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
+	return zstd.CompressLevel(nil, src, c.CompressionLevel)
+}
+
+// Decode implements the kafka.CompressionCodec interface.
+func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
+	return zstd.Decompress(nil, src)
+}


### PR DESCRIPTION
This PR adds the zstd compression algorithm available since Kafka 2.1.0 with the required internal fetch and produce request versions.

Note about this PR : in this PR we are using github.com/DataDog/ztsd which is a Go wrapper around the C implementation of ztsd. Due to that using zstd will require cgo which is quite unfortunate.