### PR TITLE
Add max idle conn timeout for Writer.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
         ports: ['9092:9092']
         environment:
           KAFKA_BROKER_ID: '1'
+          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'
@@ -42,6 +43,7 @@ jobs:
         ports: ['9092:9092','9093:9093']
         environment:
           KAFKA_BROKER_ID: '1'
+          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'
@@ -73,6 +75,7 @@ jobs:
         ports: ['9092:9092','9093:9093']
         environment:
           KAFKA_BROKER_ID: '1'
+          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'
@@ -104,6 +107,7 @@ jobs:
         ports: ['9092:9092','9093:9093']
         environment:
           KAFKA_BROKER_ID: '1'
+          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
         ports: ['9092:9092']
         environment:
           KAFKA_BROKER_ID: '1'
-          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'
@@ -43,7 +42,6 @@ jobs:
         ports: ['9092:9092','9093:9093']
         environment:
           KAFKA_BROKER_ID: '1'
-          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'
@@ -75,7 +73,6 @@ jobs:
         ports: ['9092:9092','9093:9093']
         environment:
           KAFKA_BROKER_ID: '1'
-          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'
@@ -107,7 +104,6 @@ jobs:
         ports: ['9092:9092','9093:9093']
         environment:
           KAFKA_BROKER_ID: '1'
-          KAFKA_CONNECTIONS_MAX_IDLE_MS: '2000'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
           KAFKA_ADVERTISED_HOST_NAME: 'localhost'

--- a/writer.go
+++ b/writer.go
@@ -695,16 +695,13 @@ func (w *writer) run() {
 				}
 				batchTimerRunning = false
 			}
-
 			if conn != nil && time.Now().After(idleConnDeadline) {
 				conn.Close()
 				conn = nil
 			}
-
 			if len(batch) == 0 {
 				continue
 			}
