### PR TITLE
More aggressive resets of state in xerial reader

### DIFF
--- a/snappy/xerial.go
+++ b/snappy/xerial.go
@@ -27,6 +27,7 @@ func (x *xerialReader) Reset(r io.Reader) {
 	x.reader = r
 	x.input = x.input[:0]
 	x.output = x.output[:0]
+	x.header = [16]byte{}
 	x.offset = 0
 	x.nbytes = 0
 }
@@ -72,6 +73,7 @@ func (x *xerialReader) WriteTo(w io.Writer) (int64, error) {
 }
 
 func (x *xerialReader) readChunk(dst []byte) (int, error) {
+	x.output = x.output[:0]
 	x.offset = 0
 	prefix := 0
 


### PR DESCRIPTION
In cases where the xerial reader requires more bytes than available
in the decompressed buffer, we currently get corrupt data.  That
would result in the reader halting.  Clearing out x.output and
x.header ensures that this condition is handled gracefully.