### PR TITLE
Extract record batch structure

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1057,12 +1057,14 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 			deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
 			switch version := c.apiVersions[produceRequest].MaxVersion; {
 			case version >= 7:
-				recordBatch :=
-					&recordBatch{
-						codec: codec,
-						msgs:  msgs,
-					}
-				recordBatch.init()
+				recordBatch, err :=
+					newRecordBatch(
+						codec,
+						msgs...,
+					)
+				if err != nil {
+					return err
+				}
 				return c.wb.writeProduceRequestV7(
 					id,
 					c.clientID,
@@ -1074,12 +1076,14 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 					recordBatch,
 				)
 			case version >= 3:
-				recordBatch :=
-					&recordBatch{
-						codec: codec,
-						msgs:  msgs,
-					}
-				recordBatch.init()
+				recordBatch, err :=
+					newRecordBatch(
+						codec,
+						msgs...,
+					)
+				if err != nil {
+					return err
+				}
 				return c.wb.writeProduceRequestV3(
 					id,
 					c.clientID,

--- a/conn.go
+++ b/conn.go
@@ -1070,7 +1070,6 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 				)
 			case version >= 3:
 				return c.wb.writeProduceRequestV3(
-					codec,
 					id,
 					c.clientID,
 					c.topic,
@@ -1078,7 +1077,10 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 					deadlineToTimeout(deadline, now),
 					int16(atomic.LoadInt32(&c.requiredAcks)),
 					c.transactionalID,
-					msgs...,
+					&recordBatch{
+						codec: codec,
+						msgs:  msgs,
+					},
 				)
 			default:
 				return c.wb.writeProduceRequestV2(

--- a/conn.go
+++ b/conn.go
@@ -1069,6 +1069,12 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 					msgs...,
 				)
 			case version >= 3:
+				recordBatch :=
+					&recordBatch{
+						codec: codec,
+						msgs:  msgs,
+					}
+				recordBatch.init()
 				return c.wb.writeProduceRequestV3(
 					id,
 					c.clientID,
@@ -1077,10 +1083,7 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 					deadlineToTimeout(deadline, now),
 					int16(atomic.LoadInt32(&c.requiredAcks)),
 					c.transactionalID,
-					&recordBatch{
-						codec: codec,
-						msgs:  msgs,
-					},
+					recordBatch,
 				)
 			default:
 				return c.wb.writeProduceRequestV2(

--- a/conn.go
+++ b/conn.go
@@ -1057,8 +1057,13 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 			deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
 			switch version := c.apiVersions[produceRequest].MaxVersion; {
 			case version >= 7:
+				recordBatch :=
+					&recordBatch{
+						codec: codec,
+						msgs:  msgs,
+					}
+				recordBatch.init()
 				return c.wb.writeProduceRequestV7(
-					codec,
 					id,
 					c.clientID,
 					c.topic,
@@ -1066,7 +1071,7 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 					deadlineToTimeout(deadline, now),
 					int16(atomic.LoadInt32(&c.requiredAcks)),
 					c.transactionalID,
-					msgs...,
+					recordBatch,
 				)
 			case version >= 3:
 				recordBatch :=

--- a/recordbatch.go
+++ b/recordbatch.go
@@ -63,7 +63,11 @@ type recordBatch struct {
 	size       int32
 }
 
-func (r *recordBatch) init() (err error) {
+func newRecordBatch(codec CompressionCodec, msgs ...Message) (r *recordBatch, err error) {
+	r = &recordBatch{
+		codec: codec,
+		msgs:  msgs,
+	}
 	if r.codec == nil {
 		r.size = recordBatchSize(r.msgs...)
 	} else {

--- a/recordbatch.go
+++ b/recordbatch.go
@@ -1,0 +1,59 @@
+package kafka
+
+import (
+	"bytes"
+)
+
+const recordBatchHeaderSize int32 = 0 +
+	8 + // base offset
+	4 + // batch length
+	4 + // partition leader epoch
+	1 + // magic
+	4 + // crc
+	2 + // attributes
+	4 + // last offset delta
+	8 + // first timestamp
+	8 + // max timestamp
+	8 + // producer id
+	2 + // producer epoch
+	4 + // base sequence
+	4 // msg count
+
+func recordBatchSize(msgs ...Message) (size int32) {
+	size = recordBatchHeaderSize
+	baseTime := msgs[0].Time
+
+	for i := range msgs {
+		msg := &msgs[i]
+		msz := recordSize(msg, msg.Time.Sub(baseTime), int64(i))
+		size += int32(msz + varIntLen(int64(msz)))
+	}
+
+	return
+}
+
+func compressRecordBatch(codec CompressionCodec, msgs ...Message) (compressed *bytes.Buffer, attributes int16, size int32, err error) {
+	compressed = acquireBuffer()
+	compressor := codec.NewWriter(compressed)
+	wb := &writeBuffer{w: compressor}
+
+	for i, msg := range msgs {
+		wb.writeRecord(0, msgs[0].Time, int64(i), msg)
+	}
+
+	if err = compressor.Close(); err != nil {
+		releaseBuffer(compressed)
+		return
+	}
+
+	attributes = int16(codec.Code())
+	size = recordBatchHeaderSize + int32(compressed.Len())
+	return
+}
+
+type recordBatch struct {
+	codec      CompressionCodec
+	attributes int16
+	msgs       []Message
+	compressed *bytes.Buffer
+}

--- a/recordbatch.go
+++ b/recordbatch.go
@@ -52,8 +52,21 @@ func compressRecordBatch(codec CompressionCodec, msgs ...Message) (compressed *b
 }
 
 type recordBatch struct {
+	// required input parameters
 	codec      CompressionCodec
 	attributes int16
 	msgs       []Message
+
+	// parameters calculated during init
 	compressed *bytes.Buffer
+	size       int32
+}
+
+func (r *recordBatch) init() (err error) {
+	if r.codec == nil {
+		r.size = recordBatchSize(r.msgs...)
+	} else {
+		r.compressed, r.attributes, r.size, err = compressRecordBatch(r.codec, r.msgs...)
+	}
+	return
 }

--- a/write.go
+++ b/write.go
@@ -413,21 +413,8 @@ func (wb *writeBuffer) writeProduceRequestV3(correlationID int32, clientID, topi
 	wb.writeInt32(partition)
 
 	wb.writeInt32(recordBatch.size)
-	baseTime := recordBatch.msgs[0].Time
-	lastTime := recordBatch.msgs[len(recordBatch.msgs)-1].Time
 
-	if recordBatch.compressed != nil {
-		wb.writeRecordBatch(recordBatch.attributes, recordBatch.size, len(recordBatch.msgs), baseTime, lastTime, func(wb *writeBuffer) {
-			wb.Write(recordBatch.compressed.Bytes())
-		})
-		releaseBuffer(recordBatch.compressed)
-	} else {
-		wb.writeRecordBatch(recordBatch.attributes, recordBatch.size, len(recordBatch.msgs), baseTime, lastTime, func(wb *writeBuffer) {
-			for i, msg := range recordBatch.msgs {
-				wb.writeRecord(0, recordBatch.msgs[0].Time, int64(i), msg)
-			}
-		})
-	}
+	recordBatch.writeTo(wb)
 
 	return wb.Flush()
 }


### PR DESCRIPTION
@achille-roussel @stevevls Would you be willing to merge this refactoring?

As I was working on adding transaction support to batches I realized that constructing batches deep in the invocation stack is very tedious as all their parameters should be passed to V3 and V7 functions.

I extracted record batch structure and now it's constructed one level above the writeProduceRequest functions. This way if we need to add arguments to recordBatches we can do it without touching signatures of writeProduceRequest functions. 