### PR TITLE
Stream compression

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -6,10 +6,18 @@ import (
 	"sync"
 )
 
-var errUnknownCodec = errors.New("the compression code is invalid or its codec has not been imported")
+const (
+	CompressionNoneCode = 0
 
-var codecs = make(map[int8]CompressionCodec)
-var codecsMutex sync.RWMutex
+	compressionCodecMask = 0x07
+)
+
+var (
+	errUnknownCodec = errors.New("the compression code is invalid or its codec has not been imported")
+
+	codecs      = make(map[int8]CompressionCodec)
+	codecsMutex sync.RWMutex
+)
 
 // RegisterCompressionCodec registers a compression codec so it can be used by a Writer.
 func RegisterCompressionCodec(codec func() CompressionCodec) {
@@ -41,18 +49,9 @@ type CompressionCodec interface {
 	// Code returns the compression codec code
 	Code() int8
 
-	// Encode encodes the src data
-	Encode(src []byte) ([]byte, error)
-
-	// Decode decodes the src data
-	Decode(src []byte) ([]byte, error)
-
 	// Constructs a new reader which decompresses data from r.
 	NewReader(r io.Reader) io.ReadCloser
 
 	// Constructs a new writer which writes compressed data to w.
 	NewWriter(w io.Writer) io.WriteCloser
 }
-
-const compressionCodecMask int8 = 0x07
-const CompressionNoneCode = 0

--- a/compression.go
+++ b/compression.go
@@ -20,10 +20,10 @@ var (
 )
 
 // RegisterCompressionCodec registers a compression codec so it can be used by a Writer.
-func RegisterCompressionCodec(codec func() CompressionCodec) {
-	c := codec()
+func RegisterCompressionCodec(codec CompressionCodec) {
+	code := codec.Code()
 	codecsMutex.Lock()
-	codecs[c.Code()] = c
+	codecs[code] = codec
 	codecsMutex.Unlock()
 }
 

--- a/compression.go
+++ b/compression.go
@@ -49,6 +49,9 @@ type CompressionCodec interface {
 	// Code returns the compression codec code
 	Code() int8
 
+	// Human-readable name for the codec.
+	Name() string
+
 	// Constructs a new reader which decompresses data from r.
 	NewReader(r io.Reader) io.ReadCloser
 

--- a/compression.go
+++ b/compression.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"errors"
+	"io"
 	"sync"
 )
 
@@ -45,6 +46,12 @@ type CompressionCodec interface {
 
 	// Decode decodes the src data
 	Decode(src []byte) ([]byte, error)
+
+	// Constructs a new reader which decompresses data from r.
+	NewReader(r io.Reader) io.ReadCloser
+
+	// Constructs a new writer which writes compressed data to w.
+	NewWriter(w io.Writer) io.WriteCloser
 }
 
 const compressionCodecMask int8 = 0x07

--- a/compression_test.go
+++ b/compression_test.go
@@ -3,12 +3,14 @@ package kafka_test
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/segmentio/kafka-go"
+	kafka "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/gzip"
 	"github.com/segmentio/kafka-go/lz4"
 	"github.com/segmentio/kafka-go/snappy"
@@ -239,6 +241,18 @@ func (noopCodec) Encode(src []byte) ([]byte, error) {
 func (noopCodec) Decode(src []byte) ([]byte, error) {
 	return src, nil
 }
+
+func (noopCodec) NewReader(r io.Reader) io.ReadCloser {
+	return ioutil.NopCloser(r)
+}
+
+func (noopCodec) NewWriter(w io.Writer) io.WriteCloser {
+	return nopWriteCloser{w}
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
 
 func BenchmarkCompression(b *testing.B) {
 	benchmarks := []struct {

--- a/compression_test.go
+++ b/compression_test.go
@@ -241,7 +241,7 @@ func (noopCodec) Code() int8 {
 }
 
 func (noopCodec) Name() string {
-	return ""
+	return "none"
 }
 
 func (noopCodec) NewReader(r io.Reader) io.ReadCloser {
@@ -258,32 +258,26 @@ func (nopWriteCloser) Close() error { return nil }
 
 func BenchmarkCompression(b *testing.B) {
 	benchmarks := []struct {
-		scenario string
 		codec    kafka.CompressionCodec
 		function func(*testing.B, kafka.CompressionCodec, int, map[int][]byte)
 	}{
 		{
-			scenario: "None",
 			codec:    &noopCodec{},
 			function: benchmarkCompression,
 		},
 		{
-			scenario: "GZIP",
 			codec:    gzip.NewCompressionCodec(),
 			function: benchmarkCompression,
 		},
 		{
-			scenario: "Snappy",
 			codec:    snappy.NewCompressionCodec(),
 			function: benchmarkCompression,
 		},
 		{
-			scenario: "LZ4",
 			codec:    lz4.NewCompressionCodec(),
 			function: benchmarkCompression,
 		},
 		{
-			scenario: "zstd",
 			codec:    zstd.NewCompressionCodec(),
 			function: benchmarkCompression,
 		},
@@ -297,16 +291,16 @@ func BenchmarkCompression(b *testing.B) {
 	}
 
 	for _, benchmark := range benchmarks {
-		b.Run(benchmark.scenario+"1024", func(b *testing.B) {
+		b.Run(benchmark.codec.Name()+"1024", func(b *testing.B) {
 			benchmark.function(b, benchmark.codec, 1024, payload)
 		})
-		b.Run(benchmark.scenario+"4096", func(b *testing.B) {
+		b.Run(benchmark.codec.Name()+"4096", func(b *testing.B) {
 			benchmark.function(b, benchmark.codec, 4096, payload)
 		})
-		b.Run(benchmark.scenario+"8192", func(b *testing.B) {
+		b.Run(benchmark.codec.Name()+"8192", func(b *testing.B) {
 			benchmark.function(b, benchmark.codec, 8192, payload)
 		})
-		b.Run(benchmark.scenario+"16384", func(b *testing.B) {
+		b.Run(benchmark.codec.Name()+"16384", func(b *testing.B) {
 			benchmark.function(b, benchmark.codec, 16384, payload)
 		})
 	}

--- a/compression_test.go
+++ b/compression_test.go
@@ -62,20 +62,15 @@ func decompress(codec kafka.CompressionCodec, src []byte) ([]byte, error) {
 func testEncodeDecode(t *testing.T, m kafka.Message, codec kafka.CompressionCodec) {
 	var r1, r2 []byte
 	var err error
-	var code int8
 
-	if codec != nil {
-		code = codec.Code()
-	}
-
-	t.Run("encode with "+codecToStr(code), func(t *testing.T) {
+	t.Run("encode with "+codec.Name(), func(t *testing.T) {
 		r1, err = compress(codec, m.Value)
 		if err != nil {
 			t.Error(err)
 		}
 	})
 
-	t.Run("decode with "+codecToStr(code), func(t *testing.T) {
+	t.Run("decode with "+codec.Name(), func(t *testing.T) {
 		r2, err = decompress(codec, r1)
 		if err != nil {
 			t.Error(err)
@@ -86,23 +81,6 @@ func testEncodeDecode(t *testing.T, m kafka.Message, codec kafka.CompressionCode
 			t.Log("expected: ", string(m.Value))
 		}
 	})
-}
-
-func codecToStr(codec int8) string {
-	switch codec {
-	case kafka.CompressionNoneCode:
-		return "none"
-	case gzip.Code:
-		return "gzip"
-	case snappy.Code:
-		return "snappy"
-	case lz4.Code:
-		return "lz4"
-	case zstd.Code:
-		return "zstd"
-	default:
-		return "unknown"
-	}
 }
 
 func TestCompressedMessages(t *testing.T) {
@@ -116,7 +94,7 @@ func TestCompressedMessages(t *testing.T) {
 }
 
 func testCompressedMessages(t *testing.T, codec kafka.CompressionCodec) {
-	t.Run("produce/consume with"+codecToStr(codec.Code()), func(t *testing.T) {
+	t.Run("produce/consume with"+codec.Name(), func(t *testing.T) {
 		t.Parallel()
 
 		topic := kafka.CreateTopic(t, 1)
@@ -260,6 +238,10 @@ type noopCodec struct{}
 
 func (noopCodec) Code() int8 {
 	return 0
+}
+
+func (noopCodec) Name() string {
+	return ""
 }
 
 func (noopCodec) NewReader(r io.Reader) io.ReadCloser {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.11
 
 require (
 	github.com/DataDog/zstd v1.4.0
+	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
 	github.com/golang/snappy v0.0.1
 	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/DataDog/zstd v1.4.0 h1:vhoV+DUHnRZdKW1i5UMjAk2G4JY8wN4ayRfYDNdEhwo=
 github.com/DataDog/zstd v1.4.0/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -69,6 +69,11 @@ func (c CompressionCodec) Code() int8 {
 	return Code
 }
 
+// Name implements the kafka.CompressionCodec interface.
+func (c CompressionCodec) Name() string {
+	return "gzip"
+}
+
 // NewReader implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
 	z := readerPool.Get().(*gzip.Reader)

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -2,30 +2,25 @@ package lz4
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"sync"
 
 	"github.com/pierrec/lz4"
-	"github.com/segmentio/kafka-go"
+	kafka "github.com/segmentio/kafka-go"
 )
 
 var (
-	readerPool sync.Pool
-	writerPool sync.Pool
+	readerPool = sync.Pool{
+		New: func() interface{} { return lz4.NewReader(nil) },
+	}
+
+	writerPool = sync.Pool{
+		New: func() interface{} { return lz4.NewWriter(nil) },
+	}
 )
 
 func init() {
-	readerPool = sync.Pool{
-		New: func() interface{} {
-			return lz4.NewReader(nil)
-		},
-	}
-	writerPool = sync.Pool{
-		New: func() interface{} {
-			return lz4.NewWriter(nil)
-		},
-	}
-
 	kafka.RegisterCompressionCodec(func() kafka.CompressionCodec {
 		return NewCompressionCodec()
 	})
@@ -40,42 +35,73 @@ func NewCompressionCodec() CompressionCodec {
 }
 
 // Code implements the kafka.CompressionCodec interface.
-func (c CompressionCodec) Code() int8 {
+func (CompressionCodec) Code() int8 {
 	return Code
 }
 
 // Encode implements the kafka.CompressionCodec interface.
-func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
+func (CompressionCodec) Encode(src []byte) ([]byte, error) {
 	buf := bytes.Buffer{}
 	buf.Grow(len(src)) // guess a size to avoid repeat allocations.
 	writer := writerPool.Get().(*lz4.Writer)
 	writer.Reset(&buf)
+	defer writerPool.Put(writer)
+	defer writer.Reset(nil)
 
 	_, err := writer.Write(src)
 	if err != nil {
-		// don't return writer to pool on error.
 		return nil, err
 	}
 
 	err = writer.Close()
 	if err != nil {
-		// don't return writer to pool on error.
 		return nil, err
 	}
-
-	writerPool.Put(writer)
-
 	return buf.Bytes(), err
 }
 
 // Decode implements the kafka.CompressionCodec interface.
-func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
+func (CompressionCodec) Decode(src []byte) ([]byte, error) {
 	reader := readerPool.Get().(*lz4.Reader)
+	defer readerPool.Put(reader)
+	defer reader.Reset(nil)
 	reader.Reset(bytes.NewReader(src))
-	res, err := ioutil.ReadAll(reader)
-	// only return the reader to pool if the read was a success.
-	if err == nil {
-		readerPool.Put(reader)
+	return ioutil.ReadAll(reader)
+}
+
+// NewReader implements the kafka.CompressionCodec interface.
+func (CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
+	z := readerPool.Get().(*lz4.Reader)
+	z.Reset(r)
+	return &reader{z}
+}
+
+// NewWriter implements the kafka.CompressionCodec interface.
+func (CompressionCodec) NewWriter(w io.Writer) io.WriteCloser {
+	z := writerPool.Get().(*lz4.Writer)
+	z.Reset(w)
+	return &writer{z}
+}
+
+type reader struct{ *lz4.Reader }
+
+func (r *reader) Close() (err error) {
+	if z := r.Reader; z != nil {
+		r.Reader = nil
+		z.Reset(nil)
+		readerPool.Put(z)
 	}
-	return res, err
+	return
+}
+
+type writer struct{ *lz4.Writer }
+
+func (w *writer) Close() (err error) {
+	if z := w.Writer; z != nil {
+		w.Writer = nil
+		err = z.Close()
+		z.Reset(nil)
+		writerPool.Put(z)
+	}
+	return
 }

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -37,6 +37,11 @@ func (CompressionCodec) Code() int8 {
 	return Code
 }
 
+// Name implements the kafka.CompressionCodec interface.
+func (CompressionCodec) Name() string {
+	return "lz4"
+}
+
 // NewReader implements the kafka.CompressionCodec interface.
 func (CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
 	z := readerPool.Get().(*lz4.Reader)

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -8,39 +8,25 @@ import (
 	kafka "github.com/segmentio/kafka-go"
 )
 
-var (
-	readerPool = sync.Pool{
-		New: func() interface{} { return lz4.NewReader(nil) },
-	}
-
-	writerPool = sync.Pool{
-		New: func() interface{} { return lz4.NewWriter(nil) },
-	}
-)
-
 func init() {
-	kafka.RegisterCompressionCodec(func() kafka.CompressionCodec {
-		return NewCompressionCodec()
-	})
+	kafka.RegisterCompressionCodec(NewCompressionCodec())
 }
+
+const (
+	Code = 3
+)
 
 type CompressionCodec struct{}
 
-const Code = 3
-
-func NewCompressionCodec() CompressionCodec {
-	return CompressionCodec{}
+func NewCompressionCodec() *CompressionCodec {
+	return &CompressionCodec{}
 }
 
 // Code implements the kafka.CompressionCodec interface.
-func (CompressionCodec) Code() int8 {
-	return Code
-}
+func (CompressionCodec) Code() int8 { return Code }
 
 // Name implements the kafka.CompressionCodec interface.
-func (CompressionCodec) Name() string {
-	return "lz4"
-}
+func (CompressionCodec) Name() string { return "lz4" }
 
 // NewReader implements the kafka.CompressionCodec interface.
 func (CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
@@ -77,4 +63,12 @@ func (w *writer) Close() (err error) {
 		writerPool.Put(z)
 	}
 	return
+}
+
+var readerPool = sync.Pool{
+	New: func() interface{} { return lz4.NewReader(nil) },
+}
+
+var writerPool = sync.Pool{
+	New: func() interface{} { return lz4.NewWriter(nil) },
 }

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -1,9 +1,7 @@
 package lz4
 
 import (
-	"bytes"
 	"io"
-	"io/ioutil"
 	"sync"
 
 	"github.com/pierrec/lz4"
@@ -37,36 +35,6 @@ func NewCompressionCodec() CompressionCodec {
 // Code implements the kafka.CompressionCodec interface.
 func (CompressionCodec) Code() int8 {
 	return Code
-}
-
-// Encode implements the kafka.CompressionCodec interface.
-func (CompressionCodec) Encode(src []byte) ([]byte, error) {
-	buf := bytes.Buffer{}
-	buf.Grow(len(src)) // guess a size to avoid repeat allocations.
-	writer := writerPool.Get().(*lz4.Writer)
-	writer.Reset(&buf)
-	defer writerPool.Put(writer)
-	defer writer.Reset(nil)
-
-	_, err := writer.Write(src)
-	if err != nil {
-		return nil, err
-	}
-
-	err = writer.Close()
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), err
-}
-
-// Decode implements the kafka.CompressionCodec interface.
-func (CompressionCodec) Decode(src []byte) ([]byte, error) {
-	reader := readerPool.Get().(*lz4.Reader)
-	defer readerPool.Put(reader)
-	defer reader.Reset(nil)
-	reader.Reset(bytes.NewReader(src))
-	return ioutil.ReadAll(reader)
 }
 
 // NewReader implements the kafka.CompressionCodec interface.

--- a/message.go
+++ b/message.go
@@ -241,6 +241,7 @@ func (r *messageSetReaderV1) readMessage(min int64,
 			var decompressed bytes.Buffer
 
 			if r.remain, err = readBytesWith(r.reader, r.remain, func(r *bufio.Reader, sz, n int) (remain int, err error) {
+				// x4 as a guess that the average compression ratio is near 75%
 				decompressed.Grow(4 * n)
 
 				l := io.LimitedReader{R: r, N: int64(n)}

--- a/message.go
+++ b/message.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -237,13 +238,18 @@ func (r *messageSetReaderV1) readMessage(min int64,
 			}
 
 			// read and decompress the contained message set.
-			var decompressed []byte
+			var decompressed bytes.Buffer
+
 			if r.remain, err = readBytesWith(r.reader, r.remain, func(r *bufio.Reader, sz, n int) (remain int, err error) {
-				var value []byte
-				if value, remain, err = readNewBytes(r, sz, n); err != nil {
-					return
-				}
-				decompressed, err = codec.Decode(value)
+				decompressed.Grow(4 * n)
+
+				l := io.LimitedReader{R: r, N: int64(n)}
+				d := codec.NewReader(&l)
+
+				_, err = decompressed.ReadFrom(d)
+				remain = sz - (n - int(l.N))
+
+				d.Close()
 				return
 			}); err != nil {
 				return
@@ -256,13 +262,16 @@ func (r *messageSetReaderV1) readMessage(min int64,
 			// messages at offsets 10-13, then the container message will have
 			// offset 13 and the contained messages will be 0,1,2,3.  the base
 			// offset for the container, then is 13-3=10.
-			if offset, err = extractOffset(offset, decompressed); err != nil {
+			if offset, err = extractOffset(offset, decompressed.Bytes()); err != nil {
 				return
 			}
 
 			r.readerStack = &readerStack{
-				reader: bufio.NewReader(bytes.NewReader(decompressed)),
-				remain: len(decompressed),
+				// Allocate a buffer of size 0, which gets capped at 16 bytes
+				// by the bufio package. We are already reading buffered data
+				// here, no need to reserve another 4KB buffer.
+				reader: bufio.NewReaderSize(&decompressed, 0),
+				remain: decompressed.Len(),
 				base:   offset,
 				parent: r.readerStack,
 			}
@@ -458,33 +467,40 @@ func (r *messageSetReaderV2) readMessage(min int64,
 				r.readerStack = r.parent
 			}
 		}
+
 		if err = r.readHeader(); err != nil {
 			return
 		}
-		code := r.header.compression()
-		var decompressed []byte
-		if code != 0 {
+
+		if code := r.header.compression(); code != 0 {
 			var codec CompressionCodec
 			if codec, err = resolveCodec(code); err != nil {
 				return
 			}
-			batchRemain := int(r.header.length - 49)
+
+			var batchRemain = int(r.header.length - 49)
 			if batchRemain > r.remain {
 				err = errShortRead
 				return
 			}
-			var compressed []byte
-			compressed, r.remain, err = readNewBytes(r.reader, r.remain, batchRemain)
+
+			var decompressed bytes.Buffer
+			decompressed.Grow(4 * batchRemain)
+
+			l := io.LimitedReader{R: r.reader, N: int64(batchRemain)}
+			d := codec.NewReader(&l)
+
+			_, err = decompressed.ReadFrom(d)
+			r.remain = r.remain - (batchRemain - int(l.N))
+			d.Close()
+
 			if err != nil {
-				return
-			}
-			if decompressed, err = codec.Decode(compressed); err != nil {
 				return
 			}
 
 			r.readerStack = &readerStack{
-				reader: bufio.NewReader(bytes.NewReader(decompressed)),
-				remain: len(decompressed),
+				reader: bufio.NewReaderSize(&decompressed, 0),
+				remain: decompressed.Len(),
 				base:   -1, // base is unused here
 				parent: r.readerStack,
 			}

--- a/snappy/snappy.go
+++ b/snappy/snappy.go
@@ -28,6 +28,11 @@ func (CompressionCodec) Code() int8 {
 	return Code
 }
 
+// Name implements the kafka.CompressionCodec interface.
+func (CompressionCodec) Name() string {
+	return "snappy"
+}
+
 // NewReader implements the kafka.CompressionCodec interface.
 func (CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
 	x := readerPool.Get().(*xerialReader)

--- a/snappy/snappy.go
+++ b/snappy/snappy.go
@@ -28,17 +28,6 @@ func (CompressionCodec) Code() int8 {
 	return Code
 }
 
-// Encode implements the kafka.CompressionCodec interface.
-func (CompressionCodec) Encode(src []byte) ([]byte, error) {
-	// NOTE : passing a nil dst means snappy will allocate it.
-	return snappy.Encode(nil, src), nil
-}
-
-// Decode implements the kafka.CompressionCodec interface.
-func (CompressionCodec) Decode(src []byte) ([]byte, error) {
-	return decode(src)
-}
-
 // NewReader implements the kafka.CompressionCodec interface.
 func (CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
 	x := readerPool.Get().(*xerialReader)

--- a/snappy/snappy.go
+++ b/snappy/snappy.go
@@ -1,11 +1,12 @@
 package snappy
 
 import (
-	"bytes"
 	"encoding/binary"
+	"io"
+	"sync"
 
 	"github.com/golang/snappy"
-	"github.com/segmentio/kafka-go"
+	kafka "github.com/segmentio/kafka-go"
 )
 
 func init() {
@@ -23,26 +24,73 @@ func NewCompressionCodec() CompressionCodec {
 }
 
 // Code implements the kafka.CompressionCodec interface.
-func (c CompressionCodec) Code() int8 {
+func (CompressionCodec) Code() int8 {
 	return Code
 }
 
 // Encode implements the kafka.CompressionCodec interface.
-func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
+func (CompressionCodec) Encode(src []byte) ([]byte, error) {
 	// NOTE : passing a nil dst means snappy will allocate it.
 	return snappy.Encode(nil, src), nil
 }
 
 // Decode implements the kafka.CompressionCodec interface.
-func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
+func (CompressionCodec) Decode(src []byte) ([]byte, error) {
 	return decode(src)
 }
 
-var xerialHeader = []byte{130, 83, 78, 65, 80, 80, 89, 0}
+// NewReader implements the kafka.CompressionCodec interface.
+func (CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
+	x := readerPool.Get().(*xerialReader)
+	x.Reset(r)
+	return &reader{x}
+}
+
+// NewWriter implements the kafka.CompressionCodec interface.
+func (CompressionCodec) NewWriter(w io.Writer) io.WriteCloser {
+	x := writerPool.Get().(*xerialWriter)
+	x.Reset(w)
+	return &writer{x}
+}
+
+type reader struct{ *xerialReader }
+
+func (r *reader) Close() (err error) {
+	if x := r.xerialReader; x != nil {
+		r.xerialReader = nil
+		x.Reset(nil)
+		readerPool.Put(x)
+	}
+	return
+}
+
+type writer struct{ *xerialWriter }
+
+func (w *writer) Close() (err error) {
+	if x := w.xerialWriter; x != nil {
+		w.xerialWriter = nil
+		err = x.Flush()
+		x.Reset(nil)
+		writerPool.Put(x)
+	}
+	return
+}
+
+var readerPool = sync.Pool{
+	New: func() interface{} {
+		return &xerialReader{decode: snappy.Decode}
+	},
+}
+
+var writerPool = sync.Pool{
+	New: func() interface{} {
+		return &xerialWriter{encode: snappy.Encode}
+	},
+}
 
 // From github.com/eapache/go-xerial-snappy
 func decode(src []byte) ([]byte, error) {
-	if !bytes.Equal(src[:8], xerialHeader) {
+	if !isXerialHeader(src) {
 		return snappy.Decode(nil, src)
 	}
 
@@ -53,6 +101,7 @@ func decode(src []byte) ([]byte, error) {
 		chunk []byte
 		err   error
 	)
+
 	for pos < max {
 		size := binary.BigEndian.Uint32(src[pos : pos+4])
 		pos += 4
@@ -64,5 +113,6 @@ func decode(src []byte) ([]byte, error) {
 		pos += size
 		dst = append(dst, chunk...)
 	}
+
 	return dst, nil
 }

--- a/snappy/snappy.go
+++ b/snappy/snappy.go
@@ -1,7 +1,6 @@
 package snappy
 
 import (
-	"encoding/binary"
 	"io"
 	"sync"
 
@@ -80,33 +79,4 @@ var writerPool = sync.Pool{
 	New: func() interface{} {
 		return &xerialWriter{encode: snappy.Encode}
 	},
-}
-
-// From github.com/eapache/go-xerial-snappy
-func decode(src []byte) ([]byte, error) {
-	if !isXerialHeader(src) {
-		return snappy.Decode(nil, src)
-	}
-
-	var (
-		pos   = uint32(16)
-		max   = uint32(len(src))
-		dst   = make([]byte, 0, len(src))
-		chunk []byte
-		err   error
-	)
-
-	for pos < max {
-		size := binary.BigEndian.Uint32(src[pos : pos+4])
-		pos += 4
-
-		chunk, err = snappy.Decode(chunk, src[pos:pos+size])
-		if err != nil {
-			return nil, err
-		}
-		pos += size
-		dst = append(dst, chunk...)
-	}
-
-	return dst, nil
 }

--- a/snappy/xerial.go
+++ b/snappy/xerial.go
@@ -1,0 +1,234 @@
+package snappy
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+)
+
+// An implementation of io.Reader which consumes a stream of xerial-framed
+// snappy-encoeded data. The framing is optional, if no framing is detected
+// the reader will simply forward the bytes from its underlying stream.
+type xerialReader struct {
+	reader io.Reader
+	header [20]byte
+	input  []byte
+	output []byte
+	offset int
+	decode func([]byte, []byte) ([]byte, error)
+}
+
+func (x *xerialReader) Reset(r io.Reader) {
+	x.reader = r
+	x.input = x.input[:0]
+	x.output = x.output[:0]
+	x.offset = 0
+}
+
+func (x *xerialReader) Read(b []byte) (int, error) {
+	for {
+		if x.offset < len(x.output) {
+			n := copy(b, x.output[x.offset:])
+			x.offset += n
+			return n, nil
+		}
+
+		if err := x.readChunk(); err != nil {
+			return 0, err
+		}
+	}
+}
+
+func (x *xerialReader) WriteTo(w io.Writer) (int64, error) {
+	wn := int64(0)
+
+	for {
+		for x.offset < len(x.output) {
+			n, err := w.Write(x.output[x.offset:])
+			wn += int64(n)
+			x.offset += n
+			if err != nil {
+				return wn, err
+			}
+		}
+
+		if err := x.readChunk(); err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return wn, err
+		}
+	}
+}
+
+func (x *xerialReader) readChunk() error {
+	x.offset = 0
+
+	n, err := io.ReadFull(x.reader, x.header[:])
+	if err != nil && n == 0 {
+		return err
+	}
+
+	if n == len(x.header) && isXerialHeader(x.header[:]) {
+		n := int(binary.BigEndian.Uint32(x.header[16:]))
+
+		if cap(x.input) < n {
+			x.input = make([]byte, n, align(n, 1024))
+		} else {
+			x.input = x.input[:n]
+		}
+
+		_, err := io.ReadFull(x.reader, x.input)
+		if err != nil {
+			return err
+		}
+	} else {
+		x.input = append(x.input[:0], x.header[:n]...)
+
+		for {
+			if len(x.input) == cap(x.input) {
+				b := make([]byte, len(x.input), 2*cap(x.input))
+				copy(b, x.input)
+				x.input = b
+			}
+
+			n, err := x.reader.Read(x.input[len(x.input):cap(x.input)])
+			x.input = x.input[:len(x.input)+n]
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return err
+			}
+		}
+	}
+
+	if x.decode == nil {
+		x.output, x.input = x.input, x.output
+	} else {
+		b, err := x.decode(x.output[:cap(x.output)], x.input)
+		if err != nil {
+			return err
+		}
+		x.output = b
+	}
+
+	return nil
+}
+
+// An implementation of a xerial-framed snappy-encoded output stream.
+// Each Write made to the writer is framed with a xerial header.
+type xerialWriter struct {
+	writer io.Writer
+	header [20]byte
+	input  []byte
+	output []byte
+	encode func([]byte, []byte) []byte
+}
+
+func (x *xerialWriter) Reset(w io.Writer) {
+	x.writer = w
+	x.input = x.input[:0]
+	x.output = x.output[:0]
+}
+
+func (x *xerialWriter) ReadFrom(r io.Reader) (int64, error) {
+	wn := int64(0)
+
+	if cap(x.input) == 0 {
+		x.input = make([]byte, 0, 32*1024)
+	}
+
+	for {
+		n, err := r.Read(x.input[len(x.input):cap(x.input)])
+		wn += int64(n)
+		x.input = x.input[:len(x.input)+n]
+
+		if x.fullEnough() {
+			if err := x.Flush(); err != nil {
+				return wn, err
+			}
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return wn, err
+		}
+	}
+}
+
+func (x *xerialWriter) Write(b []byte) (int, error) {
+	wn := 0
+
+	if cap(x.input) == 0 {
+		x.input = make([]byte, 0, 32*1024)
+	}
+
+	for len(b) > 0 {
+		n := copy(x.input[len(x.input):cap(x.input)], b)
+		b = b[n:]
+		wn += n
+		x.input = x.input[:len(x.input)+n]
+
+		if x.fullEnough() {
+			if err := x.Flush(); err != nil {
+				return wn, err
+			}
+		}
+	}
+
+	return wn, nil
+}
+
+func (x *xerialWriter) Flush() error {
+	if len(x.input) == 0 {
+		return nil
+	}
+
+	var b []byte
+	if x.encode == nil {
+		b = x.input
+	} else {
+		x.output = x.encode(x.output[:cap(x.output)], x.input)
+		b = x.output
+	}
+
+	x.input = x.input[:0]
+	x.output = x.output[:0]
+	writeXerialHeader(x.header[:], len(b))
+
+	if _, err := x.writer.Write(x.header[:]); err != nil {
+		return err
+	}
+
+	_, err := x.writer.Write(b)
+	return err
+}
+
+func (x *xerialWriter) fullEnough() bool {
+	return (cap(x.input) - len(x.input)) < 1024
+}
+
+func align(n, a int) int {
+	if (n % a) == 0 {
+		return n
+	}
+	return ((n / a) + 1) * a
+}
+
+var (
+	xerialVersionInfo = [...]byte{0, 0, 0, 1, 0, 0, 0, 1}
+	xerialHeader      = [...]byte{130, 83, 78, 65, 80, 80, 89, 0}
+)
+
+func isXerialHeader(src []byte) bool {
+	return len(src) >= 20 && bytes.Equal(src[:8], xerialHeader[:])
+}
+
+func writeXerialHeader(b []byte, n int) {
+	copy(b[:8], xerialHeader[:])
+	copy(b[8:], xerialVersionInfo[:])
+	binary.BigEndian.PutUint32(b[16:], uint32(n))
+}

--- a/snappy/xerial_test.go
+++ b/snappy/xerial_test.go
@@ -1,0 +1,110 @@
+package snappy
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/golang/snappy"
+)
+
+// Wrap an io.Reader or io.Writer to disable all copy optimizations like
+// io.WriterTo or io.ReaderFrom.
+// We use this to ensure writes are chunked by io.Copy's internal buffer
+// in the tests.
+type simpleReader struct{ io.Reader }
+type simpleWriter struct{ io.Writer }
+
+func TestXerialReaderSnappy(t *testing.T) {
+	rawData := new(bytes.Buffer)
+	rawData.Grow(1024 * 1024)
+	io.CopyN(rawData, rand.Reader, 1024*1024)
+
+	compressedRawData := bytes.NewReader(snappy.Encode(nil, rawData.Bytes()))
+
+	decompressedData := new(bytes.Buffer)
+	io.Copy(decompressedData,
+		&xerialReader{reader: compressedRawData, decode: snappy.Decode})
+
+	b0 := rawData.Bytes()
+	b1 := decompressedData.Bytes()
+
+	if !bytes.Equal(b0, b1) {
+		t.Error("data mismatch")
+	}
+}
+
+func TestXerialReaderWriter(t *testing.T) {
+	rawData := new(bytes.Buffer)
+	rawData.Grow(1024 * 1024)
+	io.CopyN(rawData, rand.Reader, 1024*1024)
+
+	framedData := new(bytes.Buffer)
+	framedData.Grow(rawData.Len() + 1024)
+	w := simpleWriter{&xerialWriter{writer: framedData}}
+	r := simpleReader{bytes.NewReader(rawData.Bytes())}
+	io.Copy(w, r)
+	w.Writer.(*xerialWriter).Flush()
+
+	unframedData := new(bytes.Buffer)
+	unframedData.Grow(rawData.Len())
+	io.Copy(unframedData, &xerialReader{reader: framedData})
+
+	b0 := rawData.Bytes()
+	b1 := unframedData.Bytes()
+
+	if !bytes.Equal(b0, b1) {
+		t.Error("data mismatch")
+	}
+}
+
+func TestXerialFramedCompression(t *testing.T) {
+	rawData := new(bytes.Buffer)
+	rawData.Grow(1024 * 1024)
+	io.CopyN(rawData, rand.Reader, 1024*1024)
+
+	framedAndCompressedData := new(bytes.Buffer)
+	framedAndCompressedData.Grow(rawData.Len())
+	w := simpleWriter{&xerialWriter{writer: framedAndCompressedData, encode: snappy.Encode}}
+	r := simpleReader{bytes.NewReader(rawData.Bytes())}
+	io.Copy(w, r)
+	w.Writer.(*xerialWriter).Flush()
+
+	unframedAndDecompressedData := new(bytes.Buffer)
+	unframedAndDecompressedData.Grow(rawData.Len())
+	io.Copy(unframedAndDecompressedData,
+		simpleReader{&xerialReader{reader: framedAndCompressedData, decode: snappy.Decode}})
+
+	b0 := rawData.Bytes()
+	b1 := unframedAndDecompressedData.Bytes()
+
+	if !bytes.Equal(b0, b1) {
+		t.Error("data mismatch")
+	}
+}
+
+func TestXerialFramedCompressionOptimized(t *testing.T) {
+	rawData := new(bytes.Buffer)
+	rawData.Grow(1024 * 1024)
+	io.CopyN(rawData, rand.Reader, 1024*1024)
+
+	framedAndCompressedData := new(bytes.Buffer)
+	framedAndCompressedData.Grow(rawData.Len())
+	w := &xerialWriter{writer: framedAndCompressedData, encode: snappy.Encode}
+	r := simpleReader{bytes.NewReader(rawData.Bytes())}
+	io.Copy(w, r)
+	w.Flush()
+
+	unframedAndDecompressedData := new(bytes.Buffer)
+	unframedAndDecompressedData.Grow(rawData.Len())
+	io.Copy(unframedAndDecompressedData,
+		&xerialReader{reader: framedAndCompressedData, decode: snappy.Decode})
+
+	b0 := rawData.Bytes()
+	b1 := unframedAndDecompressedData.Bytes()
+
+	if !bytes.Equal(b0, b1) {
+		t.Error("data mismatch")
+	}
+}

--- a/snappy/xerial_test.go
+++ b/snappy/xerial_test.go
@@ -67,7 +67,7 @@ func TestXerialFramedCompression(t *testing.T) {
 
 	framedAndCompressedData := new(bytes.Buffer)
 	framedAndCompressedData.Grow(rawData.Len())
-	w := simpleWriter{&xerialWriter{writer: framedAndCompressedData, encode: snappy.Encode}}
+	w := simpleWriter{&xerialWriter{writer: framedAndCompressedData, framed: true, encode: snappy.Encode}}
 	r := simpleReader{bytes.NewReader(rawData.Bytes())}
 	io.Copy(w, r)
 	w.Writer.(*xerialWriter).Flush()
@@ -92,7 +92,7 @@ func TestXerialFramedCompressionOptimized(t *testing.T) {
 
 	framedAndCompressedData := new(bytes.Buffer)
 	framedAndCompressedData.Grow(rawData.Len())
-	w := &xerialWriter{writer: framedAndCompressedData, encode: snappy.Encode}
+	w := &xerialWriter{writer: framedAndCompressedData, framed: true, encode: snappy.Encode}
 	r := simpleReader{bytes.NewReader(rawData.Bytes())}
 	io.Copy(w, r)
 	w.Flush()
@@ -146,7 +146,7 @@ func TestXerialWriterAgainstGoXerialSnappy(t *testing.T) {
 
 	framedAndCompressedData := new(bytes.Buffer)
 	framedAndCompressedData.Grow(rawData.Len())
-	w := &xerialWriter{writer: framedAndCompressedData, encode: snappy.Encode}
+	w := &xerialWriter{writer: framedAndCompressedData, framed: true, encode: snappy.Encode}
 	r := simpleReader{bytes.NewReader(rawData.Bytes())}
 	io.Copy(w, r)
 	w.Flush()

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -4,6 +4,7 @@ package zstd
 
 import (
 	"io"
+	"sync"
 
 	"github.com/DataDog/zstd"
 	kafka "github.com/segmentio/kafka-go"
@@ -21,9 +22,9 @@ type CompressionCodec struct {
 }
 
 const (
-	Code int8 = 4
+	Code = 4
 	// https://github.com/DataDog/zstd/blob/1e382f59b41eebd6f592c5db4fd1958ec38a0eba/zstd.go#L33
-	DefaultCompressionLevel int = 5
+	DefaultCompressionLevel = 5
 )
 
 func NewCompressionCodec() CompressionCodec {
@@ -53,10 +54,150 @@ func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
 
 // NewReader implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
-	return zstd.NewReader(r)
+	return &reader{
+		reader: r,
+		buffer: bufferPool.Get().(*buffer),
+	}
 }
 
 // NewWriter implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) NewWriter(w io.Writer) io.WriteCloser {
-	return zstd.NewWriterLevel(w, c.CompressionLevel)
+	return &writer{
+		writer: w,
+		buffer: bufferPool.Get().(*buffer),
+		level:  c.CompressionLevel,
+	}
+}
+
+type reader struct {
+	reader io.Reader
+	buffer *buffer
+	offset int
+}
+
+func (r *reader) Read(b []byte) (int, error) {
+	if err := r.decompress(); err != nil {
+		return 0, err
+	}
+
+	if r.offset >= len(r.buffer.output) {
+		return 0, io.EOF
+	}
+
+	n := copy(b, r.buffer.output[r.offset:])
+	r.offset += n
+	return n, nil
+}
+
+func (r *reader) WriteTo(w io.Writer) (int64, error) {
+	if err := r.decompress(); err != nil {
+		return 0, err
+	}
+
+	if r.offset >= len(r.buffer.output) {
+		return 0, nil
+	}
+
+	n, err := w.Write(r.buffer.output[r.offset:])
+	r.offset += n
+	return int64(n), err
+}
+
+func (r *reader) Close() (err error) {
+	if b := r.buffer; b != nil {
+		r.buffer = nil
+		b.reset()
+		bufferPool.Put(b)
+	}
+	return
+}
+
+func (r *reader) decompress() (err error) {
+	if r.reader == nil {
+		return
+	}
+
+	b := r.buffer
+
+	if _, err = b.readFrom(r.reader); err != nil {
+		return
+	}
+
+	r.reader = nil
+	b.output, err = zstd.Decompress(b.output[:cap(b.output)], b.input)
+	return
+}
+
+type writer struct {
+	writer io.Writer
+	buffer *buffer
+	level  int
+}
+
+func (w *writer) Write(b []byte) (int, error) {
+	return w.buffer.write(b)
+}
+
+func (w *writer) ReadFrom(r io.Reader) (int64, error) {
+	return w.buffer.readFrom(r)
+}
+
+func (w *writer) Close() (err error) {
+	if b := w.buffer; b != nil {
+		w.buffer = nil
+
+		b.output, err = zstd.Compress(b.output[:cap(b.output)], b.input)
+		if err == nil {
+			_, err = w.writer.Write(b.output)
+		}
+
+		b.reset()
+		bufferPool.Put(b)
+	}
+	return
+}
+
+type buffer struct {
+	input  []byte
+	output []byte
+}
+
+func (b *buffer) reset() {
+	b.input = b.input[:0]
+	b.output = b.output[:0]
+}
+
+func (b *buffer) readFrom(r io.Reader) (int64, error) {
+	prefix := len(b.input)
+
+	for {
+		if len(b.input) == cap(b.input) {
+			tmp := make([]byte, len(b.input), 2*cap(b.input))
+			copy(tmp, b.input)
+			b.input = tmp
+		}
+
+		n, err := r.Read(b.input[len(b.input):cap(b.input)])
+		b.input = b.input[:len(b.input)+n]
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return int64(len(b.input) - prefix), err
+		}
+	}
+}
+
+func (b *buffer) write(data []byte) (int, error) {
+	b.input = append(b.input, data...)
+	return len(data), nil
+}
+
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return &buffer{
+			input:  make([]byte, 0, 32*1024),
+			output: make([]byte, 0, 32*1024),
+		}
+	},
 }

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -3,8 +3,10 @@
 package zstd
 
 import (
+	"io"
+
 	"github.com/DataDog/zstd"
-	"github.com/segmentio/kafka-go"
+	kafka "github.com/segmentio/kafka-go"
 )
 
 func init() {
@@ -47,4 +49,14 @@ func (c CompressionCodec) Encode(src []byte) ([]byte, error) {
 // Decode implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) Decode(src []byte) ([]byte, error) {
 	return zstd.Decompress(nil, src)
+}
+
+// NewReader implements the kafka.CompressionCodec interface.
+func (c CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
+	return zstd.NewReader(r)
+}
+
+// NewWriter implements the kafka.CompressionCodec interface.
+func (c CompressionCodec) NewWriter(w io.Writer) io.WriteCloser {
+	return zstd.NewWriterLevel(w, c.CompressionLevel)
 }

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -42,6 +42,11 @@ func (c CompressionCodec) Code() int8 {
 	return Code
 }
 
+// Name implements the kafka.CompressionCodec interface.
+func (c CompressionCodec) Name() string {
+	return "zstd"
+}
+
 // NewReader implements the kafka.CompressionCodec interface.
 func (c CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
 	return &reader{


### PR DESCRIPTION
This PR modifies the compression codec API to employ `io.Reader` and `io.Writer` instead of working with byte slices. The upside is the amount of memory that gets allocated internally is greatly reduced, and we pave the way for better internal abstractions to build more efficient programs with kafka-go.

This is a breaking change in the API, but I think it's OK since these packages are intended to work with kafka-go, and programs shouldn't use these directly (maybe we'll bump to 0.3.0 on the next release?).

Here are comparisons of the compression benchmarks taken before and after:
```
benchmark                            old ns/op     new ns/op     delta
BenchmarkCompression/GZIP1024        48754         57090         +17.10%
BenchmarkCompression/GZIP4096        116650        110110        -5.61%
BenchmarkCompression/GZIP8192        204592        161450        -21.09%
BenchmarkCompression/GZIP16384       388270        290743        -25.12%
BenchmarkCompression/Snappy1024      533           509           -4.50%
BenchmarkCompression/Snappy4096      1287          1055          -18.03%
BenchmarkCompression/Snappy8192      2361          1732          -26.64%
BenchmarkCompression/Snappy16384     4429          3427          -22.62%
BenchmarkCompression/LZ41024         1033620       2991          -99.71%
BenchmarkCompression/LZ44096         994821        13117         -98.68%
BenchmarkCompression/LZ48192         1063436       28193         -97.35%
BenchmarkCompression/LZ416384        1059942       67983         -93.59%
BenchmarkCompression/zstd1024        11835         12423         +4.97%
BenchmarkCompression/zstd4096        23943         27353         +14.24%
BenchmarkCompression/zstd8192        39247         38990         -0.65%
BenchmarkCompression/zstd16384       70687         69344         -1.90%

benchmark                            old MB/s       new MB/s     speedup
BenchmarkCompression/GZIP1024        16.63          14.17        0.85x
BenchmarkCompression/GZIP4096        26.58          28.19        1.06x
BenchmarkCompression/GZIP8192        30.13          38.20        1.27x
BenchmarkCompression/GZIP16384       31.66          42.27        1.34x
BenchmarkCompression/Snappy1024      1927.83        2057.82      1.07x
BenchmarkCompression/Snappy4096      3185.87        3904.71      1.23x
BenchmarkCompression/Snappy8192      3471.45        4743.12      1.37x
BenchmarkCompression/Snappy16384     3700.07        4788.41      1.29x
BenchmarkCompression/LZ41024         1.01           348.62       345.17x
BenchmarkCompression/LZ44096         4.14           313.71       75.78x
BenchmarkCompression/LZ48192         7.72           291.23       37.72x
BenchmarkCompression/LZ416384        15.48          241.28       15.59x
BenchmarkCompression/zstd1024        68.44          65.20        0.95x
BenchmarkCompression/zstd4096        129.22         113.22       0.88x
BenchmarkCompression/zstd8192        156.60         157.73       1.01x
BenchmarkCompression/zstd16384       173.44         176.77       1.02x

benchmark                            old allocs     new allocs     delta
BenchmarkCompression/GZIP1024        5              4              -20.00%
BenchmarkCompression/GZIP4096        7              4              -42.86%
BenchmarkCompression/GZIP8192        8              4              -50.00%
BenchmarkCompression/GZIP16384       9              4              -55.56%
BenchmarkCompression/Snappy1024      2              2              +0.00%
BenchmarkCompression/Snappy4096      2              2              +0.00%
BenchmarkCompression/Snappy8192      2              2              +0.00%
BenchmarkCompression/Snappy16384     2              2              +0.00%
BenchmarkCompression/LZ41024         18             2              -88.89%
BenchmarkCompression/LZ44096         20             2              -90.00%
BenchmarkCompression/LZ48192         21             2              -90.48%
BenchmarkCompression/LZ416384        22             2              -90.91%
BenchmarkCompression/zstd1024        4              2              -50.00%
BenchmarkCompression/zstd4096        4              2              -50.00%
BenchmarkCompression/zstd8192        4              2              -50.00%
BenchmarkCompression/zstd16384       4              2              -50.00%

benchmark                            old bytes     new bytes     delta
BenchmarkCompression/GZIP1024        4079          110           -97.30%
BenchmarkCompression/GZIP4096        23417         153           -99.35%
BenchmarkCompression/GZIP8192        49863         154           -99.69%
BenchmarkCompression/GZIP16384       101673        243           -99.76%
BenchmarkCompression/Snappy1024      2304          16            -99.31%
BenchmarkCompression/Snappy4096      8960          16            -99.82%
BenchmarkCompression/Snappy8192      17920         16            -99.91%
BenchmarkCompression/Snappy16384     36864         16            -99.96%
BenchmarkCompression/LZ41024         17316671      68            -100.00%
BenchmarkCompression/LZ44096         17341247      278           -100.00%
BenchmarkCompression/LZ48192         17374015      541           -100.00%
BenchmarkCompression/LZ416384        17439551      1331          -99.99%
BenchmarkCompression/zstd1024        2224          65            -97.08%
BenchmarkCompression/zstd4096        9008          66            -99.27%
BenchmarkCompression/zstd8192        17712         66            -99.63%
BenchmarkCompression/zstd16384       34864         71            -99.80%
```

One aspect of this change that I would like to open the conversation on is framing with snappy. We used to support xerial framing on the reader side only, here I implemented framing on the writer side as well, which means the batches produces to kafka will be slightly different than what they are today. Since we were compatible on the reader side already this shouldn't be an issue, however I'm thinking we should probably make it an opt-in feature and still default to the historical behavior by default.

Another aspect is the framing mechanism used by the `github.com/golang/snappy` package is different than the one typically used in kafka programs (xerial), so the snappy-encoded data that we produce cannot be decoded with a `*snappy.Reader`. I wonder if we should offer the ability to support both framing formats.

Let me know what you think!