### PR TITLE
Log EOF errors to standard logger

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1883,6 +1883,14 @@ func (r *reader) run(ctx context.Context, offset int64) {
 				r.sendError(ctx, err)
 				break readLoop
 
+			case io.EOF:
+				r.withLogger(func(log *log.Logger) {
+					log.Printf("the kafka reader got an EOF for partition %d of %s at offset %d: %s", r.partition, r.topic, offset, err)
+				})
+				r.stats.errors.observe(1)
+				conn.Close()
+				break readLoop
+
 			default:
 				if _, ok := err.(Error); ok {
 					r.sendError(ctx, err)


### PR DESCRIPTION
They were being logged to the error logger, which caused error-level
logs to be written frequently when topics had no messages to consume:

```
the kafka reader got an unknown error reading partition 14 of my_topic at offset 80: EOF
```