### PR TITLE
Start reader go routines on SetOffset

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1542,9 +1542,10 @@ func (r *Reader) SetOffset(offset int64) error {
 			log.Printf("setting the offset of the kafka reader for partition %d of %s from %d to %d",
 				r.config.Partition, r.config.Topic, r.offset, offset)
 		})
+		prevOffset := r.offset
 		r.offset = offset
 
-		if r.version != 0 {
+		if prevOffset != r.offset {
 			r.start(map[int]int64{r.config.Partition: r.offset})
 		}
 

--- a/reader.go
+++ b/reader.go
@@ -1556,7 +1556,14 @@ func (r *Reader) SetOffset(offset int64) error {
 	return err
 }
 
-// todo
+// SetRelativeOffset takes a relative offset (either FirstOffset or LastOffset),
+// resolves it to an absolute offset, and then positions the reader.  The
+// function fails with io.ErrClosedPipe if the reader has already been closed.
+//
+// This function differs from SetOffset in that it only accepts a relative
+// offset value and in when the relative offset is resolved.  When calling
+// SetOffset, the resolution takes place asynchronously.  When calling this
+// function, the resolution takes place synchronously.
 func (r *Reader) SetRelativeOffset(ctx context.Context, offset int64) error {
 	if offset != FirstOffset && offset != LastOffset {
 		return errors.New("invalid relative offset")


### PR DESCRIPTION
It was a bit surprising when using relative offsets that the reader wasn't started up immediately since the start/end could be changing between the time of calling `SetOffset` and `FetchMessage`.  I could also only start up the reader in the case where a relative offset is specified, but it seems to me that eager initialization is preferable.