### PR TITLE
add kafka.ApiVersion.Format

### DIFF
--- a/createtopics.go
+++ b/createtopics.go
@@ -222,7 +222,7 @@ func (c *Conn) createTopics(request createTopicsRequestV0) (createTopicsResponse
 				deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
 				request.Timeout = milliseconds(deadlineToTimeout(deadline, now))
 			}
-			return c.writeRequest(createTopicsRequest, v0, id, request)
+			return c.writeRequest(createTopics, v0, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {

--- a/deletetopics.go
+++ b/deletetopics.go
@@ -94,7 +94,7 @@ func (c *Conn) deleteTopics(request deleteTopicsRequestV0) (deleteTopicsResponse
 				deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
 				request.Timeout = milliseconds(deadlineToTimeout(deadline, now))
 			}
-			return c.writeRequest(deleteTopicsRequest, v0, id, request)
+			return c.writeRequest(deleteTopics, v0, id, request)
 		},
 		func(deadline time.Time, size int) error {
 			return expectZeroSize(func() (remain int, err error) {

--- a/protocol.go
+++ b/protocol.go
@@ -42,54 +42,54 @@ func (v ApiVersion) Format(w fmt.State, r rune) {
 type apiKey int16
 
 const (
-	produce apiKey = iota
-	fetch
-	listOffsets
-	metadata
-	leaderAndIsr
-	stopReplica
-	updateMetadata
-	controlledShutdown
-	offsetCommit
-	offsetFetch
-	findCoordinator
-	joinGroup
-	heartbeat
-	leaveGroup
-	syncGroup
-	describeGroups
-	listGroups
-	saslHandshake
-	apiVersions
-	createTopics
-	deleteTopics
-	deleteRecords
-	initProducerId
-	offsetForLeaderEpoch
-	addPartitionsToTxn
-	addOffsetsToTxn
-	endTxn
-	writeTxnMarkers
-	txnOffsetCommit
-	describeAcls
-	createAcls
-	deleteAcls
-	describeConfigs
-	alterConfigs
-	alterReplicaLogDirs
-	describeLogDirs
-	saslAuthenticate
-	createPartitions
-	createDelegationToken
-	renewDelegationToken
-	expireDelegationToken
-	describeDelegationToken
-	deleteGroups
-	electLeaders
-	incrementalAlterConfigs
-	alterPartitionReassignments
-	listPartitionReassignments
-	offsetDelete
+	produce                     apiKey = 0
+	fetch                       apiKey = 1
+	listOffsets                 apiKey = 2
+	metadata                    apiKey = 3
+	leaderAndIsr                apiKey = 4
+	stopReplica                 apiKey = 5
+	updateMetadata              apiKey = 6
+	controlledShutdown          apiKey = 7
+	offsetCommit                apiKey = 8
+	offsetFetch                 apiKey = 9
+	findCoordinator             apiKey = 10
+	joinGroup                   apiKey = 11
+	heartbeat                   apiKey = 12
+	leaveGroup                  apiKey = 13
+	syncGroup                   apiKey = 14
+	describeGroups              apiKey = 15
+	listGroups                  apiKey = 16
+	saslHandshake               apiKey = 17
+	apiVersions                 apiKey = 18
+	createTopics                apiKey = 19
+	deleteTopics                apiKey = 20
+	deleteRecords               apiKey = 21
+	initProducerId              apiKey = 22
+	offsetForLeaderEpoch        apiKey = 23
+	addPartitionsToTxn          apiKey = 24
+	addOffsetsToTxn             apiKey = 25
+	endTxn                      apiKey = 26
+	writeTxnMarkers             apiKey = 27
+	txnOffsetCommit             apiKey = 28
+	describeAcls                apiKey = 29
+	createAcls                  apiKey = 30
+	deleteAcls                  apiKey = 31
+	describeConfigs             apiKey = 32
+	alterConfigs                apiKey = 33
+	alterReplicaLogDirs         apiKey = 34
+	describeLogDirs             apiKey = 35
+	saslAuthenticate            apiKey = 36
+	createPartitions            apiKey = 37
+	createDelegationToken       apiKey = 38
+	renewDelegationToken        apiKey = 39
+	expireDelegationToken       apiKey = 40
+	describeDelegationToken     apiKey = 41
+	deleteGroups                apiKey = 42
+	electLeaders                apiKey = 43
+	incrementalAlterConfigs     apiKey = 44
+	alterPartitionReassignments apiKey = 45
+	listPartitionReassignments  apiKey = 46
+	offsetDelete                apiKey = 47
 )
 
 func (k apiKey) String() string {
@@ -102,17 +102,17 @@ func (k apiKey) String() string {
 type apiVersion int16
 
 const (
-	v0 apiVersion = iota
-	v1
-	v2
-	v3
-	v4
-	v5
-	v6
-	v7
-	v8
-	v9
-	v10
+	v0  apiVersion = 0
+	v1  apiVersion = 1
+	v2  apiVersion = 2
+	v3  apiVersion = 3
+	v4  apiVersion = 4
+	v5  apiVersion = 5
+	v6  apiVersion = 6
+	v7  apiVersion = 7
+	v8  apiVersion = 8
+	v9  apiVersion = 9
+	v10 apiVersion = 10
 )
 
 var apiKeyStrings = [...]string{

--- a/protocol.go
+++ b/protocol.go
@@ -3,42 +3,168 @@ package kafka
 import (
 	"encoding/binary"
 	"fmt"
+	"strconv"
 )
+
+type ApiVersion struct {
+	ApiKey     int16
+	MinVersion int16
+	MaxVersion int16
+}
+
+func (v ApiVersion) Format(w fmt.State, r rune) {
+	switch r {
+	case 's':
+		fmt.Fprint(w, apiKey(v.ApiKey))
+	case 'd':
+		switch {
+		case w.Flag('-'):
+			fmt.Fprint(w, v.MinVersion)
+		case w.Flag('+'):
+			fmt.Fprint(w, v.MaxVersion)
+		default:
+			fmt.Fprint(w, v.ApiKey)
+		}
+	case 'v':
+		switch {
+		case w.Flag('-'):
+			fmt.Fprintf(w, "v%d", v.MinVersion)
+		case w.Flag('+'):
+			fmt.Fprintf(w, "v%d", v.MaxVersion)
+		case w.Flag('#'):
+			fmt.Fprintf(w, "kafka.ApiVersion{ApiKey:%d MinVersion:%d MaxVersion:%d}", v.ApiKey, v.MinVersion, v.MaxVersion)
+		default:
+			fmt.Fprintf(w, "%s[v%d:v%d]", apiKey(v.ApiKey), v.MinVersion, v.MaxVersion)
+		}
+	}
+}
 
 type apiKey int16
 
 const (
-	produceRequest          apiKey = 0
-	fetchRequest            apiKey = 1
-	listOffsetRequest       apiKey = 2
-	metadataRequest         apiKey = 3
-	offsetCommitRequest     apiKey = 8
-	offsetFetchRequest      apiKey = 9
-	groupCoordinatorRequest apiKey = 10
-	joinGroupRequest        apiKey = 11
-	heartbeatRequest        apiKey = 12
-	leaveGroupRequest       apiKey = 13
-	syncGroupRequest        apiKey = 14
-	describeGroupsRequest   apiKey = 15
-	listGroupsRequest       apiKey = 16
-	saslHandshakeRequest    apiKey = 17
-	apiVersionsRequest      apiKey = 18
-	createTopicsRequest     apiKey = 19
-	deleteTopicsRequest     apiKey = 20
-	saslAuthenticateRequest apiKey = 36
+	produce apiKey = iota
+	fetch
+	listOffsets
+	metadata
+	leaderAndIsr
+	stopReplica
+	updateMetadata
+	controlledShutdown
+	offsetCommit
+	offsetFetch
+	findCoordinator
+	joinGroup
+	heartbeat
+	leaveGroup
+	syncGroup
+	describeGroups
+	listGroups
+	saslHandshake
+	apiVersions
+	createTopics
+	deleteTopics
+	deleteRecords
+	initProducerId
+	offsetForLeaderEpoch
+	addPartitionsToTxn
+	addOffsetsToTxn
+	endTxn
+	writeTxnMarkers
+	txnOffsetCommit
+	describeAcls
+	createAcls
+	deleteAcls
+	describeConfigs
+	alterConfigs
+	alterReplicaLogDirs
+	describeLogDirs
+	saslAuthenticate
+	createPartitions
+	createDelegationToken
+	renewDelegationToken
+	expireDelegationToken
+	describeDelegationToken
+	deleteGroups
+	electLeaders
+	incrementalAlterConfigs
+	alterPartitionReassignments
+	listPartitionReassignments
+	offsetDelete
 )
+
+func (k apiKey) String() string {
+	if i := int(k); i >= 0 && i < len(apiKeyStrings) {
+		return apiKeyStrings[i]
+	}
+	return strconv.Itoa(int(k))
+}
 
 type apiVersion int16
 
 const (
-	v0  apiVersion = 0
-	v1  apiVersion = 1
-	v2  apiVersion = 2
-	v3  apiVersion = 3
-	v5  apiVersion = 5
-	v7  apiVersion = 7
-	v10 apiVersion = 10
+	v0 apiVersion = iota
+	v1
+	v2
+	v3
+	v4
+	v5
+	v6
+	v7
+	v8
+	v9
+	v10
 )
+
+var apiKeyStrings = [...]string{
+	produce:                     "Produce",
+	fetch:                       "Fetch",
+	listOffsets:                 "ListOffsets",
+	metadata:                    "Metadata",
+	leaderAndIsr:                "LeaderAndIsr",
+	stopReplica:                 "StopReplica",
+	updateMetadata:              "UpdateMetadata",
+	controlledShutdown:          "ControlledShutdown",
+	offsetCommit:                "OffsetCommit",
+	offsetFetch:                 "OffsetFetch",
+	findCoordinator:             "FindCoordinator",
+	joinGroup:                   "JoinGroup",
+	heartbeat:                   "Heartbeat",
+	leaveGroup:                  "LeaveGroup",
+	syncGroup:                   "SyncGroup",
+	describeGroups:              "DescribeGroups",
+	listGroups:                  "ListGroups",
+	saslHandshake:               "SaslHandshake",
+	apiVersions:                 "ApiVersions",
+	createTopics:                "CreateTopics",
+	deleteTopics:                "DeleteTopics",
+	deleteRecords:               "DeleteRecords",
+	initProducerId:              "InitProducerId",
+	offsetForLeaderEpoch:        "OffsetForLeaderEpoch",
+	addPartitionsToTxn:          "AddPartitionsToTxn",
+	addOffsetsToTxn:             "AddOffsetsToTxn",
+	endTxn:                      "EndTxn",
+	writeTxnMarkers:             "WriteTxnMarkers",
+	txnOffsetCommit:             "TxnOffsetCommit",
+	describeAcls:                "DescribeAcls",
+	createAcls:                  "CreateAcls",
+	deleteAcls:                  "DeleteAcls",
+	describeConfigs:             "DescribeConfigs",
+	alterConfigs:                "AlterConfigs",
+	alterReplicaLogDirs:         "AlterReplicaLogDirs",
+	describeLogDirs:             "DescribeLogDirs",
+	saslAuthenticate:            "SaslAuthenticate",
+	createPartitions:            "CreatePartitions",
+	createDelegationToken:       "CreateDelegationToken",
+	renewDelegationToken:        "RenewDelegationToken",
+	expireDelegationToken:       "ExpireDelegationToken",
+	describeDelegationToken:     "DescribeDelegationToken",
+	deleteGroups:                "DeleteGroups",
+	electLeaders:                "ElectLeaders",
+	incrementalAlterConfigs:     "IncrementalAlfterConfigs",
+	alterPartitionReassignments: "AlterPartitionReassignments",
+	listPartitionReassignments:  "ListPartitionReassignments",
+	offsetDelete:                "OffsetDelete",
+}
 
 type requestHeader struct {
 	Size          int32

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -8,6 +8,29 @@ import (
 	"testing"
 )
 
+func TestApiVersionsFormat(t *testing.T) {
+	for _, test := range []struct {
+		version ApiVersion
+		format  string
+		output  string
+	}{
+		{version: ApiVersion{1, 2, 5}, format: "%s", output: "Fetch"},
+		{version: ApiVersion{1, 2, 5}, format: "%d", output: "1"},
+		{version: ApiVersion{1, 2, 5}, format: "%-d", output: "2"},
+		{version: ApiVersion{1, 2, 5}, format: "%+d", output: "5"},
+		{version: ApiVersion{1, 2, 5}, format: "%v", output: "Fetch[v2:v5]"},
+		{version: ApiVersion{1, 2, 5}, format: "%-v", output: "v2"},
+		{version: ApiVersion{1, 2, 5}, format: "%+v", output: "v5"},
+		{version: ApiVersion{1, 2, 5}, format: "%#v", output: "kafka.ApiVersion{ApiKey:1 MinVersion:2 MaxVersion:5}"},
+	} {
+		t.Run(test.output, func(t *testing.T) {
+			if s := fmt.Sprintf(test.format, test.version); s != test.output {
+				t.Error("output mismatch:", s, "!=", test.output)
+			}
+		})
+	}
+}
+
 func TestProtocol(t *testing.T) {
 	t.Parallel()
 
@@ -23,7 +46,7 @@ func TestProtocol(t *testing.T) {
 
 		requestHeader{
 			Size:          26,
-			ApiKey:        int16(offsetCommitRequest),
+			ApiKey:        int16(offsetCommit),
 			ApiVersion:    int16(v2),
 			CorrelationID: 42,
 			ClientID:      "Hello World!",

--- a/write.go
+++ b/write.go
@@ -167,7 +167,7 @@ type writable interface {
 
 func (wb *writeBuffer) writeFetchRequestV2(correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration) error {
 	h := requestHeader{
-		ApiKey:        int16(fetchRequest),
+		ApiKey:        int16(fetch),
 		ApiVersion:    int16(v2),
 		CorrelationID: correlationID,
 		ClientID:      clientID,
@@ -203,7 +203,7 @@ func (wb *writeBuffer) writeFetchRequestV2(correlationID int32, clientID, topic 
 
 func (wb *writeBuffer) writeFetchRequestV5(correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
 	h := requestHeader{
-		ApiKey:        int16(fetchRequest),
+		ApiKey:        int16(fetch),
 		ApiVersion:    int16(v5),
 		CorrelationID: correlationID,
 		ClientID:      clientID,
@@ -245,7 +245,7 @@ func (wb *writeBuffer) writeFetchRequestV5(correlationID int32, clientID, topic 
 
 func (wb *writeBuffer) writeFetchRequestV10(correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8) error {
 	h := requestHeader{
-		ApiKey:        int16(fetchRequest),
+		ApiKey:        int16(fetch),
 		ApiVersion:    int16(v10),
 		CorrelationID: correlationID,
 		ClientID:      clientID,
@@ -297,7 +297,7 @@ func (wb *writeBuffer) writeFetchRequestV10(correlationID int32, clientID, topic
 
 func (wb *writeBuffer) writeListOffsetRequestV1(correlationID int32, clientID, topic string, partition int32, time int64) error {
 	h := requestHeader{
-		ApiKey:        int16(listOffsetRequest),
+		ApiKey:        int16(listOffsets),
 		ApiVersion:    int16(v1),
 		CorrelationID: correlationID,
 		ClientID:      clientID,
@@ -341,7 +341,7 @@ func (wb *writeBuffer) writeProduceRequestV2(codec CompressionCodec, correlation
 	}
 
 	h := requestHeader{
-		ApiKey:        int16(produceRequest),
+		ApiKey:        int16(produce),
 		ApiVersion:    int16(v2),
 		CorrelationID: correlationID,
 		ClientID:      clientID,
@@ -382,7 +382,7 @@ func (wb *writeBuffer) writeProduceRequestV2(codec CompressionCodec, correlation
 func (wb *writeBuffer) writeProduceRequestV3(correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, recordBatch *recordBatch) (err error) {
 
 	h := requestHeader{
-		ApiKey:        int16(produceRequest),
+		ApiKey:        int16(produce),
 		ApiVersion:    int16(v3),
 		CorrelationID: correlationID,
 		ClientID:      clientID,
@@ -420,7 +420,7 @@ func (wb *writeBuffer) writeProduceRequestV3(correlationID int32, clientID, topi
 func (wb *writeBuffer) writeProduceRequestV7(correlationID int32, clientID, topic string, partition int32, timeout time.Duration, requiredAcks int16, transactionalID *string, recordBatch *recordBatch) (err error) {
 
 	h := requestHeader{
-		ApiKey:        int16(produceRequest),
+		ApiKey:        int16(produce),
 		ApiVersion:    int16(v7),
 		CorrelationID: correlationID,
 		ClientID:      clientID,

--- a/write_test.go
+++ b/write_test.go
@@ -60,7 +60,7 @@ func testWriteFetchRequestV2(t *testing.T) {
 	const maxWait = 100 * time.Millisecond
 	testWriteOptimization(t,
 		requestHeader{
-			ApiKey:        int16(fetchRequest),
+			ApiKey:        int16(fetch),
 			ApiVersion:    int16(v2),
 			CorrelationID: testCorrelationID,
 			ClientID:      testClientID,
@@ -88,7 +88,7 @@ func testWriteListOffsetRequestV1(t *testing.T) {
 	const time = -1
 	testWriteOptimization(t,
 		requestHeader{
-			ApiKey:        int16(listOffsetRequest),
+			ApiKey:        int16(listOffsets),
 			ApiVersion:    int16(v1),
 			CorrelationID: testCorrelationID,
 			ClientID:      testClientID,
@@ -130,7 +130,7 @@ func testWriteProduceRequestV2(t *testing.T) {
 	const timeout = 100
 	testWriteOptimization(t,
 		requestHeader{
-			ApiKey:        int16(produceRequest),
+			ApiKey:        int16(produce),
 			ApiVersion:    int16(v2),
 			CorrelationID: testCorrelationID,
 			ClientID:      testClientID,


### PR DESCRIPTION
This main change in this PR is the addition of a formatting method on the `kafka.ApiVersion` type.

I also extended support for more API keys and fixed some names to match the kafka protocol documentation in https://kafka.apache.org/protocol.html#protocol_api_keys