### PR TITLE
fix offset commit bug

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -50,7 +50,7 @@ const (
 
 	// defaultRetentionTime holds the length of time a the consumer group will be
 	// saved by kafka.  This value tells the broker to use its configured value.
-	defaultRetentionTime = -1
+	defaultRetentionTime = -1 * time.Millisecond
 
 	// defaultPartitionWatchTime contains the amount of time the kafka-go will wait to
 	// query the brokers looking for partition changes.


### PR DESCRIPTION
when we use defaultRetentionTime -1
we get the gen

	gen := Generation{
		ID:              generationID,
		GroupID:         cg.config.ID,
		MemberID:        memberID,
		Assignments:     cg.makeAssignments(assignments, offsets),
		conn:            conn,
		done:            make(chan struct{}),
		retentionMillis: int64(cg.config.RetentionTime / time.Millisecond),
		log:             cg.withLogger,
		logError:        cg.withErrorLogger,
	}
the retentionMillis of gen is 0

	request := offsetCommitRequestV2{
		GroupID:       g.GroupID,
		GenerationID:  g.ID,
		MemberID:      g.MemberID,
		RetentionTime: g.retentionMillis,
		Topics:        topics,
	}
then offsetcommit request is bad with the RetentionTime=0
the group offset is expired when all consumer is down
kafka server params offsets.retention.minutes is not work
so when we restart consumer group after offsets.retention.check.interval.ms,we will lost the offset commit early