### PR TITLE
expose batch error

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -92,6 +92,19 @@ func (batch *Batch) close() (err error) {
 	return
 }
 
+// Err returns a non-nil error if the batch is broken. This is the same error
+// that would be returned by Read, ReadMessage or Close (except in the case of
+// io.EOF which is never returned by Close).
+//
+// This method is useful when building retry mechanisms for (*Conn).ReadBatch,
+// the program can check whether the batch carried a error before attempting to
+// read the first message.
+//
+// Note that checking errors on a batch is optional, calling Read or ReadMessage
+// is always valid and can be used to either read a message or an error in cases
+// where that's convenient.
+func (batch *Batch) Err() error { return batch.err }
+
 // Read reads the value of the next message from the batch into b, returning the
 // number of bytes read, or an error if the next message couldn't be read.
 //


### PR DESCRIPTION
This PR adds `func (*Batch) Err() error`, see the documentation for detailed explanations about the use cases that this new API solves for.