### PR TITLE
Replace Zstandard wrapper with native Go implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,7 @@ go 1.11
 require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
 	github.com/golang/snappy v0.0.1
-	github.com/google/go-cmp v0.4.0 // indirect
-	github.com/klauspost/compress v1.9.7
+	github.com/klauspost/compress v1.9.8
 	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	github.com/xdg/stringprep v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/segmentio/kafka-go
 go 1.11
 
 require (
-	github.com/DataDog/zstd v1.4.0
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
 	github.com/golang/snappy v0.0.1
+	github.com/google/go-cmp v0.4.0 // indirect
+	github.com/klauspost/compress v1.9.7
 	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	github.com/xdg/stringprep v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
-github.com/DataDog/zstd v1.4.0 h1:vhoV+DUHnRZdKW1i5UMjAk2G4JY8wN4ayRfYDNdEhwo=
-github.com/DataDog/zstd v1.4.0/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/klauspost/compress v1.9.7 h1:hYW1gP94JUmAhBtJ+LNz5My+gBobDxPR1iVuKug26aA=
+github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
@@ -19,3 +21,5 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/klauspost/compress v1.9.7 h1:hYW1gP94JUmAhBtJ+LNz5My+gBobDxPR1iVuKug26aA=
-github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.9.8 h1:VMAMUUOh+gaxKTMk+zqbjsSjsIcUcL/LF4o63i82QyA=
+github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
@@ -21,5 +19,3 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -15,7 +15,7 @@ func init() {
 
 const Code = 4
 
-const DefaultCompressionLevel = int(zstdlib.SpeedDefault)
+const DefaultCompressionLevel = 3
 
 type CompressionCodec struct{ level zstdlib.EncoderLevel }
 

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -1,12 +1,11 @@
-// +build cgo
-
+// Package zstd implements Zstandard compression.
 package zstd
 
 import (
 	"io"
 	"sync"
 
-	"github.com/DataDog/zstd"
+	zstdlib "github.com/klauspost/compress/zstd"
 	kafka "github.com/segmentio/kafka-go"
 )
 
@@ -14,20 +13,18 @@ func init() {
 	kafka.RegisterCompressionCodec(NewCompressionCodec())
 }
 
-const (
-	Code = 4
+const Code = 4
 
-	DefaultCompressionLevel = zstd.DefaultCompression
-)
+const DefaultCompressionLevel = int(zstdlib.SpeedDefault)
 
-type CompressionCodec struct{ level int }
+type CompressionCodec struct{ level zstdlib.EncoderLevel }
 
 func NewCompressionCodec() *CompressionCodec {
 	return NewCompressionCodecWith(DefaultCompressionLevel)
 }
 
 func NewCompressionCodecWith(level int) *CompressionCodec {
-	return &CompressionCodec{level}
+	return &CompressionCodec{zstdlib.EncoderLevelFromZstd(level)}
 }
 
 // Code implements the kafka.CompressionCodec interface.
@@ -38,161 +35,91 @@ func (c *CompressionCodec) Name() string { return "zstd" }
 
 // NewReader implements the kafka.CompressionCodec interface.
 func (c *CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
-	return &reader{
-		reader: r,
-		buffer: bufferPool.Get().(*buffer),
+	p := new(reader)
+	if cached := decPool.Get(); cached == nil {
+		p.dec, p.err = zstdlib.NewReader(r)
+	} else {
+		p.dec = cached.(*zstdlib.Decoder)
+		p.err = p.dec.Reset(r)
 	}
+	return p
+}
+
+var decPool sync.Pool
+
+type reader struct {
+	dec *zstdlib.Decoder
+	err error
+}
+
+// Close implements the io.Closer interface.
+func (r *reader) Close() error {
+	if r.err != io.ErrClosedPipe {
+		r.err = io.ErrClosedPipe
+		decPool.Put(r.dec)
+	}
+	return nil
+}
+
+// Read implements the io.Reader interface.
+func (r *reader) Read(p []byte) (n int, err error) {
+	println("zstd read", len(p))
+	if r.err != nil {
+		return 0, r.err
+	}
+	return r.dec.Read(p)
+}
+
+// WriteTo implements the io.WriterTo interface.
+func (r *reader) WriteTo(w io.Writer) (n int64, err error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+	return r.dec.WriteTo(w)
 }
 
 // NewWriter implements the kafka.CompressionCodec interface.
 func (c *CompressionCodec) NewWriter(w io.Writer) io.WriteCloser {
-	return &writer{
-		writer: w,
-		buffer: bufferPool.Get().(*buffer),
-		level:  c.level,
+	p := new(writer)
+	if cached := encPool.Get(); cached == nil {
+		p.enc, p.err = zstdlib.NewWriter(w,
+			zstdlib.WithEncoderLevel(c.level))
+	} else {
+		p.enc = cached.(*zstdlib.Encoder)
+		p.enc.Reset(w)
 	}
+	return p
 }
 
-// =============================================================================
-// The DataDog/zstd package exposes io.Writer and io.Reader implementations that
-// encode and decode streams, however there are no APIs to reuse the values like
-// other compression format have (through a Reset method usually).
-//
-// I first tried using these abstractions but the amount of state that gets
-// recreated and destroyed was so large that it was slower than using the
-// zstd.Compress and zstd.Decompress functions directly. Knowing that, I changed
-// the implementation to be more of a buffer management on top of these instead.
-// =============================================================================
-
-type reader struct {
-	reader io.Reader
-	buffer *buffer
-	offset int
-}
-
-func (r *reader) Read(b []byte) (int, error) {
-	if err := r.decompress(); err != nil {
-		return 0, err
-	}
-
-	if r.offset >= len(r.buffer.output) {
-		return 0, io.EOF
-	}
-
-	n := copy(b, r.buffer.output[r.offset:])
-	r.offset += n
-	return n, nil
-}
-
-func (r *reader) WriteTo(w io.Writer) (int64, error) {
-	if err := r.decompress(); err != nil {
-		return 0, err
-	}
-
-	if r.offset >= len(r.buffer.output) {
-		return 0, nil
-	}
-
-	n, err := w.Write(r.buffer.output[r.offset:])
-	r.offset += n
-	return int64(n), err
-}
-
-func (r *reader) Close() (err error) {
-	if b := r.buffer; b != nil {
-		r.buffer = nil
-		b.reset()
-		bufferPool.Put(b)
-	}
-	return
-}
-
-func (r *reader) decompress() (err error) {
-	if r.reader == nil {
-		return
-	}
-
-	b := r.buffer
-
-	if _, err = b.readFrom(r.reader); err != nil {
-		return
-	}
-
-	r.reader = nil
-	b.output, err = zstd.Decompress(b.output[:cap(b.output)], b.input)
-	return
-}
+var encPool sync.Pool
 
 type writer struct {
-	writer io.Writer
-	buffer *buffer
-	level  int
+	enc *zstdlib.Encoder
+	err error
 }
 
-func (w *writer) Write(b []byte) (int, error) {
-	return w.buffer.write(b)
-}
-
-func (w *writer) ReadFrom(r io.Reader) (int64, error) {
-	return w.buffer.readFrom(r)
-}
-
-func (w *writer) Close() (err error) {
-	if b := w.buffer; b != nil {
-		w.buffer = nil
-
-		b.output, err = zstd.CompressLevel(b.output[:cap(b.output)], b.input, w.level)
-		if err == nil {
-			_, err = w.writer.Write(b.output)
-		}
-
-		b.reset()
-		bufferPool.Put(b)
+// Close implements the io.Closer interface.
+func (w *writer) Close() error {
+	if w.err == io.ErrClosedPipe {
+		return nil
 	}
-	return
+	w.err = io.ErrClosedPipe
+	encPool.Put(w.enc)
+	return w.enc.Close()
 }
 
-type buffer struct {
-	input  []byte
-	output []byte
-}
-
-func (b *buffer) reset() {
-	b.input = b.input[:0]
-	b.output = b.output[:0]
-}
-
-func (b *buffer) readFrom(r io.Reader) (int64, error) {
-	prefix := len(b.input)
-
-	for {
-		if len(b.input) == cap(b.input) {
-			tmp := make([]byte, len(b.input), 2*cap(b.input))
-			copy(tmp, b.input)
-			b.input = tmp
-		}
-
-		n, err := r.Read(b.input[len(b.input):cap(b.input)])
-		b.input = b.input[:len(b.input)+n]
-		if err != nil {
-			if err == io.EOF {
-				err = nil
-			}
-			return int64(len(b.input) - prefix), err
-		}
+// WriteTo implements the io.WriterTo interface.
+func (w *writer) Write(p []byte) (n int, err error) {
+	if w.err != nil {
+		return 0, w.err
 	}
+	return w.enc.Write(p)
 }
 
-func (b *buffer) write(data []byte) (int, error) {
-	b.input = append(b.input, data...)
-	return len(data), nil
-}
-
-var bufferPool = sync.Pool{
-	New: func() interface{} {
-		return &buffer{
-			input:  make([]byte, 0, 32*1024),
-			output: make([]byte, 0, 32*1024),
-		}
-	},
+// ReadFrom implements the io.ReaderFrom interface.
+func (w *writer) ReadFrom(r io.Reader) (n int64, err error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	return w.enc.ReadFrom(r)
 }


### PR DESCRIPTION
Follow-up on stale #303 with full use of the streaming API from @klauspost.

Decompression is slower while the (default) compression ratio went down from 5 to 3.

```
name                           old time/op    new time/op    delta
Compression/zstd/compress-4      5.64ms ± 2%    3.02ms ± 2%   -46.42%  (p=0.000 n=10+10)
Compression/zstd/decompress-4     911µs ± 2%    2386µs ± 2%  +162.10%  (p=0.000 n=10+10)

name                           old speed      new speed      delta
Compression/zstd/compress-4    21.0MB/s ± 2%  44.3MB/s ± 2%  +111.39%  (p=0.000 n=10+10)
Compression/zstd/decompress-4  2.13GB/s ± 2%  0.81GB/s ± 2%   -61.85%  (p=0.000 n=10+10)
```