### PR TITLE
Use SwapInt64 to snapshot counters

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -36,10 +36,7 @@ func (c *counter) observe(v int64) {
 }
 
 func (c *counter) snapshot() int64 {
-	p := c.ptr()
-	v := atomic.LoadInt64(p)
-	atomic.AddInt64(p, -v)
-	return v
+	return atomic.SwapInt64(c.ptr(), 0)
 }
 
 // gauge is an atomic integer that may be set to any arbitrary value, the value


### PR DESCRIPTION
Using LoadInt64 and then AddInt64 can lead to incoherent results if
snapshot() is called twice at the same time.

We recently encountered this situation in production and it produced a panic somewhere else because of the negative number.