### PR TITLE
handle empty batch message set

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -803,7 +803,11 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var msgs *messageSetReader
 	if err == nil {
-		msgs, err = newMessageSetReader(&c.rbuf, remain)
+		if highWaterMark == offset {
+			msgs = &messageSetReader{empty: true}
+		} else {
+			msgs, err = newMessageSetReader(&c.rbuf, remain)
+		}
 	}
 	if err == errShortRead {
 		err = checkTimeoutErr(adjustedDeadline)

--- a/message.go
+++ b/message.go
@@ -108,6 +108,7 @@ func (s messageSet) writeTo(w *bufio.Writer) {
 }
 
 type messageSetReader struct {
+	empty   bool
 	version int
 	v1      messageSetReaderV1
 	v2      messageSetReaderV2
@@ -117,6 +118,9 @@ func (r *messageSetReader) readMessage(min int64,
 	key func(*bufio.Reader, int, int) (int, error),
 	val func(*bufio.Reader, int, int) (int, error),
 ) (offset int64, timestamp int64, headers []Header, err error) {
+	if r.empty {
+		return 0, 0, nil, errShortRead
+	}
 	switch r.version {
 	case 1:
 		return r.v1.readMessage(min, key, val)
@@ -128,6 +132,9 @@ func (r *messageSetReader) readMessage(min int64,
 }
 
 func (r *messageSetReader) remaining() (remain int) {
+	if r.empty {
+		return 0
+	}
 	switch r.version {
 	case 1:
 		return r.v1.remaining()
@@ -139,6 +146,9 @@ func (r *messageSetReader) remaining() (remain int) {
 }
 
 func (r *messageSetReader) discard() (err error) {
+	if r.empty {
+		return nil
+	}
 	switch r.version {
 	case 1:
 		return r.v1.discard()

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,36 @@
+package kafka
+
+import (
+	"bufio"
+	"testing"
+)
+
+func TestMessageSetReaderEmpty(t *testing.T) {
+	m := messageSetReader{empty: true}
+
+	noop := func(*bufio.Reader, int, int) (int, error) {
+		return 0, nil
+	}
+
+	offset, timestamp, headers, err := m.readMessage(0, noop, noop)
+	if offset != 0 {
+		t.Errorf("expected offset of 0, get %d", offset)
+	}
+	if timestamp != 0 {
+		t.Errorf("expected timestamp of 0, get %d", timestamp)
+	}
+	if headers != nil {
+		t.Errorf("expected nil headers, got %v", headers)
+	}
+	if err != errShortRead {
+		t.Errorf("expected errShortRead, got %v", err)
+	}
+
+	if m.remaining() != 0 {
+		t.Errorf("expected 0 remaining, got %d", m.remaining())
+	}
+
+	if m.discard() != nil {
+		t.Errorf("unexpected error from discard(): %v", m.discard())
+	}
+}


### PR DESCRIPTION
We have some topics that are low traffic. On topics like this, we are getting a lot of error messages, such as `the kafka reader got an unknown error reading partition 17 of some_topic_name at offset 577667: unexpected EOF`

This error originates here: https://github.com/segmentio/kafka-go/blob/master/conn.go#L806

When there are no messages to be read, kafka returns an empty response body, and `highWaterMark == currentOffset`, however `newMessageSetReader` treats this as a bad response.

This change modifies `messageSetReader` to allow it to be empty, and check for this case.