### PR TITLE
declare SeekDontCheck as uint32 to avoid integer overflow in 386 arch

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -576,7 +576,7 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 // to interpret it.
 //
 // See Seek for more details about the offset and whence values.
-func (c *Conn) Offset() (offset int64, whence int) {
+func (c *Conn) Offset() (offset int64, whence uint32) {
 	c.mutex.Lock()
 	offset = c.offset
 	c.mutex.Unlock()
@@ -604,7 +604,7 @@ const (
 	// constants to skip the bound check that the connection would do otherwise.
 	// Programs can use this flag to avoid making a metadata request to the kafka
 	// broker to read the current first and last offsets of the partition.
-	SeekDontCheck = 1 << 31
+	SeekDontCheck uint32 = 1 << 31
 )
 
 // Seek sets the offset for the next read or write operation according to whence, which
@@ -613,7 +613,7 @@ const (
 // Note that for historical reasons, these do not align with the usual whence constants
 // as in lseek(2) or os.Seek.
 // The method returns the new absolute offset of the connection.
-func (c *Conn) Seek(offset int64, whence int) (int64, error) {
+func (c *Conn) Seek(offset int64, whence uint32) (int64, error) {
 	seekDontCheck := (whence & SeekDontCheck) != 0
 	whence &= ^SeekDontCheck
 


### PR DESCRIPTION
When i build my program with `GOARCH=386`, i got the following error caused by constant `SeekDontCheck`:
```
..\github.com\segmentio\kafka-go\conn.go:613:19: constant 2147483648 overflows int
..\github.com\segmentio\kafka-go\conn.go:614:9: constant -2147483649 overflows int
..\github.com\segmentio\kafka-go\conn.go:758:38: constant 2147483648 overflows int
```
The reason it that its value (1<<31) exceeds the limit of 32-bit integer.

I think it is OK to explicitly declare it as _uint32_ and change the type of `whence` param to _uint32_ as well.