### PR TITLE
Wildcard topics

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1055,20 +1055,6 @@ func (c *Conn) ListTopics() (topics map[string][]int, err error) {
 		},
 	)
 	return
-
-	//allPartitions, err := c.ReadPartitions()
-	//
-	//if err != nil {
-	//	return nil, err
-	//}
-
-	//topics := make(map[string][]string)
-	//for _, partition := range allPartitions {
-	//	if rgx.MatchString(partition.Topic) {
-	//		partitions = append(partitions, partition)
-	//	}
-	//}
-	//return
 }
 
 // Write writes a message to the kafka broker that this connection was

--- a/conn.go
+++ b/conn.go
@@ -1045,6 +1045,7 @@ func (c *Conn) ListTopics() (topics map[string][]int, err error) {
 				}
 				partitionIDs := []int{}
 				for _, p := range t.Partitions {
+
 					partitionIDs = append(partitionIDs, int(p.PartitionID))
 				}
 				topics[t.TopicName] = partitionIDs

--- a/reader.go
+++ b/reader.go
@@ -664,6 +664,7 @@ func NewReader(config ReaderConfig) *Reader {
 	var rc *regexConfig
 	if config.WildcardTopicEnabled {
 		if scanner := getTopicScanner(); scanner != nil {
+
 			subscriberID, updateChan, unsubscribeChan, err := scanner.subscribe(config.Topic, config.Brokers)
 			if err != nil {
 				panic(err)
@@ -681,6 +682,8 @@ func NewReader(config ReaderConfig) *Reader {
 				cancelUpdateTopicLoopChan: make(chan struct{}),
 				interuptChan:              make(chan struct{}, 1),
 			}
+		} else {
+			panic(errors.New("could not get topic scanner"))
 		}
 
 	}
@@ -711,11 +714,11 @@ func NewReader(config ReaderConfig) *Reader {
 	if config.WildcardTopicEnabled {
 		go r.listenToTopicUpdates()
 	}
-
 	if r.useConsumerGroup() {
 		r.done = make(chan struct{})
 		topics := []string{r.config.Topic}
 		if config.WildcardTopicEnabled {
+
 			topics = []string{}
 			for topic, _ := range r.regexConfig.assignments {
 				topics = append(topics, topic)

--- a/reader_test.go
+++ b/reader_test.go
@@ -1368,13 +1368,6 @@ func TestReaderWildcardTopics(t *testing.T) {
 		t.Fatalf("Failed to write message: %+v", err)
 	}
 
-	for {
-		if len(reader.wildcardConfig.assignments) == 3 {
-
-			break
-		}
-	}
-
 	if msg, err := reader.ReadMessage(ctx); err != nil {
 		t.Fatalf("Failed to read message: %+v", err)
 	} else if msg.Topic != topic3 {

--- a/reader_test.go
+++ b/reader_test.go
@@ -514,7 +514,7 @@ func TestCloseLeavesGroup(t *testing.T) {
 
 	_, err = r.ReadMessage(ctx)
 	if err != nil {
-		t.Fatalf("our reader never joind its group or couldn't read a message: %v", err)
+		t.Fatalf("our reader never joined its group or couldn't read a message: %v", err)
 	}
 	resp := descGroups()
 	if len(resp.Groups) != 1 {

--- a/regex.go
+++ b/regex.go
@@ -1,17 +1,17 @@
 package kafka
 
 type (
-	regexConfig struct {
+	wildcardConfig struct {
 		subscriberID              string
-		assignments               regexAssignments
+		assignments               wildcardAssignments
 		updateChan                <-chan map[string][]int
 		unsubscribeChan           chan<- string
 		cancelUpdateTopicLoopChan chan struct{}
 	}
-	regexAssignments map[string]map[int]int64
+	wildcardAssignments map[string]map[int]int64
 )
 
-func getOffsetsByPartitionByTopic(topics map[string][]int) (offsetsByPartitionByTopic map[string]map[int]int64) {
+func getOffsetsByPartitionByTopic(topics map[string][]int) (offsetsByPartitionByTopic wildcardAssignments) {
 
 	offsetsByPartitionByTopic = map[string]map[int]int64{}
 	for topic, partitions := range topics {

--- a/regex.go
+++ b/regex.go
@@ -7,7 +7,6 @@ type (
 		updateChan                <-chan map[string][]int
 		unsubscribeChan           chan<- string
 		cancelUpdateTopicLoopChan chan struct{}
-		interuptChan              chan struct{}
 	}
 	regexAssignments map[string]map[int]int64
 )

--- a/regex.go
+++ b/regex.go
@@ -1,0 +1,9 @@
+package kafka
+
+type (
+	regexConfig struct {
+		partitions      []Partition
+		updateChan      <-chan []Partition
+		unsubscribeChan chan<- struct{}
+	}
+)

--- a/regex.go
+++ b/regex.go
@@ -2,8 +2,23 @@ package kafka
 
 type (
 	regexConfig struct {
-		partitions      []Partition
-		updateChan      <-chan []Partition
-		unsubscribeChan chan<- struct{}
+		subscriberID              string
+		assignments               regexAssignments
+		updateChan                <-chan map[string][]int
+		unsubscribeChan           chan<- string
+		cancelUpdateTopicLoopChan chan struct{}
+		interuptChan              chan struct{}
 	}
+	regexAssignments map[string]map[int]int64
 )
+
+func (r *regexConfig) getAssignmentPartitionsForTopic(topic string) *[]int {
+	if offsetsByPartition, ok := r.assignments[topic]; ok {
+		var partitions []int
+		for partition, _ := range offsetsByPartition {
+			partitions = append(partitions, partition)
+		}
+		return &partitions
+	}
+	return nil
+}

--- a/regex.go
+++ b/regex.go
@@ -12,13 +12,15 @@ type (
 	regexAssignments map[string]map[int]int64
 )
 
-func (r *regexConfig) getAssignmentPartitionsForTopic(topic string) *[]int {
-	if offsetsByPartition, ok := r.assignments[topic]; ok {
-		var partitions []int
-		for partition, _ := range offsetsByPartition {
-			partitions = append(partitions, partition)
+func getOffsetsByPartitionByTopic(topics map[string][]int) (offsetsByPartitionByTopic map[string]map[int]int64) {
+
+	offsetsByPartitionByTopic = map[string]map[int]int64{}
+	for topic, partitions := range topics {
+		offsetsByPartition := map[int]int64{}
+		for _, partition := range partitions {
+			offsetsByPartition[partition] = FirstOffset
 		}
-		return &partitions
+		offsetsByPartitionByTopic[topic] = offsetsByPartition
 	}
-	return nil
+	return
 }

--- a/topicscanner.go
+++ b/topicscanner.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -19,10 +20,14 @@ var (
 
 type (
 	topicScanner struct {
-		subscribers     []topicScannerSubscriber
-		closeChan       chan struct{}
-		unsubscribeChan chan string
-		scanIntervalMS  int
+		subscribers          []topicScannerSubscriber
+		updateSubscriberChan chan topicScannerSubscriber
+		closeChan            chan struct{}
+		unsubscribeChan      chan string
+		done                 chan struct{}
+		scanIntervalMS       int
+		closed               bool
+		mutex                sync.Mutex
 	}
 	topicScannerSubscriber struct {
 		id         string
@@ -37,7 +42,10 @@ type (
 //The first process to call this method will instantiate the topic scanner, and get it to start scanning
 //TOPIC_SCANNER_INTERVAL_MS is the environment variable that determines how often the scanner should wake up to scan
 func getTopicScanner() *topicScanner {
-
+	updateSubscriberChan := make(chan topicScannerSubscriber)
+	closeChan := make(chan struct{}, 1)
+	unsubscribeChan := make(chan string)
+	doneChan := make(chan struct{}, 1)
 	once.Do(func() {
 
 		interval := defaultScanningIntervalMS
@@ -49,13 +57,29 @@ func getTopicScanner() *topicScanner {
 			}
 		}
 		topicscanner = &topicScanner{
-			scanIntervalMS:  interval,
-			subscribers:     []topicScannerSubscriber{},
-			closeChan:       make(chan struct{}),
-			unsubscribeChan: make(chan string),
+			scanIntervalMS:       interval,
+			subscribers:          []topicScannerSubscriber{},
+			updateSubscriberChan: updateSubscriberChan,
+			closeChan:            closeChan,
+			unsubscribeChan:      unsubscribeChan,
+			done:                 doneChan,
+			closed:               false,
 		}
 		topicscanner.startScanning()
 	})
+
+	topicscanner.mutex.Lock()
+	if topicscanner.closed {
+
+		topicscanner.updateSubscriberChan = updateSubscriberChan
+		topicscanner.unsubscribeChan = unsubscribeChan
+		topicscanner.closeChan = closeChan
+		topicscanner.done = doneChan
+		topicscanner.closed = false
+		topicscanner.startScanning()
+	}
+	topicscanner.mutex.Unlock()
+
 	return topicscanner
 }
 
@@ -67,19 +91,28 @@ func getTopicScanner() *topicScanner {
 func (t *topicScanner) startScanning() {
 
 	go func() {
+		ticker := time.NewTicker(time.Duration(t.scanIntervalMS) * time.Millisecond)
 	outer:
 		for {
 			select {
 			case _ = <-t.closeChan:
 				t.cleanup()
+				t.done <- struct{}{}
 				break outer
 			case subscriberID := <-t.unsubscribeChan:
 
 				unsubscribe(subscriberID)
-			default:
+			case subscriber := <-t.updateSubscriberChan:
+				subscriberTopics := t.getSubscriberTopics(subscriber, make(map[string]map[string][]int))
+				ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+				select {
+				case <-ctx.Done():
+					break
+				case subscriber.updateChan <- subscriberTopics:
 
+				}
+			case _ = <-ticker.C:
 				t.updateSubscribers()
-				time.Sleep(time.Duration(t.scanIntervalMS) * time.Millisecond)
 			}
 		}
 
@@ -92,7 +125,6 @@ func (t *topicScanner) startScanning() {
 // 2) the channel that the scanner will update the client on it's current topics
 // 3) the channel that the subscriber should use to inform the scanner that it should no longer send it updates
 func (t *topicScanner) subscribe(regex string, brokers []string) (subscriberID string, updateChannel chan map[string][]int, unsubscribeChannel chan string, err error) {
-
 	if len(regex) == 0 {
 		err = errors.New("regex must be non-empty in order to subscribe")
 		return
@@ -112,8 +144,13 @@ func (t *topicScanner) subscribe(regex string, brokers []string) (subscriberID s
 	t.subscribers = append(t.subscribers, subscriber)
 
 	subscriberID = subscriber.id
+
 	go func() {
-		updateChannel <- t.getSubscriberTopics(subscriber, map[string]map[string][]int{})
+		ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+		select {
+		case <-ctx.Done():
+		case t.updateSubscriberChan <- subscriber:
+		}
 	}()
 
 	return
@@ -122,22 +159,39 @@ func (t *topicScanner) subscribe(regex string, brokers []string) (subscriberID s
 //Should not be called directly, if you want to unsubscribe, send a message on the unsubscribe channel
 //Remove the subscription as to no longer update it during the recurring scans
 func unsubscribe(subscriberID string) {
+
 	for index, subscriber := range topicscanner.subscribers {
 		if subscriber.id == subscriberID {
 			close(subscriber.updateChan)
-			topicscanner.subscribers = append(topicscanner.subscribers[index:], topicscanner.subscribers[:index+1]...)
+			topicscanner.subscribers = append(topicscanner.subscribers[:index], topicscanner.subscribers[index+1:]...)
+			break
 		}
 	}
 }
 
 //Run through all the subscribers
 func (t *topicScanner) updateSubscribers() {
+
 	brokerTopics := make(map[string]map[string][]int)
+	wg := sync.WaitGroup{}
+	wg.Add(len(topicscanner.subscribers))
 	for _, subscriber := range t.subscribers {
 		subscriberTopics := t.getSubscriberTopics(subscriber, brokerTopics)
-		subscriber.updateChan <- subscriberTopics
-	}
 
+		//dont block if the thing reading from this isn't reading from it yet
+		//stop trying to send after timeout, next iteration will get it
+		go func() {
+			ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+			select {
+			case <-ctx.Done():
+				break
+			case subscriber.updateChan <- subscriberTopics:
+
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 //Get the specific topics that match the subscribers' regex
@@ -197,8 +251,19 @@ func (t *topicScanner) getSubscriberTopics(subscriber topicScannerSubscriber, br
 
 //Instruct the topic scanner to close
 //Will trigger cleanup()
-func (t *topicScanner) close() {
+func (t *topicScanner) close() error {
 	t.closeChan <- struct{}{}
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+
+	select {
+	case <-ctx.Done():
+		return errors.New("could not close scanner in time")
+	case <-t.done:
+		close(t.done)
+		t.closed = true
+		break
+	}
+	return nil
 }
 
 //The Cleanup process for the topic scanner
@@ -210,6 +275,9 @@ func (t *topicScanner) cleanup() {
 		close(subscriber.updateChan)
 	}
 	close(topicscanner.closeChan)
+	close(topicscanner.updateSubscriberChan)
+	close(topicscanner.unsubscribeChan)
+
 	topicscanner.subscribers = []topicScannerSubscriber{}
 }
 

--- a/topicscanner.go
+++ b/topicscanner.go
@@ -87,7 +87,8 @@ func getTopicScanner() *topicScanner {
 //It handles:
 // 1) instructions to close, calling cleanup()
 // 2) clients un-subscribing from the topic scanner
-// 3) updating each subscriber with the current list of topics that match their regex pattern
+// 3) clients subscribing to the topic scanner will have priority in receiving their topics
+// 4) every set interval, updating each subscriber with the current list of topics that match their regex pattern
 func (t *topicScanner) startScanning() {
 
 	go func() {

--- a/topicscanner.go
+++ b/topicscanner.go
@@ -72,9 +72,16 @@ func (t *topicScanner) subscribe(regex string, brokers []string) (subscriberID s
 	t.subscribers = append(t.subscribers, subscriber)
 
 	subscriberID = subscriber.id
+	go func() {
+		updateChannel <- t.getSubscriberTopics(subscriber, map[string]map[string][]int{})
+	}()
 
-	updateChannel <- t.getSubscriberTopics(subscriber, map[string]map[string][]int{})
 	return
+}
+
+//Run this after youve started listening to the subscription's update channel
+func (t *topicScanner) getInitialTopics() {
+
 }
 
 func unsubscribe(subscriberID string) {

--- a/topicscanner.go
+++ b/topicscanner.go
@@ -1,0 +1,152 @@
+package kafka
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+var (
+	topicscanner              *topicScanner
+	once                      sync.Once
+	defaultScanningIntervalMS = 10000
+)
+
+type (
+	topicScanner struct {
+		subscribers     []topicScannerSubscriber
+		closeChan       chan struct{}
+		unsubscribeChan chan string
+		scanIntervalMS  int
+	}
+	topicScannerSubscriber struct {
+		id         string
+		regex      string
+		brokers    []string
+		updateChan chan []Partition
+	}
+)
+
+func (t *topicScanner) startScanning() {
+
+	go func() {
+	outer:
+		for {
+			select {
+			case _ = <-t.closeChan:
+				t.cleanup()
+				break outer
+			case subscriberID := <-t.unsubscribeChan:
+				unsubscribe(subscriberID)
+			default:
+				t.updateTopicSubscribers()
+				time.Sleep(time.Duration(t.scanIntervalMS) * time.Millisecond)
+			}
+		}
+
+	}()
+}
+
+func (t *topicScanner) subscribe(regex string, brokers []string) (subscriberID string, updateChannel chan []Partition, unsubscribeChannel chan string, err error) {
+
+	if len(regex) == 0 {
+		err = errors.New("regex must be non-empty in order to subscribe")
+		return
+	}
+	if len(brokers) == 0 {
+		err = errors.New("brokers must be non-empty in order to subscribe")
+		return
+	}
+	updateChannel = make(chan []Partition)
+	unsubscribeChannel = t.unsubscribeChan
+	subscriber := topicScannerSubscriber{
+		updateChan: updateChannel,
+		regex:      regex,
+		brokers:    brokers,
+	}
+	subscriber.generateID()
+	t.subscribers = append(t.subscribers, subscriber)
+
+	subscriberID = subscriber.id
+
+	return
+}
+
+func unsubscribe(subscriberID string) {
+	for index, subscriber := range topicscanner.subscribers {
+		if subscriber.id == subscriberID {
+			close(subscriber.updateChan)
+			topicscanner.subscribers = append(topicscanner.subscribers[index:], topicscanner.subscribers[:index+1]...)
+		}
+	}
+}
+
+func (t *topicScanner) updateTopicSubscribers() {
+	brokerTopics := make(map[string][]Partition)
+	for _, subscriber := range t.subscribers {
+		subscriberPartitions := []Partition{}
+		for _, broker := range subscriber.brokers {
+			b, ok := brokerTopics[broker]
+			if !ok {
+				conn, err := Dial("tcp", broker)
+				if err != nil {
+					continue
+				}
+				partitions, err := conn.ListTopics(subscriber.regex)
+				if err == nil && len(partitions) > 0 {
+					brokerTopics[broker] = partitions
+					subscriberPartitions = append(subscriberPartitions, partitions...)
+				}
+				conn.Close()
+
+			} else {
+				subscriberPartitions = append(subscriberPartitions, b...)
+			}
+		}
+		subscriber.updateChan <- subscriberPartitions
+	}
+
+}
+
+func getTopicScanner() *topicScanner {
+	once.Do(func() {
+		interval := defaultScanningIntervalMS
+		intervalString, ok := os.LookupEnv("TOPIC_SCANNER_INTERVAL_MS")
+		if ok {
+			intervalFromString, err := strconv.Atoi(intervalString)
+			if err == nil {
+				interval = intervalFromString
+			}
+		}
+		topicscanner = &topicScanner{
+			scanIntervalMS:  interval,
+			subscribers:     []topicScannerSubscriber{},
+			closeChan:       make(chan struct{}),
+			unsubscribeChan: make(chan string),
+		}
+
+	})
+	return topicscanner
+}
+
+func (t *topicScanner) close() {
+	t.closeChan <- struct{}{}
+}
+
+func (t *topicScanner) cleanup() {
+	for _, subscriber := range t.subscribers {
+		close(subscriber.updateChan)
+	}
+	close(topicscanner.closeChan)
+	topicscanner.subscribers = []topicScannerSubscriber{}
+}
+
+func (s *topicScannerSubscriber) generateID() {
+	id := s.regex
+	for _, broker := range s.brokers {
+		id += "_" + broker
+	}
+	s.id = id
+}

--- a/topicscanner.go
+++ b/topicscanner.go
@@ -113,7 +113,9 @@ func (t *topicScanner) startScanning() {
 
 				}
 			case _ = <-ticker.C:
+				t.mutex.Lock()
 				t.updateSubscribers()
+				t.mutex.Unlock()
 			}
 		}
 
@@ -142,8 +144,9 @@ func (t *topicScanner) subscribe(regex string, brokers []string) (subscriberID s
 		brokers:    brokers,
 	}
 	subscriber.generateID()
+	t.mutex.Lock()
 	t.subscribers = append(t.subscribers, subscriber)
-
+	t.mutex.Unlock()
 	subscriberID = subscriber.id
 
 	go func() {

--- a/topicscanner_test.go
+++ b/topicscanner_test.go
@@ -1,0 +1,127 @@
+package kafka
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestTopicScanner(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		scenario string
+		function func(*testing.T, context.Context, *topicScanner)
+	}{
+		{
+			scenario: "calling topic scanner subscribe and getting back the topics that match regex",
+			function: testScannerSubscribe,
+		},
+		{
+			scenario: "calling topic scanner unsubscribe and successfully un-subscribing",
+			function: testScannerUnsubscribe,
+		},
+	}
+	err := os.Setenv("TOPIC_SCANNER_INTERVAL_MS", "1000")
+	if err != nil {
+		t.Fatalf("could not scanner interval: %v", err)
+	}
+
+	for _, test := range tests {
+		testFunc := test.function
+		t.Run(test.scenario, func(t *testing.T) {
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			scanner := getTopicScanner()
+			testFunc(t, ctx, scanner)
+			defer scanner.close()
+
+		})
+	}
+}
+
+func testScannerSubscribe(t *testing.T, ctx context.Context, scanner *topicScanner) {
+	topic1 := makeTopic()
+	topic2 := makeTopic()
+	topic3 := makeTopic()
+	createTopic(t, topic1, 1)
+	createTopic(t, topic2, 2)
+	createTopic(t, topic3, 3)
+
+	regex := topic1 + "|" + topic2
+	brokers := []string{"localhost:9092"}
+	_, updateChan, _, err := scanner.subscribe(regex, brokers)
+	if err != nil {
+		t.Fatalf("could not subscribe to scanner: %v", err)
+	}
+outer:
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("updated topics did not come in time")
+
+		case partitionsByTopic := <-updateChan:
+			if len(partitionsByTopic) != 2 {
+				t.Fatalf("unexpected number of topics recieved by scanner: %v", partitionsByTopic)
+			}
+			if partitions, ok := partitionsByTopic[topic1]; !ok {
+				t.Fatalf("topic1 not returned by scanner: %v", partitionsByTopic)
+			} else {
+				if len(partitions) != 1 {
+					t.Fatalf("topic1 returned by scanner does not have only 1 partition listed: %v", partitionsByTopic)
+				}
+			}
+			if partitions, ok := partitionsByTopic[topic2]; !ok {
+				t.Fatalf("topic2 not returned by scanner: %v", partitionsByTopic)
+			} else {
+				if len(partitions) != 2 {
+					t.Fatalf("topic2 returned by scanner does not have only 2 partition listed: %v", partitionsByTopic)
+				}
+			}
+			break outer
+		}
+	}
+
+}
+
+func testScannerUnsubscribe(t *testing.T, ctx context.Context, scanner *topicScanner) {
+	topic1 := makeTopic()
+	topic2 := makeTopic()
+	createTopic(t, topic1, 1)
+	createTopic(t, topic2, 2)
+
+	regex := topic1 + "|" + topic2
+	brokers := []string{"localhost:9092"}
+
+	subscriberID, updatechan, unsubscribeChan, err := scanner.subscribe(regex, brokers)
+	if err != nil {
+		t.Fatalf("could not subscribe to scanner: %v", err)
+	}
+	_, updatechan2, _, err := scanner.subscribe(regex, brokers)
+	if err != nil {
+		t.Fatalf("could not subscribe to scanner: %v", err)
+	}
+
+	//unsubscribe the second subscriber, make sure only one ise left
+
+outer:
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("scanner subscribers did not decrease in time")
+		case _ = <-updatechan:
+
+			//close this channel after getting the first message
+			if len(scanner.subscribers) == 1 {
+				break outer
+			}
+			unsubscribeChan <- subscriberID
+		case <-updatechan2:
+
+		}
+
+	}
+}


### PR DESCRIPTION
This PR revolves around giving the Reader capabilities to read from wildcard topics

There is a singleton routine called the topic scanner that gets triggered by the first reader that wants to use a wildcard topic evaluation. Those readers that want to use the wildcard topics will subscribe to the topic scanner and receive periodic updates from the scanner that keeps track of them and their wildcard pattern. The scanner also allows readers to unsubscribe when they close. The scanner will run each subscriber's regex against the list of all the topics in that broker to send it only matching topics (regex matching is based off of the golang regex.MatchString()). The scanner will cache the list of topics for a broker while its updating each subscriber to reduce the amount of calls made to kafka.

One decision I made was that if the reader is not associated with a consumer group and has wildcards enabled, it will ignore the partition field as there is no guarantee you'll find a specific partition across several topics, though that can be changed based on your input.