### PR TITLE
decrease value of seekdontcheck to avoid integer overflow in 386 arch

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -600,7 +600,7 @@ const (
 	// constants to skip the bound check that the connection would do otherwise.
 	// Programs can use this flag to avoid making a metadata request to the kafka
 	// broker to read the current first and last offsets of the partition.
-	SeekDontCheck = 1 << 31
+	SeekDontCheck = 1 << 30
 )
 
 // Seek sets the offset for the next read or write operation according to whence, which


### PR DESCRIPTION
The value `1<<31` exceeds the limit of 32-bit integer, which will cause compile failure in 386 arch.
Reducing it to 1<<30 (as suggested by @achille-roussel in [!330](https://github.com/segmentio/kafka-go/pull/330)) solves the error and preserves the flag's functionality.