### PR TITLE
Use RequestTimedOut on empty batch instead of errShortRead

### DIFF
--- a/message.go
+++ b/message.go
@@ -119,7 +119,7 @@ func (r *messageSetReader) readMessage(min int64,
 	val func(*bufio.Reader, int, int) (int, error),
 ) (offset int64, timestamp int64, headers []Header, err error) {
 	if r.empty {
-		return 0, 0, nil, errShortRead
+		return 0, 0, nil, RequestTimedOut
 	}
 	switch r.version {
 	case 1:

--- a/message_test.go
+++ b/message_test.go
@@ -22,8 +22,8 @@ func TestMessageSetReaderEmpty(t *testing.T) {
 	if headers != nil {
 		t.Errorf("expected nil headers, got %v", headers)
 	}
-	if err != errShortRead {
-		t.Errorf("expected errShortRead, got %v", err)
+	if err != RequestTimedOut {
+		t.Errorf("expected RequestTimedOut, got %v", err)
 	}
 
 	if m.remaining() != 0 {


### PR DESCRIPTION
This should better capture the spirit of the empty batch by
surfacing the error code that indicates the broker wasn't able to
return new messages before the max wait time passes.