### PR TITLE
recycle compression buffers

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,0 +1,27 @@
+package kafka
+
+import (
+	"bytes"
+	"sync"
+)
+
+var bufferPool = sync.Pool{
+	New: func() interface{} { return newBuffer() },
+}
+
+func newBuffer() *bytes.Buffer {
+	b := new(bytes.Buffer)
+	b.Grow(65536)
+	return b
+}
+
+func acquireBuffer() *bytes.Buffer {
+	return bufferPool.Get().(*bytes.Buffer)
+}
+
+func releaseBuffer(b *bytes.Buffer) {
+	if b != nil {
+		b.Reset()
+		bufferPool.Put(b)
+	}
+}

--- a/compression.go
+++ b/compression.go
@@ -7,8 +7,6 @@ import (
 )
 
 const (
-	CompressionNoneCode = 0
-
 	compressionCodecMask = 0x07
 )
 


### PR DESCRIPTION
This PR should wrap up optimizing the write path of `*kafka.Conn` by recycling the buffers where compressed messages are written.