### PR TITLE
Don't fail consumer group assignment if topic does not exist

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -257,7 +257,7 @@ func (r *Reader) assignTopicPartitions(conn partitionReader, group joinGroupResp
 	// it's not a failure if the topic doesn't exist yet.  it results in no
 	// assignments for the topic.  this matches the behavior of the official
 	// clients: java, python, and librdkafka.
-	// ana topic watcher can trigger a rebalance when the topic comes into being.
+	// a topic watcher can trigger a rebalance when the topic comes into being.
 	if err != nil && err != UnknownTopicOrPartition {
 		return nil, fmt.Errorf("unable to read partitions: %v", err)
 	}

--- a/reader.go
+++ b/reader.go
@@ -253,7 +253,12 @@ func (r *Reader) assignTopicPartitions(conn partitionReader, group joinGroupResp
 
 	topics := extractTopics(members)
 	partitions, err := conn.ReadPartitions(topics...)
-	if err != nil {
+
+	// it's not a failure if the topic doesn't exist yet.  it results in no
+	// assignments for the topic.  this matches the behavior of the official
+	// clients: java, python, and librdkafka.
+	// ana topic watcher can trigger a rebalance when the topic comes into being.
+	if err != nil && err != UnknownTopicOrPartition {
 		return nil, fmt.Errorf("unable to read partitions: %v", err)
 	}
 


### PR DESCRIPTION
Official Kafka clients (librdkafka, java) do not throw an error in
this case. Instead, they hand back empty assignments to all the
consumers. The partition watch functionality can be used to trigger
a rebalance if the topic comes into existence later.