### PR TITLE
protect against invalid header counts

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1040,8 +1040,14 @@ func (c *Conn) writeCompressedMessages(codec CompressionCodec, msgs ...Message) 
 			err = errInvalidWriteTopic
 			return
 		}
+
 		if msg.Partition != 0 {
 			err = errInvalidWritePartition
+			return
+		}
+
+		if len(msg.Headers) > headerCountLimit {
+			err = fmt.Errorf("header count beyond the supported limit: %d > %d", len(msg.Headers), headerCountLimit)
 			return
 		}
 


### PR DESCRIPTION
This PR protects the program against bugs or corrupted data on the wire which could result in crashes caused by allocating very large header slices.

We set a limit to 1024 header entries per message, which in practice seem more than any acceptable use cases, although we could increase it later as needed, I just want to make sure any insane value is not let through and cascades in even worse outcomes.