-
 			var err error
 			if conn, err = w.write(conn, batch, resch); err != nil {
 				if conn != nil {

--- a/writer.go
+++ b/writer.go
@@ -103,6 +103,11 @@ type WriterConfig struct {
 	// The default is to refresh partitions every 15 seconds.
 	RebalanceInterval time.Duration
 
+	// Connections that were idle for this duration will not be reused.
+	//
+	// Defaults to 540 seconds.
+	ConnMaxIdleTimeout time.Duration
+
 	// Number of acknowledges from partition replicas required before receiving
 	// a response to a produce request (default to -1, which means to wait for
 	// all replicas).
@@ -247,6 +252,9 @@ func NewWriter(config WriterConfig) *Writer {
 
 	if config.RebalanceInterval == 0 {
 		config.RebalanceInterval = 15 * time.Second
+	}
+	if config.ConnMaxIdleTimeout == 0 {
+		config.ConnMaxIdleTimeout = 540 * time.Second
 	}
 
 	w := &Writer{
@@ -556,6 +564,7 @@ type writer struct {
 	maxMessageBytes int
 	batchTimeout    time.Duration
 	writeTimeout    time.Duration
+	connIdleTimeout time.Duration
 	dialer          *Dialer
 	msgs            chan writerMessage
 	join            sync.WaitGroup
@@ -575,6 +584,7 @@ func newWriter(partition int, config WriterConfig, stats *writerStats) *writer {
 		maxMessageBytes: config.BatchBytes,
 		batchTimeout:    config.BatchTimeout,
 		writeTimeout:    config.WriteTimeout,
+		connIdleTimeout: config.ConnMaxIdleTimeout,
 		dialer:          config.Dialer,
 		msgs:            make(chan writerMessage, config.QueueCapacity),
 		stats:           stats,
@@ -624,6 +634,7 @@ func (w *writer) run() {
 	var resch = make([](chan<- error), 0, w.batchSize)
 	var lastMsg writerMessage
 	var batchSizeBytes int
+	var connIdleDeadline time.Time
 
 	defer func() {
 		if conn != nil {
@@ -687,6 +698,10 @@ func (w *writer) run() {
 			if len(batch) == 0 {
 				continue
 			}
+			if conn != nil && time.Now().After(connIdleDeadline) {
+				conn.Close()
+				conn = nil
+			}
 			var err error
 			if conn, err = w.write(conn, batch, resch); err != nil {
 				if conn != nil {
@@ -694,6 +709,7 @@ func (w *writer) run() {
 					conn = nil
 				}
 			}
+			connIdleDeadline = time.Now().Add(w.connIdleTimeout)
 			for i := range batch {
 				batch[i] = Message{}
 			}

--- a/writer_test.go
+++ b/writer_test.go
@@ -47,6 +47,14 @@ func TestWriter(t *testing.T) {
 			scenario: "writing messsages with a small batch byte size",
 			function: testWriterSmallBatchBytes,
 		},
+		{
+			scenario: "writing messages to a connection after the broker's max idle connection time",
+			function: testWriterIdleConnDefaultTimeout,
+		},
+		{
+			scenario: "writing messages to a connection after the broker's max idle connection time, with lower idle conn timeout",
+			function: testWriterIdleConnSpecificTimeout,
+		},
 	}
 
 	for _, test := range tests {
@@ -205,33 +213,32 @@ func testWriterMaxBytes(t *testing.T) {
 		return
 	}
 
-	firstMsg :=[]byte("Hello World!")
+	firstMsg := []byte("Hello World!")
 	secondMsg := []byte("LeftOver!")
 	msgs := []Message{
-			{
-				Value: firstMsg,
-			},
-			{
-				Value: secondMsg,
-			},
-
+		{
+			Value: firstMsg,
+		},
+		{
+			Value: secondMsg,
+		},
 	}
-	if err := w.WriteMessages(context.Background(),msgs...) ; err == nil {
+	if err := w.WriteMessages(context.Background(), msgs...); err == nil {
 		t.Error("expected error")
 		return
 	} else if err != nil {
 		switch e := err.(type) {
 		case MessageTooLargeError:
 			if string(e.Message.Value) != string(firstMsg) {
-				t.Errorf("unxpected returned message. Expected: %s, Got %s",firstMsg, e.Message.Value)
+				t.Errorf("unxpected returned message. Expected: %s, Got %s", firstMsg, e.Message.Value)
 				return
 			}
 			if len(e.Remaining) != 1 {
 				t.Error("expected remaining errors; found none")
 				return
 			}
-			if string(e.Remaining[0].Value) != string(secondMsg){
-				t.Errorf("unxpected returned message. Expected: %s, Got %s",secondMsg, e.Message.Value)
+			if string(e.Remaining[0].Value) != string(secondMsg) {
+				t.Errorf("unxpected returned message. Expected: %s, Got %s", secondMsg, e.Message.Value)
 				return
 			}
 		default:
@@ -431,4 +438,65 @@ func testWriterSmallBatchBytes(t *testing.T) {
 		}
 		t.Error("bad messages in partition", msgs)
 	}
+}
+
+func testWriterIdleConnDefaultTimeout(t *testing.T) {
+	const topic = "test-writer-idleconn-1"
+	createTopic(t, topic, 1)
+	w := newTestWriter(WriterConfig{
+		Topic: topic,
+	})
+	defer w.Close()
+	ctx := context.Background()
+	msg := Message{Value: []byte("Hello World")}
+	// initial message when we establish a connection with the broker
+	err := w.WriteMessages(ctx, msg)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	// sleep for more than the broker's max idle conn time
+	time.Sleep(2300 * time.Millisecond)
+
+	// The write should fail as we will try to send the message on a connection that the broker closed
+	err = w.WriteMessages(ctx, msg)
+	if err == nil {
+		t.Errorf("Expected broken pipe error")
+	}
+	// This write should pass as the writer will establish a new connection after the previous failure.
+	err = w.WriteMessages(ctx, msg)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+}
+
+func testWriterIdleConnSpecificTimeout(t *testing.T) {
+	const topic = "test-writer-idleconn-2"
+	createTopic(t, topic, 1)
+	w := newTestWriter(WriterConfig{
+		Topic:              topic,
+		ConnMaxIdleTimeout: 1500 * time.Millisecond,
+	})
+	defer w.Close()
+	ctx := context.Background()
+	msg := Message{Value: []byte("Hello World")}
+	// initial message when we establish a connection with the broker
+	err := w.WriteMessages(ctx, msg)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	// sleep for more than the broker's max idle conn time
+	time.Sleep(2300 * time.Millisecond)
+
+	// This write should pass as the writer will establish a new connection after the max idle conn timeout.
+	err = w.WriteMessages(ctx, msg)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	// This write should pass as the writer will establish a new connection after the previous failure.
+	err = w.WriteMessages(ctx, msg)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
 }


### PR DESCRIPTION
https://github.com/segmentio/kafka-go/issues/345#issuecomment-528451990
> We saw a similar issue on our production boxes, we have a metrics topic where we observed weird behavior, messages are successfully published for 25 mins, then we see broken pipe errors for the next 25 mins, and then the cycle continues.

> Upon further investigation we found that,

> We publish one message per 5 mins, and there are 5 partitions, so the Kafka writer sends 1 message to each partition every 25mins. Under the default settings, the Kafka broker closes a connection if it doesn't receive any new message in the last 10 mins. But the Kafka writer doesn’t know that the connection has been closed, so when it tries to a second message on the same connection, it sees broken pipe errors.

> So for the next 25 mins as the writer cycles through the partitions it sends messages on connections which have been closed, and on next cycle new connections are created and the messages sent on these new connections succeed, and cycle repeats.

> When I looked through Kafka documentation, I found that there is a config that can solve this issue, please note that the default value is set to 9mins, which is 1 min less than broker timeout.

> connections.max.idle.ms | Close idle connections after the number of milliseconds specified by this config. | long | 540000 |  


Add max idle connection time for writer.
https://kafka.apache.org/documentation/#producerconfigs
