### PR TITLE
Pad shorter version with zeroes

### DIFF
--- a/testing/version.go
+++ b/testing/version.go
@@ -20,6 +20,11 @@ func (v semver) atLeast(other semver) bool {
 			return true
 		}
 	}
+	for i := len(v); i < len(other); i++ {
+		if 0 < other[i] {
+			return false
+		}
+	}
 	return true
 }
 

--- a/testing/version.go
+++ b/testing/version.go
@@ -21,7 +21,7 @@ func (v semver) atLeast(other semver) bool {
 		}
 	}
 	for i := len(v); i < len(other); i++ {
-		if 0 < other[i] {
+		if other[i] > 0 {
 			return false
 		}
 	}

--- a/testing/version_test.go
+++ b/testing/version_test.go
@@ -1,0 +1,19 @@
+package kafka
+
+import (
+	"testing"
+)
+
+func TestSemVersionAtLeastEmpty(t *testing.T) {
+	result := semver([]int{}).atLeast(semver([]int{1, 2}))
+	if result {
+		t.Errorf("Empty version can't be at least 1.2")
+	}
+}
+
+func TestSemVersionAtLeastShorter(t *testing.T) {
+	result := semver([]int{1, 1}).atLeast(semver([]int{1, 1, 2}))
+	if result {
+		t.Errorf("Version 1.1 version can't be at least 1.1.2")
+	}
+}


### PR DESCRIPTION
Shorter(including empty) kafka versions are perceived as satisfying atLeast requirement.