### PR TITLE
kafka.writeBuffer

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -55,6 +55,7 @@ type Conn struct {
 	// write buffer (synchronized on wlock)
 	wlock sync.Mutex
 	wbuf  bufio.Writer
+	wb    writeBuffer
 
 	// deadline management
 	wdeadline connDeadline
@@ -150,8 +151,6 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 
 	c := &Conn{
 		conn:            conn,
-		rbuf:            *bufio.NewReader(conn),
-		wbuf:            *bufio.NewWriter(conn),
 		clientID:        config.ClientID,
 		topic:           config.Topic,
 		partition:       int32(config.Partition),
@@ -159,6 +158,10 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 		requiredAcks:    -1,
 		transactionalID: emptyToNullable(config.TransactionalID),
 	}
+
+	c.rbuf.Reset(conn)
+	c.wbuf.Reset(conn)
+	c.wb.w = &c.wbuf
 
 	// The fetch request needs to ask for a MaxBytes value that is at least
 	// enough to load the control data of the response. To avoid having to
@@ -767,8 +770,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 		adjustedDeadline = deadline
 		switch c.fetchVersion {
 		case v10:
-			return writeFetchRequestV10(
-				&c.wbuf,
+			return c.wb.writeFetchRequestV10(
 				id,
 				c.clientID,
 				c.topic,
@@ -780,8 +782,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 				int8(cfg.IsolationLevel),
 			)
 		case v5:
-			return writeFetchRequestV5(
-				&c.wbuf,
+			return c.wb.writeFetchRequestV5(
 				id,
 				c.clientID,
 				c.topic,
@@ -793,8 +794,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 				int8(cfg.IsolationLevel),
 			)
 		default:
-			return writeFetchRequestV2(
-				&c.wbuf,
+			return c.wb.writeFetchRequestV2(
 				id,
 				c.clientID,
 				c.topic,
@@ -891,7 +891,7 @@ func (c *Conn) ReadOffsets() (first, last int64, err error) {
 func (c *Conn) readOffset(t int64) (offset int64, err error) {
 	err = c.readOperation(
 		func(deadline time.Time, id int32) error {
-			return writeListOffsetRequestV1(&c.wbuf, id, c.clientID, c.topic, c.partition, t)
+			return c.wb.writeListOffsetRequestV1(id, c.clientID, c.topic, c.partition, t)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(readArrayWith(&c.rbuf, size, func(r *bufio.Reader, size int) (int, error) {
@@ -1058,8 +1058,7 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 			deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
 			switch version := c.apiVersions[produceRequest].MaxVersion; {
 			case version >= 7:
-				return writeProduceRequestV7(
-					&c.wbuf,
+				return c.wb.writeProduceRequestV7(
 					codec,
 					id,
 					c.clientID,
@@ -1071,8 +1070,7 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 					msgs...,
 				)
 			case version >= 3:
-				return writeProduceRequestV3(
-					&c.wbuf,
+				return c.wb.writeProduceRequestV3(
 					codec,
 					id,
 					c.clientID,
@@ -1084,8 +1082,7 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 					msgs...,
 				)
 			default:
-				return writeProduceRequestV2(
-					&c.wbuf,
+				return c.wb.writeProduceRequestV2(
 					codec,
 					id,
 					c.clientID,
@@ -1170,14 +1167,14 @@ func (c *Conn) SetRequiredAcks(n int) error {
 func (c *Conn) writeRequestHeader(apiKey apiKey, apiVersion apiVersion, correlationID int32, size int32) {
 	hdr := c.requestHeader(apiKey, apiVersion, correlationID)
 	hdr.Size = (hdr.size() + size) - 4
-	hdr.writeTo(&c.wbuf)
+	hdr.writeTo(&c.wb)
 }
 
 func (c *Conn) writeRequest(apiKey apiKey, apiVersion apiVersion, correlationID int32, req request) error {
 	hdr := c.requestHeader(apiKey, apiVersion, correlationID)
 	hdr.Size = (hdr.size() + req.size()) - 4
-	hdr.writeTo(&c.wbuf)
-	req.writeTo(&c.wbuf)
+	hdr.writeTo(&c.wb)
+	req.writeTo(&c.wb)
 	return c.wbuf.Flush()
 }
 
@@ -1369,7 +1366,7 @@ func (c *Conn) ApiVersions() ([]ApiVersion, error) {
 		}
 		h.Size = (h.size() - 4)
 
-		h.writeTo(&c.wbuf)
+		h.writeTo(&c.wb)
 		return c.wbuf.Flush()
 	})
 	if err != nil {
@@ -1538,11 +1535,11 @@ func (c *Conn) saslAuthenticate(data []byte) ([]byte, error) {
 
 	// fall back to opaque bytes on the wire.  the broker is expecting these if
 	// it just processed a v0 sasl handshake.
-	writeInt32(&c.wbuf, int32(len(data)))
-	if _, err := c.wbuf.Write(data); err != nil {
+	c.wb.writeInt32(int32(len(data)))
+	if _, err := c.wb.Write(data); err != nil {
 		return nil, err
 	}
-	if err := c.wbuf.Flush(); err != nil {
+	if err := c.wb.Flush(); err != nil {
 		return nil, err
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -151,6 +151,8 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 
 	c := &Conn{
 		conn:            conn,
+		rbuf:            *bufio.NewReader(conn),
+		wbuf:            *bufio.NewWriter(conn),
 		clientID:        config.ClientID,
 		topic:           config.Topic,
 		partition:       int32(config.Partition),
@@ -159,8 +161,6 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 		transactionalID: emptyToNullable(config.TransactionalID),
 	}
 
-	c.rbuf.Reset(conn)
-	c.wbuf.Reset(conn)
 	c.wb.w = &c.wbuf
 
 	// The fetch request needs to ask for a MaxBytes value that is at least

--- a/crc32.go
+++ b/crc32.go
@@ -1,118 +1,61 @@
 package kafka
 
 import (
-	"bytes"
 	"encoding/binary"
 	"hash/crc32"
 	"io"
-	"sync"
 )
 
 type crc32Writer struct {
+	table  *crc32.Table
+	buffer [8]byte
 	crc32  uint32
-	writer *writeBuffer
+}
+
+func (w *crc32Writer) update(b []byte) {
+	w.crc32 = crc32.Update(w.crc32, w.table, b)
+}
+
+func (w *crc32Writer) writeInt8(i int8) {
+	w.buffer[0] = byte(i)
+	w.update(w.buffer[:1])
 }
 
 func (w *crc32Writer) writeInt16(i int16) {
-	w.writer.writeInt16(i)
-	w.crc32 = crc32Update(w.crc32, w.writer.b[:2])
+	binary.BigEndian.PutUint16(w.buffer[:2], uint16(i))
+	w.update(w.buffer[:2])
 }
 
 func (w *crc32Writer) writeInt32(i int32) {
-	w.writer.writeInt32(i)
-	w.crc32 = crc32Update(w.crc32, w.writer.b[:4])
+	binary.BigEndian.PutUint32(w.buffer[:4], uint32(i))
+	w.update(w.buffer[:4])
 }
 
 func (w *crc32Writer) writeInt64(i int64) {
-	w.writer.writeInt64(i)
-	w.crc32 = crc32Update(w.crc32, w.writer.b[:8])
+	binary.BigEndian.PutUint64(w.buffer[:8], uint64(i))
+	w.update(w.buffer[:8])
+}
+
+func (w *crc32Writer) writeBytes(b []byte) {
+	n := len(b)
+	if b == nil {
+		n = -1
+	}
+	w.writeInt32(int32(n))
+	w.update(b)
 }
 
 func (w *crc32Writer) Write(b []byte) (int, error) {
-	n, err := w.writer.Write(b)
-	w.crc32 = crc32Update(w.crc32, b[:n])
-	return n, err
+	w.update(b)
+	return len(b), nil
 }
 
 func (w *crc32Writer) WriteString(s string) (int, error) {
-	n, err := w.writer.WriteString(s)
-	w.crc32 = crc32Update(w.crc32, []byte(s[:n]))
-	return n, err
+	w.update([]byte(s))
+	return len(s), nil
 }
 
 var (
 	_ io.Writer       = (*crc32Writer)(nil)
 	_ io.StringWriter = (*crc32Writer)(nil)
 )
-
-func crc32OfMessage(magicByte int8, attributes int8, timestamp int64, key []byte, value []byte) uint32 {
-	b := acquireCrc32Buffer()
-	b.writeInt8(magicByte)
-	b.writeInt8(attributes)
-	if magicByte != 0 {
-		b.writeInt64(timestamp)
-	}
-	b.writeBytes(key)
-	b.writeBytes(value)
-	sum := b.sum
-	releaseCrc32Buffer(b)
-	return sum
-}
-
-type crc32Buffer struct {
-	sum uint32
-	buf bytes.Buffer
-}
-
-func (c *crc32Buffer) writeInt8(i int8) {
-	c.buf.Truncate(0)
-	c.buf.WriteByte(byte(i))
-	c.update()
-}
-
-func (c *crc32Buffer) writeInt32(i int32) {
-	a := [4]byte{}
-	binary.BigEndian.PutUint32(a[:], uint32(i))
-	c.buf.Truncate(0)
-	c.buf.Write(a[:])
-	c.update()
-}
-
-func (c *crc32Buffer) writeInt64(i int64) {
-	a := [8]byte{}
-	binary.BigEndian.PutUint64(a[:], uint64(i))
-	c.buf.Truncate(0)
-	c.buf.Write(a[:])
-	c.update()
-}
-
-func (c *crc32Buffer) writeBytes(b []byte) {
-	if b == nil {
-		c.writeInt32(-1)
-	} else {
-		c.writeInt32(int32(len(b)))
-	}
-	c.sum = crc32Update(c.sum, b)
-}
-
-func (c *crc32Buffer) update() {
-	c.sum = crc32Update(c.sum, c.buf.Bytes())
-}
-
-func crc32Update(sum uint32, b []byte) uint32 {
-	return crc32.Update(sum, crc32.MakeTable(crc32.Castagnoli), b)
-}
-
-var crc32BufferPool = sync.Pool{
-	New: func() interface{} { return &crc32Buffer{} },
-}
-
-func acquireCrc32Buffer() *crc32Buffer {
-	c := crc32BufferPool.Get().(*crc32Buffer)
-	c.sum = 0
-	return c
-}
-
-func releaseCrc32Buffer(b *crc32Buffer) {
-	crc32BufferPool.Put(b)
-}

--- a/crc32_test.go
+++ b/crc32_test.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"bufio"
 	"bytes"
 	"hash/crc32"
 	"testing"
@@ -18,11 +17,10 @@ func TestMessageCRC32(t *testing.T) {
 	}
 
 	b := &bytes.Buffer{}
-	w := bufio.NewWriter(b)
-	write(w, m)
-	w.Flush()
+	w := &writeBuffer{w: b}
+	w.write(m)
 
-	h := crc32.NewIEEE()
+	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	h.Write(b.Bytes()[4:])
 
 	sum1 := h.Sum32()

--- a/crc32_test.go
+++ b/crc32_test.go
@@ -20,11 +20,11 @@ func TestMessageCRC32(t *testing.T) {
 	w := &writeBuffer{w: b}
 	w.write(m)
 
-	h := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	h := crc32.New(crc32.IEEETable)
 	h.Write(b.Bytes()[4:])
 
 	sum1 := h.Sum32()
-	sum2 := uint32(m.crc32())
+	sum2 := uint32(m.crc32(&crc32Writer{table: crc32.IEEETable}))
 
 	if sum1 != sum2 {
 		t.Error("bad CRC32:")

--- a/createtopics.go
+++ b/createtopics.go
@@ -27,9 +27,9 @@ func (t createTopicsRequestV0ConfigEntry) size() int32 {
 		sizeofString(t.ConfigValue)
 }
 
-func (t createTopicsRequestV0ConfigEntry) writeTo(w *bufio.Writer) {
-	writeString(w, t.ConfigName)
-	writeString(w, t.ConfigValue)
+func (t createTopicsRequestV0ConfigEntry) writeTo(wb *writeBuffer) {
+	wb.writeString(t.ConfigName)
+	wb.writeString(t.ConfigValue)
 }
 
 type ReplicaAssignment struct {
@@ -54,9 +54,9 @@ func (t createTopicsRequestV0ReplicaAssignment) size() int32 {
 		sizeofInt32(t.Replicas)
 }
 
-func (t createTopicsRequestV0ReplicaAssignment) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.Partition)
-	writeInt32(w, t.Replicas)
+func (t createTopicsRequestV0ReplicaAssignment) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.Partition)
+	wb.writeInt32(t.Replicas)
 }
 
 type TopicConfig struct {
@@ -126,12 +126,12 @@ func (t createTopicsRequestV0Topic) size() int32 {
 		sizeofArray(len(t.ConfigEntries), func(i int) int32 { return t.ConfigEntries[i].size() })
 }
 
-func (t createTopicsRequestV0Topic) writeTo(w *bufio.Writer) {
-	writeString(w, t.Topic)
-	writeInt32(w, t.NumPartitions)
-	writeInt16(w, t.ReplicationFactor)
-	writeArray(w, len(t.ReplicaAssignments), func(i int) { t.ReplicaAssignments[i].writeTo(w) })
-	writeArray(w, len(t.ConfigEntries), func(i int) { t.ConfigEntries[i].writeTo(w) })
+func (t createTopicsRequestV0Topic) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Topic)
+	wb.writeInt32(t.NumPartitions)
+	wb.writeInt16(t.ReplicationFactor)
+	wb.writeArray(len(t.ReplicaAssignments), func(i int) { t.ReplicaAssignments[i].writeTo(wb) })
+	wb.writeArray(len(t.ConfigEntries), func(i int) { t.ConfigEntries[i].writeTo(wb) })
 }
 
 // See http://kafka.apache.org/protocol.html#The_Messages_CreateTopics
@@ -150,9 +150,9 @@ func (t createTopicsRequestV0) size() int32 {
 		sizeofInt32(t.Timeout)
 }
 
-func (t createTopicsRequestV0) writeTo(w *bufio.Writer) {
-	writeArray(w, len(t.Topics), func(i int) { t.Topics[i].writeTo(w) })
-	writeInt32(w, t.Timeout)
+func (t createTopicsRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.Topics), func(i int) { t.Topics[i].writeTo(wb) })
+	wb.writeInt32(t.Timeout)
 }
 
 type createTopicsResponseV0TopicError struct {
@@ -168,9 +168,9 @@ func (t createTopicsResponseV0TopicError) size() int32 {
 		sizeofInt16(t.ErrorCode)
 }
 
-func (t createTopicsResponseV0TopicError) writeTo(w *bufio.Writer) {
-	writeString(w, t.Topic)
-	writeInt16(w, t.ErrorCode)
+func (t createTopicsResponseV0TopicError) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Topic)
+	wb.writeInt16(t.ErrorCode)
 }
 
 func (t *createTopicsResponseV0TopicError) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -192,8 +192,8 @@ func (t createTopicsResponseV0) size() int32 {
 	return sizeofArray(len(t.TopicErrors), func(i int) int32 { return t.TopicErrors[i].size() })
 }
 
-func (t createTopicsResponseV0) writeTo(w *bufio.Writer) {
-	writeArray(w, len(t.TopicErrors), func(i int) { t.TopicErrors[i].writeTo(w) })
+func (t createTopicsResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.TopicErrors), func(i int) { t.TopicErrors[i].writeTo(wb) })
 }
 
 func (t *createTopicsResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {

--- a/createtopics_test.go
+++ b/createtopics_test.go
@@ -17,13 +17,12 @@ func TestCreateTopicsResponseV0(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found createTopicsResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/deletetopics.go
+++ b/deletetopics.go
@@ -21,9 +21,9 @@ func (t deleteTopicsRequestV0) size() int32 {
 		sizeofInt32(t.Timeout)
 }
 
-func (t deleteTopicsRequestV0) writeTo(w *bufio.Writer) {
-	writeStringArray(w, t.Topics)
-	writeInt32(w, t.Timeout)
+func (t deleteTopicsRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeStringArray(t.Topics)
+	wb.writeInt32(t.Timeout)
 }
 
 type deleteTopicsResponseV0 struct {
@@ -50,8 +50,8 @@ func (t *deleteTopicsResponseV0) readFrom(r *bufio.Reader, size int) (remain int
 	return
 }
 
-func (t deleteTopicsResponseV0) writeTo(w *bufio.Writer) {
-	writeArray(w, len(t.TopicErrorCodes), func(i int) { t.TopicErrorCodes[i].writeTo(w) })
+func (t deleteTopicsResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.TopicErrorCodes), func(i int) { t.TopicErrorCodes[i].writeTo(wb) })
 }
 
 type deleteTopicsResponseV0TopicErrorCode struct {
@@ -77,9 +77,9 @@ func (t *deleteTopicsResponseV0TopicErrorCode) readFrom(r *bufio.Reader, size in
 	return
 }
 
-func (t deleteTopicsResponseV0TopicErrorCode) writeTo(w *bufio.Writer) {
-	writeString(w, t.Topic)
-	writeInt16(w, t.ErrorCode)
+func (t deleteTopicsResponseV0TopicErrorCode) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Topic)
+	wb.writeInt16(t.ErrorCode)
 }
 
 // deleteTopics deletes the specified topics.

--- a/deletetopics_test.go
+++ b/deletetopics_test.go
@@ -17,13 +17,12 @@ func TestDeleteTopicsResponseV1(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found deleteTopicsResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/describegroups.go
+++ b/describegroups.go
@@ -13,8 +13,8 @@ func (t describeGroupsRequestV0) size() int32 {
 	return sizeofStringArray(t.GroupIDs)
 }
 
-func (t describeGroupsRequestV0) writeTo(w *bufio.Writer) {
-	writeStringArray(w, t.GroupIDs)
+func (t describeGroupsRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeStringArray(t.GroupIDs)
 }
 
 type describeGroupsResponseMemberV0 struct {
@@ -47,12 +47,12 @@ func (t describeGroupsResponseMemberV0) size() int32 {
 		sizeofBytes(t.MemberAssignments)
 }
 
-func (t describeGroupsResponseMemberV0) writeTo(w *bufio.Writer) {
-	writeString(w, t.MemberID)
-	writeString(w, t.ClientID)
-	writeString(w, t.ClientHost)
-	writeBytes(w, t.MemberMetadata)
-	writeBytes(w, t.MemberAssignments)
+func (t describeGroupsResponseMemberV0) writeTo(wb *writeBuffer) {
+	wb.writeString(t.MemberID)
+	wb.writeString(t.ClientID)
+	wb.writeString(t.ClientHost)
+	wb.writeBytes(t.MemberMetadata)
+	wb.writeBytes(t.MemberAssignments)
 }
 
 func (t *describeGroupsResponseMemberV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -105,13 +105,13 @@ func (t describeGroupsResponseGroupV0) size() int32 {
 		sizeofArray(len(t.Members), func(i int) int32 { return t.Members[i].size() })
 }
 
-func (t describeGroupsResponseGroupV0) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
-	writeString(w, t.GroupID)
-	writeString(w, t.State)
-	writeString(w, t.ProtocolType)
-	writeString(w, t.Protocol)
-	writeArray(w, len(t.Members), func(i int) { t.Members[i].writeTo(w) })
+func (t describeGroupsResponseGroupV0) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	wb.writeString(t.GroupID)
+	wb.writeString(t.State)
+	wb.writeString(t.ProtocolType)
+	wb.writeString(t.Protocol)
+	wb.writeArray(len(t.Members), func(i int) { t.Members[i].writeTo(wb) })
 }
 
 func (t *describeGroupsResponseGroupV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -155,8 +155,8 @@ func (t describeGroupsResponseV0) size() int32 {
 	return sizeofArray(len(t.Groups), func(i int) int32 { return t.Groups[i].size() })
 }
 
-func (t describeGroupsResponseV0) writeTo(w *bufio.Writer) {
-	writeArray(w, len(t.Groups), func(i int) { t.Groups[i].writeTo(w) })
+func (t describeGroupsResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.Groups), func(i int) { t.Groups[i].writeTo(wb) })
 }
 
 func (t *describeGroupsResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {

--- a/describegroups_test.go
+++ b/describegroups_test.go
@@ -29,13 +29,12 @@ func TestDescribeGroupsResponseV0(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found describeGroupsResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/fetch.go
+++ b/fetch.go
@@ -1,7 +1,5 @@
 package kafka
 
-import "bufio"
-
 type fetchRequestV2 struct {
 	ReplicaID   int32
 	MaxWaitTime int32
@@ -13,11 +11,11 @@ func (r fetchRequestV2) size() int32 {
 	return 4 + 4 + 4 + sizeofArray(len(r.Topics), func(i int) int32 { return r.Topics[i].size() })
 }
 
-func (r fetchRequestV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, r.ReplicaID)
-	writeInt32(w, r.MaxWaitTime)
-	writeInt32(w, r.MinBytes)
-	writeArray(w, len(r.Topics), func(i int) { r.Topics[i].writeTo(w) })
+func (r fetchRequestV2) writeTo(wb *writeBuffer) {
+	wb.writeInt32(r.ReplicaID)
+	wb.writeInt32(r.MaxWaitTime)
+	wb.writeInt32(r.MinBytes)
+	wb.writeArray(len(r.Topics), func(i int) { r.Topics[i].writeTo(wb) })
 }
 
 type fetchRequestTopicV2 struct {
@@ -30,9 +28,9 @@ func (t fetchRequestTopicV2) size() int32 {
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t fetchRequestTopicV2) writeTo(w *bufio.Writer) {
-	writeString(w, t.TopicName)
-	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
+func (t fetchRequestTopicV2) writeTo(wb *writeBuffer) {
+	wb.writeString(t.TopicName)
+	wb.writeArray(len(t.Partitions), func(i int) { t.Partitions[i].writeTo(wb) })
 }
 
 type fetchRequestPartitionV2 struct {
@@ -45,10 +43,10 @@ func (p fetchRequestPartitionV2) size() int32 {
 	return 4 + 8 + 4
 }
 
-func (p fetchRequestPartitionV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, p.Partition)
-	writeInt64(w, p.FetchOffset)
-	writeInt32(w, p.MaxBytes)
+func (p fetchRequestPartitionV2) writeTo(wb *writeBuffer) {
+	wb.writeInt32(p.Partition)
+	wb.writeInt64(p.FetchOffset)
+	wb.writeInt32(p.MaxBytes)
 }
 
 type fetchResponseV2 struct {
@@ -60,9 +58,9 @@ func (r fetchResponseV2) size() int32 {
 	return 4 + sizeofArray(len(r.Topics), func(i int) int32 { return r.Topics[i].size() })
 }
 
-func (r fetchResponseV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, r.ThrottleTime)
-	writeArray(w, len(r.Topics), func(i int) { r.Topics[i].writeTo(w) })
+func (r fetchResponseV2) writeTo(wb *writeBuffer) {
+	wb.writeInt32(r.ThrottleTime)
+	wb.writeArray(len(r.Topics), func(i int) { r.Topics[i].writeTo(wb) })
 }
 
 type fetchResponseTopicV2 struct {
@@ -75,9 +73,9 @@ func (t fetchResponseTopicV2) size() int32 {
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t fetchResponseTopicV2) writeTo(w *bufio.Writer) {
-	writeString(w, t.TopicName)
-	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
+func (t fetchResponseTopicV2) writeTo(wb *writeBuffer) {
+	wb.writeString(t.TopicName)
+	wb.writeArray(len(t.Partitions), func(i int) { t.Partitions[i].writeTo(wb) })
 }
 
 type fetchResponsePartitionV2 struct {
@@ -92,10 +90,10 @@ func (p fetchResponsePartitionV2) size() int32 {
 	return 4 + 2 + 8 + 4 + p.MessageSet.size()
 }
 
-func (p fetchResponsePartitionV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, p.Partition)
-	writeInt16(w, p.ErrorCode)
-	writeInt64(w, p.HighwaterMarkOffset)
-	writeInt32(w, p.MessageSetSize)
-	p.MessageSet.writeTo(w)
+func (p fetchResponsePartitionV2) writeTo(wb *writeBuffer) {
+	wb.writeInt32(p.Partition)
+	wb.writeInt16(p.ErrorCode)
+	wb.writeInt64(p.HighwaterMarkOffset)
+	wb.writeInt32(p.MessageSetSize)
+	p.MessageSet.writeTo(wb)
 }

--- a/findcoordinator.go
+++ b/findcoordinator.go
@@ -17,8 +17,8 @@ func (t findCoordinatorRequestV0) size() int32 {
 	return sizeofString(t.CoordinatorKey)
 }
 
-func (t findCoordinatorRequestV0) writeTo(w *bufio.Writer) {
-	writeString(w, t.CoordinatorKey)
+func (t findCoordinatorRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeString(t.CoordinatorKey)
 }
 
 type findCoordinatorResponseCoordinatorV0 struct {
@@ -38,10 +38,10 @@ func (t findCoordinatorResponseCoordinatorV0) size() int32 {
 		sizeofInt32(t.Port)
 }
 
-func (t findCoordinatorResponseCoordinatorV0) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.NodeID)
-	writeString(w, t.Host)
-	writeInt32(w, t.Port)
+func (t findCoordinatorResponseCoordinatorV0) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.NodeID)
+	wb.writeString(t.Host)
+	wb.writeInt32(t.Port)
 }
 
 func (t *findCoordinatorResponseCoordinatorV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -70,9 +70,9 @@ func (t findCoordinatorResponseV0) size() int32 {
 		t.Coordinator.size()
 }
 
-func (t findCoordinatorResponseV0) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
-	t.Coordinator.writeTo(w)
+func (t findCoordinatorResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	t.Coordinator.writeTo(wb)
 }
 
 func (t *findCoordinatorResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -17,13 +17,12 @@ func TestFindCoordinatorResponseV0(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found findCoordinatorResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -19,10 +19,10 @@ func (t heartbeatRequestV0) size() int32 {
 		sizeofString(t.MemberID)
 }
 
-func (t heartbeatRequestV0) writeTo(w *bufio.Writer) {
-	writeString(w, t.GroupID)
-	writeInt32(w, t.GenerationID)
-	writeString(w, t.MemberID)
+func (t heartbeatRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeString(t.GroupID)
+	wb.writeInt32(t.GenerationID)
+	wb.writeString(t.MemberID)
 }
 
 type heartbeatResponseV0 struct {
@@ -34,8 +34,8 @@ func (t heartbeatResponseV0) size() int32 {
 	return sizeofInt16(t.ErrorCode)
 }
 
-func (t heartbeatResponseV0) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
+func (t heartbeatResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
 }
 
 func (t *heartbeatResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -12,13 +12,12 @@ func TestHeartbeatRequestV0(t *testing.T) {
 		ErrorCode: 2,
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found heartbeatResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/joingroup.go
+++ b/joingroup.go
@@ -24,17 +24,15 @@ func (t groupMetadata) size() int32 {
 		sizeofBytes(t.UserData)
 }
 
-func (t groupMetadata) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.Version)
-	writeStringArray(w, t.Topics)
-	writeBytes(w, t.UserData)
+func (t groupMetadata) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.Version)
+	wb.writeStringArray(t.Topics)
+	wb.writeBytes(t.UserData)
 }
 
 func (t groupMetadata) bytes() []byte {
 	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
-	t.writeTo(w)
-	w.Flush()
+	t.writeTo(&writeBuffer{w: buf})
 	return buf.Bytes()
 }
 
@@ -61,9 +59,9 @@ func (t joinGroupRequestGroupProtocolV1) size() int32 {
 		sizeofBytes(t.ProtocolMetadata)
 }
 
-func (t joinGroupRequestGroupProtocolV1) writeTo(w *bufio.Writer) {
-	writeString(w, t.ProtocolName)
-	writeBytes(w, t.ProtocolMetadata)
+func (t joinGroupRequestGroupProtocolV1) writeTo(wb *writeBuffer) {
+	wb.writeString(t.ProtocolName)
+	wb.writeBytes(t.ProtocolMetadata)
 }
 
 type joinGroupRequestV1 struct {
@@ -98,13 +96,13 @@ func (t joinGroupRequestV1) size() int32 {
 		sizeofArray(len(t.GroupProtocols), func(i int) int32 { return t.GroupProtocols[i].size() })
 }
 
-func (t joinGroupRequestV1) writeTo(w *bufio.Writer) {
-	writeString(w, t.GroupID)
-	writeInt32(w, t.SessionTimeout)
-	writeInt32(w, t.RebalanceTimeout)
-	writeString(w, t.MemberID)
-	writeString(w, t.ProtocolType)
-	writeArray(w, len(t.GroupProtocols), func(i int) { t.GroupProtocols[i].writeTo(w) })
+func (t joinGroupRequestV1) writeTo(wb *writeBuffer) {
+	wb.writeString(t.GroupID)
+	wb.writeInt32(t.SessionTimeout)
+	wb.writeInt32(t.RebalanceTimeout)
+	wb.writeString(t.MemberID)
+	wb.writeString(t.ProtocolType)
+	wb.writeArray(len(t.GroupProtocols), func(i int) { t.GroupProtocols[i].writeTo(wb) })
 }
 
 type joinGroupResponseMemberV1 struct {
@@ -118,9 +116,9 @@ func (t joinGroupResponseMemberV1) size() int32 {
 		sizeofBytes(t.MemberMetadata)
 }
 
-func (t joinGroupResponseMemberV1) writeTo(w *bufio.Writer) {
-	writeString(w, t.MemberID)
-	writeBytes(w, t.MemberMetadata)
+func (t joinGroupResponseMemberV1) writeTo(wb *writeBuffer) {
+	wb.writeString(t.MemberID)
+	wb.writeBytes(t.MemberMetadata)
 }
 
 func (t *joinGroupResponseMemberV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -160,13 +158,13 @@ func (t joinGroupResponseV1) size() int32 {
 		sizeofArray(len(t.MemberID), func(i int) int32 { return t.Members[i].size() })
 }
 
-func (t joinGroupResponseV1) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
-	writeInt32(w, t.GenerationID)
-	writeString(w, t.GroupProtocol)
-	writeString(w, t.LeaderID)
-	writeString(w, t.MemberID)
-	writeArray(w, len(t.Members), func(i int) { t.Members[i].writeTo(w) })
+func (t joinGroupResponseV1) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	wb.writeInt32(t.GenerationID)
+	wb.writeString(t.GroupProtocol)
+	wb.writeString(t.LeaderID)
+	wb.writeString(t.MemberID)
+	wb.writeArray(len(t.Members), func(i int) { t.Members[i].writeTo(wb) })
 }
 
 func (t *joinGroupResponseV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {

--- a/joingroup_test.go
+++ b/joingroup_test.go
@@ -80,13 +80,12 @@ func TestMemberMetadata(t *testing.T) {
 		UserData: []byte(`blah`),
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found groupMetadata
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -116,13 +115,12 @@ func TestJoinGroupResponseV1(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found joinGroupResponseV1
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/leavegroup.go
+++ b/leavegroup.go
@@ -12,13 +12,12 @@ type leaveGroupRequestV0 struct {
 }
 
 func (t leaveGroupRequestV0) size() int32 {
-	return sizeofString(t.GroupID) +
-		sizeofString(t.MemberID)
+	return sizeofString(t.GroupID) + sizeofString(t.MemberID)
 }
 
-func (t leaveGroupRequestV0) writeTo(w *bufio.Writer) {
-	writeString(w, t.GroupID)
-	writeString(w, t.MemberID)
+func (t leaveGroupRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeString(t.GroupID)
+	wb.writeString(t.MemberID)
 }
 
 type leaveGroupResponseV0 struct {
@@ -30,13 +29,11 @@ func (t leaveGroupResponseV0) size() int32 {
 	return sizeofInt16(t.ErrorCode)
 }
 
-func (t leaveGroupResponseV0) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
+func (t leaveGroupResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
 }
 
 func (t *leaveGroupResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
-	if remain, err = readInt16(r, size, &t.ErrorCode); err != nil {
-		return
-	}
+	remain, err = readInt16(r, size, &t.ErrorCode)
 	return
 }

--- a/leavegroup_test.go
+++ b/leavegroup_test.go
@@ -12,13 +12,12 @@ func TestLeaveGroupResponseV0(t *testing.T) {
 		ErrorCode: 2,
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found leaveGroupResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/listgroups.go
+++ b/listgroups.go
@@ -11,7 +11,7 @@ func (t listGroupsRequestV1) size() int32 {
 	return 0
 }
 
-func (t listGroupsRequestV1) writeTo(w *bufio.Writer) {
+func (t listGroupsRequestV1) writeTo(wb *writeBuffer) {
 }
 
 type ListGroupsResponseGroupV1 struct {
@@ -21,13 +21,12 @@ type ListGroupsResponseGroupV1 struct {
 }
 
 func (t ListGroupsResponseGroupV1) size() int32 {
-	return sizeofString(t.GroupID) +
-		sizeofString(t.ProtocolType)
+	return sizeofString(t.GroupID) + sizeofString(t.ProtocolType)
 }
 
-func (t ListGroupsResponseGroupV1) writeTo(w *bufio.Writer) {
-	writeString(w, t.GroupID)
-	writeString(w, t.ProtocolType)
+func (t ListGroupsResponseGroupV1) writeTo(wb *writeBuffer) {
+	wb.writeString(t.GroupID)
+	wb.writeString(t.ProtocolType)
 }
 
 func (t *ListGroupsResponseGroupV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -57,10 +56,10 @@ func (t listGroupsResponseV1) size() int32 {
 		sizeofArray(len(t.Groups), func(i int) int32 { return t.Groups[i].size() })
 }
 
-func (t listGroupsResponseV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.ThrottleTimeMS)
-	writeInt16(w, t.ErrorCode)
-	writeArray(w, len(t.Groups), func(i int) { t.Groups[i].writeTo(w) })
+func (t listGroupsResponseV1) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.ThrottleTimeMS)
+	wb.writeInt16(t.ErrorCode)
+	wb.writeArray(len(t.Groups), func(i int) { t.Groups[i].writeTo(wb) })
 }
 
 func (t *listGroupsResponseV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {

--- a/listgroups_test.go
+++ b/listgroups_test.go
@@ -18,13 +18,12 @@ func TestListGroupsResponseV1(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found listGroupsResponseV1
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/listoffset.go
+++ b/listoffset.go
@@ -11,9 +11,9 @@ func (r listOffsetRequestV1) size() int32 {
 	return 4 + sizeofArray(len(r.Topics), func(i int) int32 { return r.Topics[i].size() })
 }
 
-func (r listOffsetRequestV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, r.ReplicaID)
-	writeArray(w, len(r.Topics), func(i int) { r.Topics[i].writeTo(w) })
+func (r listOffsetRequestV1) writeTo(wb *writeBuffer) {
+	wb.writeInt32(r.ReplicaID)
+	wb.writeArray(len(r.Topics), func(i int) { r.Topics[i].writeTo(wb) })
 }
 
 type listOffsetRequestTopicV1 struct {
@@ -26,9 +26,9 @@ func (t listOffsetRequestTopicV1) size() int32 {
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t listOffsetRequestTopicV1) writeTo(w *bufio.Writer) {
-	writeString(w, t.TopicName)
-	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
+func (t listOffsetRequestTopicV1) writeTo(wb *writeBuffer) {
+	wb.writeString(t.TopicName)
+	wb.writeArray(len(t.Partitions), func(i int) { t.Partitions[i].writeTo(wb) })
 }
 
 type listOffsetRequestPartitionV1 struct {
@@ -40,9 +40,9 @@ func (p listOffsetRequestPartitionV1) size() int32 {
 	return 4 + 8
 }
 
-func (p listOffsetRequestPartitionV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, p.Partition)
-	writeInt64(w, p.Time)
+func (p listOffsetRequestPartitionV1) writeTo(wb *writeBuffer) {
+	wb.writeInt32(p.Partition)
+	wb.writeInt64(p.Time)
 }
 
 type listOffsetResponseV1 []listOffsetResponseTopicV1
@@ -51,8 +51,8 @@ func (r listOffsetResponseV1) size() int32 {
 	return sizeofArray(len(r), func(i int) int32 { return r[i].size() })
 }
 
-func (r listOffsetResponseV1) writeTo(w *bufio.Writer) {
-	writeArray(w, len(r), func(i int) { r[i].writeTo(w) })
+func (r listOffsetResponseV1) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(r), func(i int) { r[i].writeTo(wb) })
 }
 
 type listOffsetResponseTopicV1 struct {
@@ -65,9 +65,9 @@ func (t listOffsetResponseTopicV1) size() int32 {
 		sizeofArray(len(t.PartitionOffsets), func(i int) int32 { return t.PartitionOffsets[i].size() })
 }
 
-func (t listOffsetResponseTopicV1) writeTo(w *bufio.Writer) {
-	writeString(w, t.TopicName)
-	writeArray(w, len(t.PartitionOffsets), func(i int) { t.PartitionOffsets[i].writeTo(w) })
+func (t listOffsetResponseTopicV1) writeTo(wb *writeBuffer) {
+	wb.writeString(t.TopicName)
+	wb.writeArray(len(t.PartitionOffsets), func(i int) { t.PartitionOffsets[i].writeTo(wb) })
 }
 
 type partitionOffsetV1 struct {
@@ -81,11 +81,11 @@ func (p partitionOffsetV1) size() int32 {
 	return 4 + 2 + 8 + 8
 }
 
-func (p partitionOffsetV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, p.Partition)
-	writeInt16(w, p.ErrorCode)
-	writeInt64(w, p.Timestamp)
-	writeInt64(w, p.Offset)
+func (p partitionOffsetV1) writeTo(wb *writeBuffer) {
+	wb.writeInt32(p.Partition)
+	wb.writeInt16(p.ErrorCode)
+	wb.writeInt64(p.Timestamp)
+	wb.writeInt64(p.Offset)
 }
 
 func (p *partitionOffsetV1) readFrom(r *bufio.Reader, sz int) (remain int, err error) {

--- a/message.go
+++ b/message.go
@@ -66,15 +66,15 @@ func (m message) size() int32 {
 	return size
 }
 
-func (m message) writeTo(w *bufio.Writer) {
-	writeInt32(w, m.CRC)
-	writeInt8(w, m.MagicByte)
-	writeInt8(w, m.Attributes)
+func (m message) writeTo(wb *writeBuffer) {
+	wb.writeInt32(m.CRC)
+	wb.writeInt8(m.MagicByte)
+	wb.writeInt8(m.Attributes)
 	if m.MagicByte != 0 {
-		writeInt64(w, m.Timestamp)
+		wb.writeInt64(m.Timestamp)
 	}
-	writeBytes(w, m.Key)
-	writeBytes(w, m.Value)
+	wb.writeBytes(m.Key)
+	wb.writeBytes(m.Value)
 }
 
 type messageSetItem struct {
@@ -87,10 +87,10 @@ func (m messageSetItem) size() int32 {
 	return 8 + 4 + m.Message.size()
 }
 
-func (m messageSetItem) writeTo(w *bufio.Writer) {
-	writeInt64(w, m.Offset)
-	writeInt32(w, m.MessageSize)
-	m.Message.writeTo(w)
+func (m messageSetItem) writeTo(wb *writeBuffer) {
+	wb.writeInt64(m.Offset)
+	wb.writeInt32(m.MessageSize)
+	m.Message.writeTo(wb)
 }
 
 type messageSet []messageSetItem
@@ -102,9 +102,9 @@ func (s messageSet) size() (size int32) {
 	return
 }
 
-func (s messageSet) writeTo(w *bufio.Writer) {
+func (s messageSet) writeTo(wb *writeBuffer) {
 	for _, m := range s {
-		m.writeTo(w)
+		m.writeTo(wb)
 	}
 }
 

--- a/metadata.go
+++ b/metadata.go
@@ -1,15 +1,13 @@
 package kafka
 
-import "bufio"
-
 type topicMetadataRequestV1 []string
 
 func (r topicMetadataRequestV1) size() int32 {
 	return sizeofStringArray([]string(r))
 }
 
-func (r topicMetadataRequestV1) writeTo(w *bufio.Writer) {
-	writeStringArray(w, []string(r))
+func (r topicMetadataRequestV1) writeTo(wb *writeBuffer) {
+	wb.writeStringArray([]string(r))
 }
 
 type metadataResponseV1 struct {
@@ -24,10 +22,10 @@ func (r metadataResponseV1) size() int32 {
 	return 4 + n1 + n2
 }
 
-func (r metadataResponseV1) writeTo(w *bufio.Writer) {
-	writeArray(w, len(r.Brokers), func(i int) { r.Brokers[i].writeTo(w) })
-	writeInt32(w, r.ControllerID)
-	writeArray(w, len(r.Topics), func(i int) { r.Topics[i].writeTo(w) })
+func (r metadataResponseV1) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(r.Brokers), func(i int) { r.Brokers[i].writeTo(wb) })
+	wb.writeInt32(r.ControllerID)
+	wb.writeArray(len(r.Topics), func(i int) { r.Topics[i].writeTo(wb) })
 }
 
 type brokerMetadataV1 struct {
@@ -41,11 +39,11 @@ func (b brokerMetadataV1) size() int32 {
 	return 4 + 4 + sizeofString(b.Host) + sizeofString(b.Rack)
 }
 
-func (b brokerMetadataV1) writeTo(w *bufio.Writer) {
-	writeInt32(w, b.NodeID)
-	writeString(w, b.Host)
-	writeInt32(w, b.Port)
-	writeString(w, b.Rack)
+func (b brokerMetadataV1) writeTo(wb *writeBuffer) {
+	wb.writeInt32(b.NodeID)
+	wb.writeString(b.Host)
+	wb.writeInt32(b.Port)
+	wb.writeString(b.Rack)
 }
 
 type topicMetadataV1 struct {
@@ -61,11 +59,11 @@ func (t topicMetadataV1) size() int32 {
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t topicMetadataV1) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.TopicErrorCode)
-	writeString(w, t.TopicName)
-	writeBool(w, t.Internal)
-	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
+func (t topicMetadataV1) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.TopicErrorCode)
+	wb.writeString(t.TopicName)
+	wb.writeBool(t.Internal)
+	wb.writeArray(len(t.Partitions), func(i int) { t.Partitions[i].writeTo(wb) })
 }
 
 type partitionMetadataV1 struct {
@@ -80,10 +78,10 @@ func (p partitionMetadataV1) size() int32 {
 	return 2 + 4 + 4 + sizeofInt32Array(p.Replicas) + sizeofInt32Array(p.Isr)
 }
 
-func (p partitionMetadataV1) writeTo(w *bufio.Writer) {
-	writeInt16(w, p.PartitionErrorCode)
-	writeInt32(w, p.PartitionID)
-	writeInt32(w, p.Leader)
-	writeInt32Array(w, p.Replicas)
-	writeInt32Array(w, p.Isr)
+func (p partitionMetadataV1) writeTo(wb *writeBuffer) {
+	wb.writeInt16(p.PartitionErrorCode)
+	wb.writeInt32(p.PartitionID)
+	wb.writeInt32(p.Leader)
+	wb.writeInt32Array(p.Replicas)
+	wb.writeInt32Array(p.Isr)
 }

--- a/offsetcommit.go
+++ b/offsetcommit.go
@@ -19,10 +19,10 @@ func (t offsetCommitRequestV2Partition) size() int32 {
 		sizeofString(t.Metadata)
 }
 
-func (t offsetCommitRequestV2Partition) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.Partition)
-	writeInt64(w, t.Offset)
-	writeString(w, t.Metadata)
+func (t offsetCommitRequestV2Partition) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.Partition)
+	wb.writeInt64(t.Offset)
+	wb.writeString(t.Metadata)
 }
 
 type offsetCommitRequestV2Topic struct {
@@ -38,9 +38,9 @@ func (t offsetCommitRequestV2Topic) size() int32 {
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t offsetCommitRequestV2Topic) writeTo(w *bufio.Writer) {
-	writeString(w, t.Topic)
-	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
+func (t offsetCommitRequestV2Topic) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Topic)
+	wb.writeArray(len(t.Partitions), func(i int) { t.Partitions[i].writeTo(wb) })
 }
 
 type offsetCommitRequestV2 struct {
@@ -68,12 +68,12 @@ func (t offsetCommitRequestV2) size() int32 {
 		sizeofArray(len(t.Topics), func(i int) int32 { return t.Topics[i].size() })
 }
 
-func (t offsetCommitRequestV2) writeTo(w *bufio.Writer) {
-	writeString(w, t.GroupID)
-	writeInt32(w, t.GenerationID)
-	writeString(w, t.MemberID)
-	writeInt64(w, t.RetentionTime)
-	writeArray(w, len(t.Topics), func(i int) { t.Topics[i].writeTo(w) })
+func (t offsetCommitRequestV2) writeTo(wb *writeBuffer) {
+	wb.writeString(t.GroupID)
+	wb.writeInt32(t.GenerationID)
+	wb.writeString(t.MemberID)
+	wb.writeInt64(t.RetentionTime)
+	wb.writeArray(len(t.Topics), func(i int) { t.Topics[i].writeTo(wb) })
 }
 
 type offsetCommitResponseV2PartitionResponse struct {
@@ -88,9 +88,9 @@ func (t offsetCommitResponseV2PartitionResponse) size() int32 {
 		sizeofInt16(t.ErrorCode)
 }
 
-func (t offsetCommitResponseV2PartitionResponse) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.Partition)
-	writeInt16(w, t.ErrorCode)
+func (t offsetCommitResponseV2PartitionResponse) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.Partition)
+	wb.writeInt16(t.ErrorCode)
 }
 
 func (t *offsetCommitResponseV2PartitionResponse) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -113,9 +113,9 @@ func (t offsetCommitResponseV2Response) size() int32 {
 		sizeofArray(len(t.PartitionResponses), func(i int) int32 { return t.PartitionResponses[i].size() })
 }
 
-func (t offsetCommitResponseV2Response) writeTo(w *bufio.Writer) {
-	writeString(w, t.Topic)
-	writeArray(w, len(t.PartitionResponses), func(i int) { t.PartitionResponses[i].writeTo(w) })
+func (t offsetCommitResponseV2Response) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Topic)
+	wb.writeArray(len(t.PartitionResponses), func(i int) { t.PartitionResponses[i].writeTo(wb) })
 }
 
 func (t *offsetCommitResponseV2Response) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -146,8 +146,8 @@ func (t offsetCommitResponseV2) size() int32 {
 	return sizeofArray(len(t.Responses), func(i int) int32 { return t.Responses[i].size() })
 }
 
-func (t offsetCommitResponseV2) writeTo(w *bufio.Writer) {
-	writeArray(w, len(t.Responses), func(i int) { t.Responses[i].writeTo(w) })
+func (t offsetCommitResponseV2) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.Responses), func(i int) { t.Responses[i].writeTo(wb) })
 }
 
 func (t *offsetCommitResponseV2) readFrom(r *bufio.Reader, size int) (remain int, err error) {

--- a/offsetcommit_test.go
+++ b/offsetcommit_test.go
@@ -22,13 +22,12 @@ func TestOffsetCommitResponseV2(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found offsetCommitResponseV2
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/offsetfetch.go
+++ b/offsetfetch.go
@@ -17,9 +17,9 @@ func (t offsetFetchRequestV1Topic) size() int32 {
 		sizeofInt32Array(t.Partitions)
 }
 
-func (t offsetFetchRequestV1Topic) writeTo(w *bufio.Writer) {
-	writeString(w, t.Topic)
-	writeInt32Array(w, t.Partitions)
+func (t offsetFetchRequestV1Topic) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Topic)
+	wb.writeInt32Array(t.Partitions)
 }
 
 type offsetFetchRequestV1 struct {
@@ -35,9 +35,9 @@ func (t offsetFetchRequestV1) size() int32 {
 		sizeofArray(len(t.Topics), func(i int) int32 { return t.Topics[i].size() })
 }
 
-func (t offsetFetchRequestV1) writeTo(w *bufio.Writer) {
-	writeString(w, t.GroupID)
-	writeArray(w, len(t.Topics), func(i int) { t.Topics[i].writeTo(w) })
+func (t offsetFetchRequestV1) writeTo(wb *writeBuffer) {
+	wb.writeString(t.GroupID)
+	wb.writeArray(len(t.Topics), func(i int) { t.Topics[i].writeTo(wb) })
 }
 
 type offsetFetchResponseV1PartitionResponse struct {
@@ -61,11 +61,11 @@ func (t offsetFetchResponseV1PartitionResponse) size() int32 {
 		sizeofInt16(t.ErrorCode)
 }
 
-func (t offsetFetchResponseV1PartitionResponse) writeTo(w *bufio.Writer) {
-	writeInt32(w, t.Partition)
-	writeInt64(w, t.Offset)
-	writeString(w, t.Metadata)
-	writeInt16(w, t.ErrorCode)
+func (t offsetFetchResponseV1PartitionResponse) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.Partition)
+	wb.writeInt64(t.Offset)
+	wb.writeString(t.Metadata)
+	wb.writeInt16(t.ErrorCode)
 }
 
 func (t *offsetFetchResponseV1PartitionResponse) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -97,9 +97,9 @@ func (t offsetFetchResponseV1Response) size() int32 {
 		sizeofArray(len(t.PartitionResponses), func(i int) int32 { return t.PartitionResponses[i].size() })
 }
 
-func (t offsetFetchResponseV1Response) writeTo(w *bufio.Writer) {
-	writeString(w, t.Topic)
-	writeArray(w, len(t.PartitionResponses), func(i int) { t.PartitionResponses[i].writeTo(w) })
+func (t offsetFetchResponseV1Response) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Topic)
+	wb.writeArray(len(t.PartitionResponses), func(i int) { t.PartitionResponses[i].writeTo(wb) })
 }
 
 func (t *offsetFetchResponseV1Response) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -131,8 +131,8 @@ func (t offsetFetchResponseV1) size() int32 {
 	return sizeofArray(len(t.Responses), func(i int) int32 { return t.Responses[i].size() })
 }
 
-func (t offsetFetchResponseV1) writeTo(w *bufio.Writer) {
-	writeArray(w, len(t.Responses), func(i int) { t.Responses[i].writeTo(w) })
+func (t offsetFetchResponseV1) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.Responses), func(i int) { t.Responses[i].writeTo(wb) })
 }
 
 func (t *offsetFetchResponseV1) readFrom(r *bufio.Reader, size int) (remain int, err error) {

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -24,13 +24,12 @@ func TestOffsetFetchResponseV1(t *testing.T) {
 		},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found offsetFetchResponseV1
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/produce.go
+++ b/produce.go
@@ -12,10 +12,10 @@ func (r produceRequestV2) size() int32 {
 	return 2 + 4 + sizeofArray(len(r.Topics), func(i int) int32 { return r.Topics[i].size() })
 }
 
-func (r produceRequestV2) writeTo(w *bufio.Writer) {
-	writeInt16(w, r.RequiredAcks)
-	writeInt32(w, r.Timeout)
-	writeArray(w, len(r.Topics), func(i int) { r.Topics[i].writeTo(w) })
+func (r produceRequestV2) writeTo(wb *writeBuffer) {
+	wb.writeInt16(r.RequiredAcks)
+	wb.writeInt32(r.Timeout)
+	wb.writeArray(len(r.Topics), func(i int) { r.Topics[i].writeTo(wb) })
 }
 
 type produceRequestTopicV2 struct {
@@ -28,9 +28,9 @@ func (t produceRequestTopicV2) size() int32 {
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t produceRequestTopicV2) writeTo(w *bufio.Writer) {
-	writeString(w, t.TopicName)
-	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
+func (t produceRequestTopicV2) writeTo(wb *writeBuffer) {
+	wb.writeString(t.TopicName)
+	wb.writeArray(len(t.Partitions), func(i int) { t.Partitions[i].writeTo(wb) })
 }
 
 type produceRequestPartitionV2 struct {
@@ -43,10 +43,10 @@ func (p produceRequestPartitionV2) size() int32 {
 	return 4 + 4 + p.MessageSet.size()
 }
 
-func (p produceRequestPartitionV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, p.Partition)
-	writeInt32(w, p.MessageSetSize)
-	p.MessageSet.writeTo(w)
+func (p produceRequestPartitionV2) writeTo(wb *writeBuffer) {
+	wb.writeInt32(p.Partition)
+	wb.writeInt32(p.MessageSetSize)
+	p.MessageSet.writeTo(wb)
 }
 
 type produceResponseV2 struct {
@@ -58,9 +58,9 @@ func (r produceResponseV2) size() int32 {
 	return 4 + sizeofArray(len(r.Topics), func(i int) int32 { return r.Topics[i].size() })
 }
 
-func (r produceResponseV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, r.ThrottleTime)
-	writeArray(w, len(r.Topics), func(i int) { r.Topics[i].writeTo(w) })
+func (r produceResponseV2) writeTo(wb *writeBuffer) {
+	wb.writeInt32(r.ThrottleTime)
+	wb.writeArray(len(r.Topics), func(i int) { r.Topics[i].writeTo(wb) })
 }
 
 type produceResponseTopicV2 struct {
@@ -73,9 +73,9 @@ func (t produceResponseTopicV2) size() int32 {
 		sizeofArray(len(t.Partitions), func(i int) int32 { return t.Partitions[i].size() })
 }
 
-func (t produceResponseTopicV2) writeTo(w *bufio.Writer) {
-	writeString(w, t.TopicName)
-	writeArray(w, len(t.Partitions), func(i int) { t.Partitions[i].writeTo(w) })
+func (t produceResponseTopicV2) writeTo(wb *writeBuffer) {
+	wb.writeString(t.TopicName)
+	wb.writeArray(len(t.Partitions), func(i int) { t.Partitions[i].writeTo(wb) })
 }
 
 type produceResponsePartitionV2 struct {
@@ -89,11 +89,11 @@ func (p produceResponsePartitionV2) size() int32 {
 	return 4 + 2 + 8 + 8
 }
 
-func (p produceResponsePartitionV2) writeTo(w *bufio.Writer) {
-	writeInt32(w, p.Partition)
-	writeInt16(w, p.ErrorCode)
-	writeInt64(w, p.Offset)
-	writeInt64(w, p.Timestamp)
+func (p produceResponsePartitionV2) writeTo(wb *writeBuffer) {
+	wb.writeInt32(p.Partition)
+	wb.writeInt16(p.ErrorCode)
+	wb.writeInt64(p.Offset)
+	wb.writeInt64(p.Timestamp)
 }
 
 func (p *produceResponsePartitionV2) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
@@ -124,12 +124,12 @@ func (p produceResponsePartitionV7) size() int32 {
 	return 4 + 2 + 8 + 8 + 8
 }
 
-func (p produceResponsePartitionV7) writeTo(w *bufio.Writer) {
-	writeInt32(w, p.Partition)
-	writeInt16(w, p.ErrorCode)
-	writeInt64(w, p.Offset)
-	writeInt64(w, p.Timestamp)
-	writeInt64(w, p.StartOffset)
+func (p produceResponsePartitionV7) writeTo(wb *writeBuffer) {
+	wb.writeInt32(p.Partition)
+	wb.writeInt16(p.ErrorCode)
+	wb.writeInt64(p.Offset)
+	wb.writeInt64(p.Timestamp)
+	wb.writeInt64(p.StartOffset)
 }
 
 func (p *produceResponsePartitionV7) readFrom(r *bufio.Reader, sz int) (remain int, err error) {

--- a/protocol.go
+++ b/protocol.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"bufio"
 	"encoding/binary"
 	"fmt"
 )
@@ -53,17 +52,17 @@ func (h requestHeader) size() int32 {
 	return 4 + 2 + 2 + 4 + sizeofString(h.ClientID)
 }
 
-func (h requestHeader) writeTo(w *bufio.Writer) {
-	writeInt32(w, h.Size)
-	writeInt16(w, h.ApiKey)
-	writeInt16(w, h.ApiVersion)
-	writeInt32(w, h.CorrelationID)
-	writeString(w, h.ClientID)
+func (h requestHeader) writeTo(wb *writeBuffer) {
+	wb.writeInt32(h.Size)
+	wb.writeInt16(h.ApiKey)
+	wb.writeInt16(h.ApiVersion)
+	wb.writeInt32(h.CorrelationID)
+	wb.writeString(h.ClientID)
 }
 
 type request interface {
 	size() int32
-	writeTo(*bufio.Writer)
+	writable
 }
 
 func makeInt8(b []byte) int8 {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -87,13 +87,8 @@ func TestProtocol(t *testing.T) {
 		t.Run(fmt.Sprintf("%T", test), func(t *testing.T) {
 			b := &bytes.Buffer{}
 			r := bufio.NewReader(b)
-			w := bufio.NewWriter(b)
-
-			write(w, test)
-
-			if err := w.Flush(); err != nil {
-				t.Fatal(err)
-			}
+			w := &writeBuffer{w: b}
+			w.write(test)
 
 			if size := int(sizeof(test)); size != b.Len() {
 				t.Error("invalid size:", size, "!=", b.Len())

--- a/saslauthenticate.go
+++ b/saslauthenticate.go
@@ -17,8 +17,8 @@ func (t *saslAuthenticateRequestV0) readFrom(r *bufio.Reader, sz int) (remain in
 	return readBytes(r, sz, &t.Data)
 }
 
-func (t saslAuthenticateRequestV0) writeTo(w *bufio.Writer) {
-	writeBytes(w, t.Data)
+func (t saslAuthenticateRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeBytes(t.Data)
 }
 
 type saslAuthenticateResponseV0 struct {
@@ -34,10 +34,10 @@ func (t saslAuthenticateResponseV0) size() int32 {
 	return sizeofInt16(t.ErrorCode) + sizeofString(t.ErrorMessage) + sizeofBytes(t.Data)
 }
 
-func (t saslAuthenticateResponseV0) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
-	writeString(w, t.ErrorMessage)
-	writeBytes(w, t.Data)
+func (t saslAuthenticateResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	wb.writeString(t.ErrorMessage)
+	wb.writeBytes(t.Data)
 }
 
 func (t *saslAuthenticateResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {

--- a/saslauthenticate_test.go
+++ b/saslauthenticate_test.go
@@ -12,13 +12,12 @@ func TestSASLAuthenticateRequestV0(t *testing.T) {
 		Data: []byte("\x00user\x00pass"),
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found saslAuthenticateRequestV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -40,13 +39,12 @@ func TestSASLAuthenticateResponseV0(t *testing.T) {
 		Data:         []byte("bytes"),
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found saslAuthenticateResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/saslhandshake.go
+++ b/saslhandshake.go
@@ -19,8 +19,8 @@ func (t *saslHandshakeRequestV0) readFrom(r *bufio.Reader, sz int) (remain int, 
 	return readString(r, sz, &t.Mechanism)
 }
 
-func (t saslHandshakeRequestV0) writeTo(w *bufio.Writer) {
-	writeString(w, t.Mechanism)
+func (t saslHandshakeRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Mechanism)
 }
 
 // saslHandshakeResponseV0 implements the format for V0 and V1 SASL
@@ -37,9 +37,9 @@ func (t saslHandshakeResponseV0) size() int32 {
 	return sizeofInt16(t.ErrorCode) + sizeofStringArray(t.EnabledMechanisms)
 }
 
-func (t saslHandshakeResponseV0) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
-	writeStringArray(w, t.EnabledMechanisms)
+func (t saslHandshakeResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	wb.writeStringArray(t.EnabledMechanisms)
 }
 
 func (t *saslHandshakeResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {

--- a/saslhandshake_test.go
+++ b/saslhandshake_test.go
@@ -12,13 +12,12 @@ func TestSASLHandshakeRequestV0(t *testing.T) {
 		Mechanism: "SCRAM-SHA-512",
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found saslHandshakeRequestV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -39,13 +38,12 @@ func TestSASLHandshakeResponseV0(t *testing.T) {
 		EnabledMechanisms: []string{"PLAIN", "SCRAM-SHA-512"},
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found saslHandshakeResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/syncgroup.go
+++ b/syncgroup.go
@@ -21,16 +21,16 @@ func (t groupAssignment) size() int32 {
 	return sz + sizeofBytes(t.UserData)
 }
 
-func (t groupAssignment) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.Version)
-	writeInt32(w, int32(len(t.Topics)))
+func (t groupAssignment) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.Version)
+	wb.writeInt32(int32(len(t.Topics)))
 
 	for topic, partitions := range t.Topics {
-		writeString(w, topic)
-		writeInt32Array(w, partitions)
+		wb.writeString(topic)
+		wb.writeInt32Array(partitions)
 	}
 
-	writeBytes(w, t.UserData)
+	wb.writeBytes(t.UserData)
 }
 
 func (t *groupAssignment) readFrom(r *bufio.Reader, size int) (remain int, err error) {
@@ -57,9 +57,7 @@ func (t *groupAssignment) readFrom(r *bufio.Reader, size int) (remain int, err e
 
 func (t groupAssignment) bytes() []byte {
 	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
-	t.writeTo(w)
-	w.Flush()
+	t.writeTo(&writeBuffer{w: buf})
 	return buf.Bytes()
 }
 
@@ -78,9 +76,9 @@ func (t syncGroupRequestGroupAssignmentV0) size() int32 {
 		sizeofBytes(t.MemberAssignments)
 }
 
-func (t syncGroupRequestGroupAssignmentV0) writeTo(w *bufio.Writer) {
-	writeString(w, t.MemberID)
-	writeBytes(w, t.MemberAssignments)
+func (t syncGroupRequestGroupAssignmentV0) writeTo(wb *writeBuffer) {
+	wb.writeString(t.MemberID)
+	wb.writeBytes(t.MemberAssignments)
 }
 
 type syncGroupRequestV0 struct {
@@ -103,11 +101,11 @@ func (t syncGroupRequestV0) size() int32 {
 		sizeofArray(len(t.GroupAssignments), func(i int) int32 { return t.GroupAssignments[i].size() })
 }
 
-func (t syncGroupRequestV0) writeTo(w *bufio.Writer) {
-	writeString(w, t.GroupID)
-	writeInt32(w, t.GenerationID)
-	writeString(w, t.MemberID)
-	writeArray(w, len(t.GroupAssignments), func(i int) { t.GroupAssignments[i].writeTo(w) })
+func (t syncGroupRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeString(t.GroupID)
+	wb.writeInt32(t.GenerationID)
+	wb.writeString(t.MemberID)
+	wb.writeArray(len(t.GroupAssignments), func(i int) { t.GroupAssignments[i].writeTo(wb) })
 }
 
 type syncGroupResponseV0 struct {
@@ -125,9 +123,9 @@ func (t syncGroupResponseV0) size() int32 {
 		sizeofBytes(t.MemberAssignments)
 }
 
-func (t syncGroupResponseV0) writeTo(w *bufio.Writer) {
-	writeInt16(w, t.ErrorCode)
-	writeBytes(w, t.MemberAssignments)
+func (t syncGroupResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	wb.writeBytes(t.MemberAssignments)
 }
 
 func (t *syncGroupResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {

--- a/syncgroup_test.go
+++ b/syncgroup_test.go
@@ -18,13 +18,12 @@ func TestGroupAssignment(t *testing.T) {
 		UserData: []byte(`blah`),
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found groupAssignment
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -61,13 +60,12 @@ func TestSyncGroupResponseV0(t *testing.T) {
 		MemberAssignments: []byte(`blah`),
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
 	var found syncGroupResponseV0
-	remain, err := (&found).readFrom(bufio.NewReader(buf), buf.Len())
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -88,14 +86,13 @@ func BenchmarkSyncGroupResponseV0(t *testing.B) {
 		MemberAssignments: []byte(`blah`),
 	}
 
-	buf := bytes.NewBuffer(nil)
-	w := bufio.NewWriter(buf)
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
 	item.writeTo(w)
-	w.Flush()
 
-	r := bytes.NewReader(buf.Bytes())
+	r := bytes.NewReader(b.Bytes())
 	reader := bufio.NewReader(r)
-	size := buf.Len()
+	size := b.Len()
 
 	for i := 0; i < t.N; i++ {
 		r.Seek(0, io.SeekStart)

--- a/write.go
+++ b/write.go
@@ -1,149 +1,165 @@
 package kafka
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"hash/crc32"
+	"io"
 	"time"
 )
 
-type writable interface {
-	writeTo(*bufio.Writer)
+type writeBuffer struct {
+	w io.Writer
+	b [16]byte
 }
 
-func writeInt8(w *bufio.Writer, i int8) {
-	w.WriteByte(byte(i))
+func (wb *writeBuffer) writeInt8(i int8) {
+	wb.b[0] = byte(i)
+	wb.Write(wb.b[:1])
 }
 
-func writeInt16(w *bufio.Writer, i int16) {
-	var b [2]byte
-	binary.BigEndian.PutUint16(b[:], uint16(i))
-	w.WriteByte(b[0])
-	w.WriteByte(b[1])
+func (wb *writeBuffer) writeInt16(i int16) {
+	binary.BigEndian.PutUint16(wb.b[:2], uint16(i))
+	wb.Write(wb.b[:2])
 }
 
-func writeInt32(w *bufio.Writer, i int32) {
-	var b [4]byte
-	binary.BigEndian.PutUint32(b[:], uint32(i))
-	w.WriteByte(b[0])
-	w.WriteByte(b[1])
-	w.WriteByte(b[2])
-	w.WriteByte(b[3])
+func (wb *writeBuffer) writeInt32(i int32) {
+	binary.BigEndian.PutUint32(wb.b[:4], uint32(i))
+	wb.Write(wb.b[:4])
 }
 
-func writeInt64(w *bufio.Writer, i int64) {
-	var b [8]byte
-	binary.BigEndian.PutUint64(b[:], uint64(i))
-	w.WriteByte(b[0])
-	w.WriteByte(b[1])
-	w.WriteByte(b[2])
-	w.WriteByte(b[3])
-	w.WriteByte(b[4])
-	w.WriteByte(b[5])
-	w.WriteByte(b[6])
-	w.WriteByte(b[7])
+func (wb *writeBuffer) writeInt64(i int64) {
+	binary.BigEndian.PutUint64(wb.b[:8], uint64(i))
+	wb.Write(wb.b[:8])
 }
 
-func writeVarInt(w *bufio.Writer, i int64) {
+func (wb *writeBuffer) writeVarInt(i int64) {
 	u := uint64((i << 1) ^ (i >> 63))
+	n := 0
 
-	for u >= 0x80 {
-		w.WriteByte(byte(u) | 0x80)
+	for u >= 0x80 && n < len(wb.b) {
+		wb.b[n] = byte(u) | 0x80
 		u >>= 7
+		n++
 	}
 
-	w.WriteByte(byte(u))
-}
-
-func varIntLen(i int64) (l int) {
-	i = i<<1 ^ i>>63
-	for i&0x7f != i {
-		l++
-		i >>= 7
+	if n < len(wb.b) {
+		wb.b[n] = byte(u)
+		n++
 	}
-	l++
-	return l
+
+	wb.Write(wb.b[:n])
 }
 
-func writeString(w *bufio.Writer, s string) {
-	writeInt16(w, int16(len(s)))
-	w.WriteString(s)
+func (wb *writeBuffer) writeString(s string) {
+	wb.writeInt16(int16(len(s)))
+	wb.WriteString(s)
 }
 
-func writeNullableString(w *bufio.Writer, s *string) {
+func (wb *writeBuffer) writeVarString(s string) {
+	wb.writeVarInt(int64(len(s)))
+	wb.WriteString(s)
+}
+
+func (wb *writeBuffer) writeNullableString(s *string) {
 	if s == nil {
-		writeInt16(w, -1)
+		wb.writeInt16(-1)
 	} else {
-		writeString(w, *s)
+		wb.writeString(*s)
 	}
 }
 
-func writeBytes(w *bufio.Writer, b []byte) {
+func (wb *writeBuffer) writeBytes(b []byte) {
 	n := len(b)
 	if b == nil {
 		n = -1
 	}
-	writeInt32(w, int32(n))
-	w.Write(b)
+	wb.writeInt32(int32(n))
+	wb.Write(b)
 }
 
-func writeBool(w *bufio.Writer, b bool) {
+func (wb *writeBuffer) writeVarBytes(b []byte) {
+	wb.writeVarInt(int64(len(b)))
+	wb.Write(b)
+}
+
+func (wb *writeBuffer) writeBool(b bool) {
 	v := int8(0)
 	if b {
 		v = 1
 	}
-	writeInt8(w, v)
+	wb.writeInt8(v)
 }
 
-func writeArrayLen(w *bufio.Writer, n int) {
-	writeInt32(w, int32(n))
+func (wb *writeBuffer) writeArrayLen(n int) {
+	wb.writeInt32(int32(n))
 }
 
-func writeArray(w *bufio.Writer, n int, f func(int)) {
-	writeArrayLen(w, n)
-	for i := 0; i != n; i++ {
+func (wb *writeBuffer) writeArray(n int, f func(int)) {
+	wb.writeArrayLen(n)
+	for i := 0; i < n; i++ {
 		f(i)
 	}
 }
 
-func writeStringArray(w *bufio.Writer, a []string) {
-	writeArray(w, len(a), func(i int) { writeString(w, a[i]) })
+func (wb *writeBuffer) writeVarArray(n int, f func(int)) {
+	wb.writeVarInt(int64(n))
+	for i := 0; i < n; i++ {
+		f(i)
+	}
 }
 
-func writeInt32Array(w *bufio.Writer, a []int32) {
-	writeArray(w, len(a), func(i int) { writeInt32(w, a[i]) })
+func (wb *writeBuffer) writeStringArray(a []string) {
+	wb.writeArray(len(a), func(i int) { wb.writeString(a[i]) })
 }
 
-func write(w *bufio.Writer, a interface{}) {
+func (wb *writeBuffer) writeInt32Array(a []int32) {
+	wb.writeArray(len(a), func(i int) { wb.writeInt32(a[i]) })
+}
+
+func (wb *writeBuffer) write(a interface{}) {
 	switch v := a.(type) {
 	case int8:
-		writeInt8(w, v)
+		wb.writeInt8(v)
 	case int16:
-		writeInt16(w, v)
+		wb.writeInt16(v)
 	case int32:
-		writeInt32(w, v)
+		wb.writeInt32(v)
 	case int64:
-		writeInt64(w, v)
+		wb.writeInt64(v)
 	case string:
-		writeString(w, v)
+		wb.writeString(v)
 	case []byte:
-		writeBytes(w, v)
+		wb.writeBytes(v)
 	case bool:
-		writeBool(w, v)
+		wb.writeBool(v)
 	case writable:
-		v.writeTo(w)
+		v.writeTo(wb)
 	default:
 		panic(fmt.Sprintf("unsupported type: %T", a))
 	}
 }
 
-// The functions bellow are used as optimizations to avoid dynamic memory
-// allocations that occur when building the data structures representing the
-// kafka protocol requests.
+func (wb *writeBuffer) Write(b []byte) (int, error) {
+	return wb.w.Write(b)
+}
 
-func writeFetchRequestV2(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration) error {
+func (wb *writeBuffer) WriteString(s string) (int, error) {
+	return io.WriteString(wb.w, s)
+}
+
+func (wb *writeBuffer) Flush() error {
+	if x, ok := wb.w.(interface{ Flush() error }); ok {
+		return x.Flush()
+	}
+	return nil
+}
+
+type writable interface {
+	writeTo(*writeBuffer)
+}
+
+func (wb *writeBuffer) writeFetchRequestV2(correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration) error {
 	h := requestHeader{
 		ApiKey:        int16(fetchRequest),
 		ApiVersion:    int16(v2),
@@ -161,25 +177,25 @@ func writeFetchRequestV2(w *bufio.Writer, correlationID int32, clientID, topic s
 		8 + // offset
 		4 // max bytes
 
-	h.writeTo(w)
-	writeInt32(w, -1) // replica ID
-	writeInt32(w, milliseconds(maxWait))
-	writeInt32(w, int32(minBytes))
+	h.writeTo(wb)
+	wb.writeInt32(-1) // replica ID
+	wb.writeInt32(milliseconds(maxWait))
+	wb.writeInt32(int32(minBytes))
 
 	// topic array
-	writeArrayLen(w, 1)
-	writeString(w, topic)
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
 
 	// partition array
-	writeArrayLen(w, 1)
-	writeInt32(w, partition)
-	writeInt64(w, offset)
-	writeInt32(w, int32(maxBytes))
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
+	wb.writeInt64(offset)
+	wb.writeInt32(int32(maxBytes))
 
-	return w.Flush()
+	return wb.Flush()
 }
 
-func writeFetchRequestV5(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
+func (wb *writeBuffer) writeFetchRequestV5(correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
 	h := requestHeader{
 		ApiKey:        int16(fetchRequest),
 		ApiVersion:    int16(v5),
@@ -200,28 +216,28 @@ func writeFetchRequestV5(w *bufio.Writer, correlationID int32, clientID, topic s
 		8 + // log start offset
 		4 // max bytes
 
-	h.writeTo(w)
-	writeInt32(w, -1) // replica ID
-	writeInt32(w, milliseconds(maxWait))
-	writeInt32(w, int32(minBytes))
-	writeInt32(w, int32(maxBytes))
-	writeInt8(w, isolationLevel) // isolation level 0 - read uncommitted
+	h.writeTo(wb)
+	wb.writeInt32(-1) // replica ID
+	wb.writeInt32(milliseconds(maxWait))
+	wb.writeInt32(int32(minBytes))
+	wb.writeInt32(int32(maxBytes))
+	wb.writeInt8(isolationLevel) // isolation level 0 - read uncommitted
 
 	// topic array
-	writeArrayLen(w, 1)
-	writeString(w, topic)
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
 
 	// partition array
-	writeArrayLen(w, 1)
-	writeInt32(w, partition)
-	writeInt64(w, offset)
-	writeInt64(w, int64(0)) // log start offset only used when is sent by follower
-	writeInt32(w, int32(maxBytes))
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
+	wb.writeInt64(offset)
+	wb.writeInt64(int64(0)) // log start offset only used when is sent by follower
+	wb.writeInt32(int32(maxBytes))
 
-	return w.Flush()
+	return wb.Flush()
 }
 
-func writeFetchRequestV10(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
+func (wb *writeBuffer) writeFetchRequestV10(correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
 	h := requestHeader{
 		ApiKey:        int16(fetchRequest),
 		ApiVersion:    int16(v10),
@@ -246,34 +262,34 @@ func writeFetchRequestV10(w *bufio.Writer, correlationID int32, clientID, topic 
 		4 + // partition max bytes
 		4 // forgotten topics data
 
-	h.writeTo(w)
-	writeInt32(w, -1) // replica ID
-	writeInt32(w, milliseconds(maxWait))
-	writeInt32(w, int32(minBytes))
-	writeInt32(w, int32(maxBytes))
-	writeInt8(w, isolationLevel) // isolation level 0 - read uncommitted
-	writeInt32(w, 0)             //FIXME
-	writeInt32(w, -1)            //FIXME
+	h.writeTo(wb)
+	wb.writeInt32(-1) // replica ID
+	wb.writeInt32(milliseconds(maxWait))
+	wb.writeInt32(int32(minBytes))
+	wb.writeInt32(int32(maxBytes))
+	wb.writeInt8(isolationLevel) // isolation level 0 - read uncommitted
+	wb.writeInt32(0)             //FIXME
+	wb.writeInt32(-1)            //FIXME
 
 	// topic array
-	writeArrayLen(w, 1)
-	writeString(w, topic)
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
 
 	// partition array
-	writeArrayLen(w, 1)
-	writeInt32(w, partition)
-	writeInt32(w, -1) //FIXME
-	writeInt64(w, offset)
-	writeInt64(w, int64(0)) // log start offset only used when is sent by follower
-	writeInt32(w, int32(maxBytes))
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
+	wb.writeInt32(-1) //FIXME
+	wb.writeInt64(offset)
+	wb.writeInt64(int64(0)) // log start offset only used when is sent by follower
+	wb.writeInt32(int32(maxBytes))
 
 	// forgotten topics array
-	writeArrayLen(w, 0) // forgotten topics not supported yet
+	wb.writeArrayLen(0) // forgotten topics not supported yet
 
-	return w.Flush()
+	return wb.Flush()
 }
 
-func writeListOffsetRequestV1(w *bufio.Writer, correlationID int32, clientID, topic string, partition int32, time int64) error {
+func (wb *writeBuffer) writeListOffsetRequestV1(correlationID int32, clientID, topic string, partition int32, time int64) error {
 	h := requestHeader{
 		ApiKey:        int16(listOffsetRequest),
 		ApiVersion:    int16(v1),
@@ -288,23 +304,22 @@ func writeListOffsetRequestV1(w *bufio.Writer, correlationID int32, clientID, to
 		4 + // partition
 		8 // time
 
-	h.writeTo(w)
-	writeInt32(w, -1) // replica ID
+	h.writeTo(wb)
+	wb.writeInt32(-1) // replica ID
 
 	// topic array
-	writeArrayLen(w, 1)
-	writeString(w, topic)
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
 
 	// partition array
-	writeArrayLen(w, 1)
-	writeInt32(w, partition)
-	writeInt64(w, time)
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
+	wb.writeInt64(time)
 
-	return w.Flush()
+	return wb.Flush()
 }
 
-func writeProduceRequestV2(w *bufio.Writer, codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, msgs ...Message) (err error) {
-
+func (wb *writeBuffer) writeProduceRequestV2(codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, msgs ...Message) (err error) {
 	attributes := int8(CompressionNoneCode)
 	if codec != nil {
 		if msgs, err = compressMessageSet(codec, msgs...); err != nil {
@@ -330,26 +345,26 @@ func writeProduceRequestV2(w *bufio.Writer, codec CompressionCodec, correlationI
 		4 + // message set size
 		size
 
-	h.writeTo(w)
-	writeInt16(w, requiredAcks) // required acks
-	writeInt32(w, milliseconds(timeout))
+	h.writeTo(wb)
+	wb.writeInt16(requiredAcks) // required acks
+	wb.writeInt32(milliseconds(timeout))
 
 	// topic array
-	writeArrayLen(w, 1)
-	writeString(w, topic)
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
 
 	// partition array
-	writeArrayLen(w, 1)
-	writeInt32(w, partition)
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
 
-	writeInt32(w, size)
+	wb.writeInt32(size)
 	for _, msg := range msgs {
-		writeMessage(w, msg.Offset, attributes, msg.Time, msg.Key, msg.Value)
+		wb.writeMessage(msg.Offset, attributes, msg.Time, msg.Key, msg.Value)
 	}
-	return w.Flush()
+	return wb.Flush()
 }
 
-func writeProduceRequestV3(w *bufio.Writer, codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, msgs ...Message) (err error) {
+func (wb *writeBuffer) writeProduceRequestV3(codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, msgs ...Message) (err error) {
 	var size int32
 	var compressed []byte
 	var attributes int16
@@ -381,39 +396,39 @@ func writeProduceRequestV3(w *bufio.Writer, codec CompressionCodec, correlationI
 		4 + // message set size
 		size
 
-	h.writeTo(w)
-	writeNullableString(w, transactionalID)
-	writeInt16(w, requiredAcks) // required acks
-	writeInt32(w, milliseconds(timeout))
+	h.writeTo(wb)
+	wb.writeNullableString(transactionalID)
+	wb.writeInt16(requiredAcks) // required acks
+	wb.writeInt32(milliseconds(timeout))
 
 	// topic array
-	writeArrayLen(w, 1)
-	writeString(w, topic)
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
 
 	// partition array
-	writeArrayLen(w, 1)
-	writeInt32(w, partition)
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
 
-	writeInt32(w, size)
+	wb.writeInt32(size)
+	baseTime := msgs[0].Time
+	lastTime := msgs[len(msgs)-1].Time
+
 	if codec != nil {
-		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
-			w.Write(compressed)
-		}, msgs...)
+		wb.writeRecordBatch(attributes, size, len(msgs), baseTime, lastTime, func(wb *writeBuffer) {
+			wb.Write(compressed)
+		})
 	} else {
-		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
+		wb.writeRecordBatch(attributes, size, len(msgs), baseTime, lastTime, func(wb *writeBuffer) {
 			for i, msg := range msgs {
-				writeRecord(w, 0, msgs[0].Time, int64(i), msg)
+				wb.writeRecord(0, msgs[0].Time, int64(i), msg)
 			}
-		}, msgs...)
-	}
-	if err != nil {
-		return
+		})
 	}
 
-	return w.Flush()
+	return wb.Flush()
 }
 
-func writeProduceRequestV7(w *bufio.Writer, codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, msgs ...Message) (err error) {
+func (wb *writeBuffer) writeProduceRequestV7(codec CompressionCodec, correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, msgs ...Message) (err error) {
 	var size int32
 	var compressed []byte
 	var attributes int16
@@ -444,36 +459,174 @@ func writeProduceRequestV7(w *bufio.Writer, codec CompressionCodec, correlationI
 		4 + // message set size
 		size
 
-	h.writeTo(w)
-	writeNullableString(w, transactionalID)
-	writeInt16(w, requiredAcks) // required acks
-	writeInt32(w, milliseconds(timeout))
+	h.writeTo(wb)
+	wb.writeNullableString(transactionalID)
+	wb.writeInt16(requiredAcks) // required acks
+	wb.writeInt32(milliseconds(timeout))
 
 	// topic array
-	writeArrayLen(w, 1)
-	writeString(w, topic)
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
 
 	// partition array
-	writeArrayLen(w, 1)
-	writeInt32(w, partition)
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
 
-	writeInt32(w, size)
+	wb.writeInt32(size)
+	baseTime := msgs[0].Time
+	lastTime := msgs[len(msgs)-1].Time
+
 	if codec != nil {
-		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
-			w.Write(compressed)
-		}, msgs...)
+		wb.writeRecordBatch(attributes, size, len(msgs), baseTime, lastTime, func(wb *writeBuffer) {
+			wb.Write(compressed)
+		})
 	} else {
-		err = writeRecordBatch(w, attributes, size, func(w *bufio.Writer) {
+		wb.writeRecordBatch(attributes, size, len(msgs), baseTime, lastTime, func(wb *writeBuffer) {
 			for i, msg := range msgs {
-				writeRecord(w, 0, msgs[0].Time, int64(i), msg)
+				wb.writeRecord(0, msgs[0].Time, int64(i), msg)
 			}
-		}, msgs...)
+		})
 	}
-	if err != nil {
+
+	return wb.Flush()
+}
+
+func (wb *writeBuffer) writeRecordBatch(attributes int16, size int32, count int, baseTime, lastTime time.Time, write func(*writeBuffer)) {
+	wb.writeInt64(int64(0))
+	wb.writeInt32(int32(size - 12)) // 12 = batch length + base offset sizes
+	wb.writeInt32(-1)               // partition leader epoch
+	wb.writeInt8(2)                 // magic byte
+
+	cw := &crc32Writer{writer: wb}
+	cw.writeInt16(attributes)       // attributes, timestamp type 0 - create time, not part of a transaction, no control messages
+	cw.writeInt32(int32(count - 1)) // last offset delta
+	cw.writeInt64(timestamp(baseTime))
+	cw.writeInt64(timestamp(lastTime))
+	cw.writeInt64(-1)           // default producer id for now
+	cw.writeInt16(-1)           // default producer epoch for now
+	cw.writeInt32(-1)           // default base sequence
+	cw.writeInt32(int32(count)) // record count
+
+	write(&writeBuffer{w: cw})
+	wb.writeInt32(int32(cw.crc32))
+}
+
+var maxDate = time.Date(5000, time.January, 0, 0, 0, 0, 0, time.UTC)
+
+func compressMessageSet(codec CompressionCodec, msgs ...Message) ([]Message, error) {
+	estimatedLen := 0
+
+	for _, msg := range msgs {
+		estimatedLen += int(messageSize(msg.Key, msg.Value))
+	}
+
+	buffer := &bytes.Buffer{}
+	buffer.Grow(estimatedLen / 2)
+	compressor := codec.NewWriter(buffer)
+	wb := &writeBuffer{w: compressor}
+
+	for offset, msg := range msgs {
+		wb.writeMessage(int64(offset), CompressionNoneCode, msg.Time, msg.Key, msg.Value)
+	}
+
+	if err := compressor.Close(); err != nil {
+		return nil, err
+	}
+
+	return []Message{{Value: buffer.Bytes()}}, nil
+}
+
+func compressRecordBatch(codec CompressionCodec, msgs ...Message) (compressed []byte, attributes int16, size int32, err error) {
+	recordBuf := &bytes.Buffer{}
+	recordBuf.Grow(int(recordBatchSize(msgs...)) / 2)
+	compressor := codec.NewWriter(recordBuf)
+	wb := &writeBuffer{w: compressor}
+
+	for i, msg := range msgs {
+		wb.writeRecord(0, msgs[0].Time, int64(i), msg)
+	}
+
+	if err = compressor.Close(); err != nil {
 		return
 	}
 
-	return w.Flush()
+	compressed = recordBuf.Bytes()
+	attributes = int16(codec.Code())
+	size = recordBatchHeaderSize + int32(len(compressed))
+	return
+}
+
+func (wb *writeBuffer) writeMessage(offset int64, attributes int8, time time.Time, key, value []byte) {
+	const magicByte = 1 // compatible with kafka 0.10.0.0+
+
+	timestamp := timestamp(time)
+	crc32 := crc32OfMessage(magicByte, attributes, timestamp, key, value)
+	size := messageSize(key, value)
+
+	wb.writeInt64(offset)
+	wb.writeInt32(size)
+	wb.writeInt32(int32(crc32))
+	wb.writeInt8(magicByte)
+	wb.writeInt8(attributes)
+	wb.writeInt64(timestamp)
+	wb.writeBytes(key)
+	wb.writeBytes(value)
+}
+
+// Messages with magic >2 are called records. This method writes messages using message format 2.
+func (wb *writeBuffer) writeRecord(attributes int8, baseTime time.Time, offset int64, msg Message) {
+	timestampDelta := msg.Time.Sub(baseTime)
+	offsetDelta := int64(offset)
+
+	wb.writeVarInt(int64(recordSize(&msg, timestampDelta, offsetDelta)))
+	wb.writeInt8(attributes)
+	wb.writeVarInt(int64(milliseconds(timestampDelta)))
+	wb.writeVarInt(offsetDelta)
+
+	wb.writeVarBytes(msg.Key)
+	wb.writeVarBytes(msg.Value)
+	wb.writeVarArray(len(msg.Headers), func(i int) {
+		h := &msg.Headers[i]
+		wb.writeVarString(h.Key)
+		wb.writeVarBytes(h.Value)
+	})
+}
+
+func varIntLen(i int64) int {
+	u := uint64((i << 1) ^ (i >> 63)) // zig-zag encoding
+	n := 0
+
+	for u >= 0x80 {
+		u >>= 7
+		n++
+	}
+
+	return n + 1
+}
+
+func varBytesLen(b []byte) int {
+	return varIntLen(int64(len(b))) + len(b)
+}
+
+func varStringLen(s string) int {
+	return varIntLen(int64(len(s))) + len(s)
+}
+
+func varArrayLen(n int, f func(int) int) int {
+	size := varIntLen(int64(n))
+	for i := 0; i < n; i++ {
+		size += f(i)
+	}
+	return size
+}
+
+func messageSize(key, value []byte) int32 {
+	return 4 + // crc
+		1 + // magic byte
+		1 + // attributes
+		8 + // timestamp
+		sizeofBytes(key) +
+		sizeofBytes(value)
 }
 
 func messageSetSize(msgs ...Message) (size int32) {
@@ -488,6 +641,18 @@ func messageSetSize(msgs ...Message) (size int32) {
 			sizeofBytes(msg.Value)
 	}
 	return
+}
+
+func recordSize(msg *Message, timestampDelta time.Duration, offsetDelta int64) int {
+	return 1 + // attributes
+		varIntLen(int64(milliseconds(timestampDelta))) +
+		varIntLen(offsetDelta) +
+		varBytesLen(msg.Key) +
+		varBytesLen(msg.Value) +
+		varArrayLen(len(msg.Headers), func(i int) int {
+			h := &msg.Headers[i]
+			return varStringLen(h.Key) + varBytesLen(h.Value)
+		})
 }
 
 const recordBatchHeaderSize int32 = 0 +
@@ -509,176 +674,11 @@ func recordBatchSize(msgs ...Message) (size int32) {
 	size = recordBatchHeaderSize
 	baseTime := msgs[0].Time
 
-	for i, msg := range msgs {
-		sz := recordSize(&msg, msg.Time.Sub(baseTime), int64(i))
-		size += int32(sz + varIntLen(int64(sz)))
+	for i := range msgs {
+		msg := &msgs[i]
+		msz := recordSize(msg, msg.Time.Sub(baseTime), int64(i))
+		size += int32(msz + varIntLen(int64(msz)))
 	}
 
 	return
-}
-
-func writeRecordBatch(w *bufio.Writer, attributes int16, size int32, write func(*bufio.Writer), msgs ...Message) error {
-
-	baseTime := msgs[0].Time
-	lastTime := msgs[len(msgs)-1].Time
-
-	writeInt64(w, int64(0))
-
-	writeInt32(w, int32(size-12)) // 12 = batch length + base offset sizes
-
-	writeInt32(w, -1) // partition leader epoch
-	writeInt8(w, 2)   // magic byte
-
-	crcBuf := &bytes.Buffer{}
-	crcBuf.Grow(int(size - 12)) // 12 = batch length + base offset sizes
-	crcWriter := bufio.NewWriter(crcBuf)
-
-	writeInt16(crcWriter, attributes)         // attributes, timestamp type 0 - create time, not part of a transaction, no control messages
-	writeInt32(crcWriter, int32(len(msgs)-1)) // max offset
-	writeInt64(crcWriter, timestamp(baseTime))
-	writeInt64(crcWriter, timestamp(lastTime))
-	writeInt64(crcWriter, -1)               // default producer id for now
-	writeInt16(crcWriter, -1)               // default producer epoch for now
-	writeInt32(crcWriter, -1)               // default base sequence
-	writeInt32(crcWriter, int32(len(msgs))) // record count
-
-	write(crcWriter)
-	if err := crcWriter.Flush(); err != nil {
-		return err
-	}
-
-	crcTable := crc32.MakeTable(crc32.Castagnoli)
-	crcChecksum := crc32.Checksum(crcBuf.Bytes(), crcTable)
-
-	writeInt32(w, int32(crcChecksum))
-	if _, err := w.Write(crcBuf.Bytes()); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-var maxDate = time.Date(5000, time.January, 0, 0, 0, 0, 0, time.UTC)
-
-func recordSize(msg *Message, timestampDelta time.Duration, offsetDelta int64) (size int) {
-	size += 1 + // attributes
-		varIntLen(int64(milliseconds(timestampDelta))) +
-		varIntLen(offsetDelta) +
-		varIntLen(int64(len(msg.Key))) +
-		len(msg.Key) +
-		varIntLen(int64(len(msg.Value))) +
-		len(msg.Value) +
-		varIntLen(int64(len(msg.Headers)))
-	for _, h := range msg.Headers {
-		size += varIntLen(int64(len([]byte(h.Key)))) +
-			len([]byte(h.Key)) +
-			varIntLen(int64(len(h.Value))) +
-			len(h.Value)
-	}
-	return
-}
-
-func compressMessageSet(codec CompressionCodec, msgs ...Message) ([]Message, error) {
-	estimatedLen := 0
-
-	for _, msg := range msgs {
-		estimatedLen += int(msgSize(msg.Key, msg.Value))
-	}
-
-	buffer := &bytes.Buffer{}
-	buffer.Grow(estimatedLen / 2)
-	compressor := codec.NewWriter(buffer)
-	compressedWriter := bufio.NewWriterSize(compressor, 512)
-
-	for offset, msg := range msgs {
-		writeMessage(compressedWriter, int64(offset), CompressionNoneCode, msg.Time, msg.Key, msg.Value)
-	}
-
-	if err := compressedWriter.Flush(); err != nil {
-		compressor.Close()
-		return nil, err
-	}
-
-	if err := compressor.Close(); err != nil {
-		return nil, err
-	}
-
-	return []Message{{Value: buffer.Bytes()}}, nil
-}
-
-func compressRecordBatch(codec CompressionCodec, msgs ...Message) (compressed []byte, attributes int16, size int32, err error) {
-	recordBuf := new(bytes.Buffer)
-	recordBuf.Grow(int(recordBatchSize(msgs...)) / 2)
-	compressor := codec.NewWriter(recordBuf)
-	compressedWriter := bufio.NewWriterSize(compressor, 512)
-
-	for i, msg := range msgs {
-		writeRecord(compressedWriter, 0, msgs[0].Time, int64(i), msg)
-	}
-
-	if err = compressedWriter.Flush(); err != nil {
-		compressor.Close()
-		return
-	}
-
-	if err = compressor.Close(); err != nil {
-		return
-	}
-
-	compressed = recordBuf.Bytes()
-	attributes = int16(codec.Code())
-	size = recordBatchHeaderSize + int32(len(compressed))
-	return
-}
-
-const magicByte = 1 // compatible with kafka 0.10.0.0+
-
-func writeMessage(w *bufio.Writer, offset int64, attributes int8, time time.Time, key, value []byte) {
-	timestamp := timestamp(time)
-	crc32 := crc32OfMessage(magicByte, attributes, timestamp, key, value)
-	size := msgSize(key, value)
-
-	writeInt64(w, offset)
-	writeInt32(w, size)
-	writeInt32(w, int32(crc32))
-	writeInt8(w, magicByte)
-	writeInt8(w, attributes)
-	writeInt64(w, timestamp)
-	writeBytes(w, key)
-	writeBytes(w, value)
-}
-
-func msgSize(key, value []byte) int32 {
-	return 4 + // crc
-		1 + // magic byte
-		1 + // attributes
-		8 + // timestamp
-		sizeofBytes(key) +
-		sizeofBytes(value)
-}
-
-// Messages with magic >2 are called records. This method writes messages using message format 2.
-func writeRecord(w *bufio.Writer, attributes int8, baseTime time.Time, offset int64, msg Message) {
-
-	timestampDelta := msg.Time.Sub(baseTime)
-	offsetDelta := int64(offset)
-
-	writeVarInt(w, int64(recordSize(&msg, timestampDelta, offsetDelta)))
-
-	writeInt8(w, attributes)
-	writeVarInt(w, int64(milliseconds(timestampDelta)))
-	writeVarInt(w, offsetDelta)
-
-	writeVarInt(w, int64(len(msg.Key)))
-	w.Write(msg.Key)
-	writeVarInt(w, int64(len(msg.Value)))
-	w.Write(msg.Value)
-	writeVarInt(w, int64(len(msg.Headers)))
-
-	for _, h := range msg.Headers {
-		writeVarInt(w, int64(len(h.Key)))
-		w.Write([]byte(h.Key))
-		writeVarInt(w, int64(len(h.Value)))
-		w.Write(h.Value)
-	}
 }

--- a/write_test.go
+++ b/write_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"hash/crc32"
 	"testing"
 	"time"
 
@@ -122,7 +123,9 @@ func testWriteProduceRequestV2(t *testing.T) {
 		},
 	}
 	msg.MessageSize = msg.Message.size()
-	msg.Message.CRC = msg.Message.crc32()
+	msg.Message.CRC = msg.Message.crc32(&crc32Writer{
+		table: crc32.IEEETable,
+	})
 
 	const timeout = 100
 	testWriteOptimization(t,

--- a/write_test.go
+++ b/write_test.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -36,12 +35,12 @@ func TestWriteVarInt(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		buf := &bytes.Buffer{}
-		bufWriter := bufio.NewWriter(buf)
-		writeVarInt(bufWriter, tc.tc)
-		bufWriter.Flush()
-		if !bytes.Equal(buf.Bytes(), tc.v) {
-			t.Errorf("Expected %v; got %v", tc.v, buf.Bytes())
+		b := &bytes.Buffer{}
+		w := &writeBuffer{w: b}
+		w.writeVarInt(tc.tc)
+
+		if !bytes.Equal(b.Bytes(), tc.v) {
+			t.Errorf("Expected %v; got %v", tc.v, b.Bytes())
 		}
 	}
 }
@@ -78,8 +77,8 @@ func testWriteFetchRequestV2(t *testing.T) {
 				}},
 			}},
 		},
-		func(w *bufio.Writer) {
-			writeFetchRequestV2(w, testCorrelationID, testClientID, testTopic, testPartition, offset, minBytes, maxBytes, maxWait)
+		func(w *writeBuffer) {
+			w.writeFetchRequestV2(testCorrelationID, testClientID, testTopic, testPartition, offset, minBytes, maxBytes, maxWait)
 		},
 	)
 }
@@ -103,8 +102,8 @@ func testWriteListOffsetRequestV1(t *testing.T) {
 				}},
 			}},
 		},
-		func(w *bufio.Writer) {
-			writeListOffsetRequestV1(w, testCorrelationID, testClientID, testTopic, testPartition, time)
+		func(w *writeBuffer) {
+			w.writeListOffsetRequestV1(testCorrelationID, testClientID, testTopic, testPartition, time)
 		},
 	)
 }
@@ -144,8 +143,8 @@ func testWriteProduceRequestV2(t *testing.T) {
 				}},
 			}},
 		},
-		func(w *bufio.Writer) {
-			writeProduceRequestV2(w, nil, testCorrelationID, testClientID, testTopic, testPartition, timeout*time.Millisecond, -1, Message{
+		func(w *writeBuffer) {
+			w.writeProduceRequestV2(nil, testCorrelationID, testClientID, testTopic, testPartition, timeout*time.Millisecond, -1, Message{
 				Offset: 10,
 				Key:    key,
 				Value:  val,
@@ -154,20 +153,18 @@ func testWriteProduceRequestV2(t *testing.T) {
 	)
 }
 
-func testWriteOptimization(t *testing.T, h requestHeader, r request, f func(*bufio.Writer)) {
+func testWriteOptimization(t *testing.T, h requestHeader, r request, f func(*writeBuffer)) {
 	b1 := &bytes.Buffer{}
-	w1 := bufio.NewWriter(b1)
+	w1 := &writeBuffer{w: b1}
 
 	b2 := &bytes.Buffer{}
-	w2 := bufio.NewWriter(b2)
+	w2 := &writeBuffer{w: b2}
 
 	h.Size = (h.size() + r.size()) - 4
 	h.writeTo(w1)
 	r.writeTo(w1)
-	w1.Flush()
 
 	f(w2)
-	w2.Flush()
 
 	c1 := b1.Bytes()
 	c2 := b2.Bytes()

--- a/writer.go
+++ b/writer.go
@@ -311,7 +311,7 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 		}
 
 		for i, msg := range msgs {
-			if int(msg.message().size()) > w.config.BatchBytes {
+			if int(msg.message(nil).size()) > w.config.BatchBytes {
 				err := MessageTooLargeError{
 					Message:   msg,
 					Remaining: msgs[i+1:],
@@ -640,7 +640,7 @@ func (w *writer) run() {
 			if lastMsg.res != nil {
 				resch = append(resch, lastMsg.res)
 			}
-			batchSizeBytes += int(lastMsg.msg.message().size())
+			batchSizeBytes += int(lastMsg.msg.message(nil).size())
 			lastMsg = writerMessage{}
 			if !batchTimerRunning {
 				batchTimer.Reset(w.batchTimeout)
@@ -652,7 +652,7 @@ func (w *writer) run() {
 			if !ok {
 				done, mustFlush = true, true
 			} else {
-				if int(wm.msg.message().size())+batchSizeBytes > w.maxMessageBytes {
+				if int(wm.msg.message(nil).size())+batchSizeBytes > w.maxMessageBytes {
 					// If the size of the current message puts us over the maxMessageBytes limit,
 					// store the message but don't send it in this batch.
 					mustFlush = true
@@ -663,7 +663,7 @@ func (w *writer) run() {
 				if wm.res != nil {
 					resch = append(resch, wm.res)
 				}
-				batchSizeBytes += int(wm.msg.message().size())
+				batchSizeBytes += int(wm.msg.message(nil).size())
 				mustFlush = len(batch) >= w.batchSize || batchSizeBytes >= w.maxMessageBytes
 			}
 			if !batchTimerRunning {


### PR DESCRIPTION
This PR refactors the write paths to remove the intermediary buffer that we used to compute checksums of record batches. These temporary buffers would end up being really large as they would have to hold the entire batch, depending on the buffering strategy this could end up being multiple MB of memory allocated on each write to kafka.

Memory footprint on writes should be greatly reduced by this change:
```
benchmark               old ns/op     new ns/op     delta
BenchmarkConn/Write     1026737       1004170       -2.20%

benchmark               old MB/s     new MB/s     speedup
BenchmarkConn/Write     9.74         9.96         1.02x

benchmark               old allocs     new allocs     delta
BenchmarkConn/Write     10             7              -30.00%

benchmark               old bytes     new bytes     delta
BenchmarkConn/Write     14738         322           -97.82%
```

Varint encoding is also much faster now that we work on a local buffer:
```
benchmark                old ns/op     new ns/op     delta
BenchmarkWriteVarInt     34.5          9.70          -71.88%
BenchmarkReadVarInt      50.1          47.9          -4.39%

benchmark                old allocs     new allocs     delta
BenchmarkWriteVarInt     0              0              +0.00%
BenchmarkReadVarInt      0              0              +0.00%

benchmark                old bytes     new bytes     delta
BenchmarkWriteVarInt     0             0             +0.00%
BenchmarkReadVarInt      0             0             +0.00%
```