### PR TITLE
Expose the calculated lag to Readers configured with a GroupID

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -892,10 +892,6 @@ func (r *Reader) Offset() int64 {
 // Lag returns the lag of the last message returned by ReadMessage, or -1
 // if r is backed by a consumer group.
 func (r *Reader) Lag() int64 {
-	if r.useConsumerGroup() {
-		return -1
-	}
-
 	r.mutex.Lock()
 	lag := r.lag
 	r.mutex.Unlock()

--- a/reader.go
+++ b/reader.go
@@ -889,8 +889,7 @@ func (r *Reader) Offset() int64 {
 	return offset
 }
 
-// Lag returns the lag of the last message returned by ReadMessage, or -1
-// if r is backed by a consumer group.
+// Lag returns the lag of the last message returned by ReadMessage or FetchMessage.
 func (r *Reader) Lag() int64 {
 	r.mutex.Lock()
 	lag := r.lag


### PR DESCRIPTION
We have a use case where seeing the lag for a given topic/partition is almost critical. kafka-go already tracks this internally, and it would be good to be able to read this value in the context of a Consumer Group. This change works fine here, but I'd rather not continue using a fork.

Worst-case, if there are fatal flaws with exposing this, or perhaps non-fatal caveats, they could be added to the README to good effect.

Thanks!