### PR TITLE
fix and optimize varint encoding

### DIFF
--- a/read.go
+++ b/read.go
@@ -51,12 +51,11 @@ func readVarInt(r *bufio.Reader, sz int, v *int64) (remain int, err error) {
 	s := uint(0)
 
 	for {
-		for i, b := range input {
-			if i >= sz {
-				r.Discard(i + 1)
-				return 0, errShortRead
-			}
+		if len(input) > sz {
+			input = input[:sz]
+		}
 
+		for i, b := range input {
 			if b < 0x80 {
 				x |= uint64(b) << s
 				*v = int64(x>>1) ^ -(int64(x) & 1)
@@ -73,6 +72,9 @@ func readVarInt(r *bufio.Reader, sz int, v *int64) (remain int, err error) {
 		// varint decoding can continue on the next loop iteration.
 		n, _ := r.Discard(len(input))
 		sz -= n
+		if sz == 0 {
+			return 0, errShortRead
+		}
 
 		// Fill the buffer: ask for one more byte, but in practice the reader
 		// will load way more from the underlying stream.

--- a/write.go
+++ b/write.go
@@ -47,12 +47,14 @@ func writeInt64(w *bufio.Writer, i int64) {
 }
 
 func writeVarInt(w *bufio.Writer, i int64) {
-	i = i<<1 ^ i>>63
-	for i&0x7f != i {
-		w.WriteByte(byte(i&0x7f | 0x80))
-		i >>= 7
+	u := uint64((i << 1) ^ (i >> 63))
+
+	for u >= 0x80 {
+		w.WriteByte(byte(u) | 0x80)
+		u >>= 7
 	}
-	w.WriteByte(byte(i))
+
+	w.WriteByte(byte(u))
 }
 
 func varIntLen(i int64) (l int) {


### PR DESCRIPTION
I was looking into optimizing varint decoding because we have a use case where during CPU-intensive work, ~15% of the time is spent on this code path.

While writing the initial benchmarks to validate the change I noticed that encoding and decoding was broken for large integer values due to some mistakes in the way zig-zag encoding was being handled. This probably never triggered in practice because the varints are not used to encode values in the 2^56~2^64 range, but we're better off with a fix anyways ;)

The optimization yielded good results on the read path:
```
benchmark                old ns/op     new ns/op     delta
BenchmarkWriteVarInt     20.8          20.3          -2.40%
BenchmarkReadVarInt      93.3          38.0          -59.27%
```
