### PR TITLE
Fix zstd decoder leak

### DIFF
--- a/zstd/pool.go
+++ b/zstd/pool.go
@@ -1,0 +1,50 @@
+package zstd
+
+import zstdlib "github.com/klauspost/compress/zstd"
+
+// decoderPool is very basic implementation of a pool of zstdlib.Decoders.
+//
+// A decoderPool is initially empty. Callers should create new decoders as
+// necessary and add them to the pool when no longer necessary (via Put).
+// If the pool is at capacity when Put is called, any excess decoders will
+// be closed and discarded.
+//
+// This implementation never downsizes.
+type decoderPool struct {
+	pool chan *zstdlib.Decoder
+}
+
+// newDecoderPool creates a new decoderPool with specified maxSize.
+func newDecoderPool(maxSize int) *decoderPool {
+	return &decoderPool{
+		pool: make(chan *zstdlib.Decoder, maxSize),
+	}
+}
+
+// Get immediately returns an available pooled decoder or nil, if none are
+// available.
+//
+// If nil is returned, caller should create a new zstdlib.Decoder.
+// When the decoder is no longer necessary, it should be added/returned to the
+// pool with Put.
+func (p *decoderPool) Get() *zstdlib.Decoder {
+	select {
+	case dec := <-p.pool:
+		return dec
+	default:
+		// No available decoders in pool; caller should create
+		// one and return it to the pool via Put when done.
+		return nil
+	}
+}
+
+// Put adds a decoder to the pool, if there is available capacity.
+// Any excess decoders will be immediately closed and discarded.
+func (p *decoderPool) Put(dec *zstdlib.Decoder) {
+	select {
+	case p.pool <- dec:
+	default:
+		// No space left in pool; close and discard excess decoders.
+		dec.Close()
+	}
+}

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -17,6 +17,9 @@ const Code = 4
 
 const DefaultCompressionLevel = 3
 
+// DefaultDecoderPoolMaxSize is the default max number of cached decoders for a decoderPool.
+const DefaultDecoderPoolMaxSize = 100
+
 type CompressionCodec struct{ level zstdlib.EncoderLevel }
 
 func NewCompressionCodec() *CompressionCodec {
@@ -39,13 +42,13 @@ func (c *CompressionCodec) NewReader(r io.Reader) io.ReadCloser {
 	if cached := decPool.Get(); cached == nil {
 		p.dec, p.err = zstdlib.NewReader(r)
 	} else {
-		p.dec = cached.(*zstdlib.Decoder)
+		p.dec = cached
 		p.err = p.dec.Reset(r)
 	}
 	return p
 }
 
-var decPool sync.Pool
+var decPool = newDecoderPool(DefaultDecoderPoolMaxSize)
 
 type reader struct {
 	dec *zstdlib.Decoder

--- a/zstd/zstd_test.go
+++ b/zstd/zstd_test.go
@@ -1,0 +1,82 @@
+package zstd
+
+import (
+	"bytes"
+	"crypto/rand"
+	"github.com/segmentio/kafka-go"
+	"io"
+	"runtime"
+	"testing"
+)
+
+func Test2(t *testing.T) {
+	codec := NewCompressionCodec()
+
+	// Run a compress/decompress cycle to create the first decoder and encoder.
+	compressDecompress(codec)
+
+	// Take a snapshot of the number of goroutines after the first comp+dec cycle.
+	// Since all compression and decompression is serial and in this test case
+	// goroutines can only go up if new decoders are created, this number is
+	// expected to remain the same. If it doesn't, there's a leak.
+	goroutinesBefore := runtime.NumGoroutine()
+
+	// Stress the comp+dec cycle in serial fashion.
+	for i := 0; i < 10000; i++ {
+		compressDecompress(codec)
+	}
+
+	// There should be a single decoder in the pool.
+	pooled := 0
+	for dec := decPool.Get(); dec != nil; pooled, dec = pooled+1, decPool.Get() {
+	}
+	if pooled > 1 {
+		t.Errorf("too many pooled decoders; expecting 1, got %d", pooled)
+	}
+
+	// And the number of goroutines shouldn't have gone up.
+	goroutinesAfter := runtime.NumGoroutine()
+	if goroutinesBefore != goroutinesAfter {
+		t.Errorf("unexpected goroutine increase; expecting %d, got %d",
+			goroutinesBefore, goroutinesAfter)
+	}
+}
+
+func compressDecompress(codec *CompressionCodec) {
+	data := randomData(2048)
+	comp, _ := compress(codec, data)
+	_, _ = decompress(codec, comp)
+}
+
+func randomData(len int) []byte {
+	b := make([]byte, 0, len)
+	_, _ = rand.Read(b)
+	return b
+}
+
+func compress(codec kafka.CompressionCodec, src []byte) ([]byte, error) {
+	b := new(bytes.Buffer)
+	r := bytes.NewReader(src)
+	w := codec.NewWriter(b)
+	if _, err := io.Copy(w, r); err != nil {
+		_ = w.Close()
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func decompress(codec kafka.CompressionCodec, src []byte) ([]byte, error) {
+	b := new(bytes.Buffer)
+	r := codec.NewReader(bytes.NewReader(src))
+	if _, err := io.Copy(b, r); err != nil {
+		_ = r.Close()
+		return nil, err
+	}
+	if err := r.Close(); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}


### PR DESCRIPTION
**Description**
Using `sync.Pool` to pool encoders/decoders that are not eligible for
deallocation once the pool loses their reference leads to goroutine & mem leaks.

**Kafka Version**
Irrelevant; library issue.

**To Reproduce**
See added test.

**Expected behavior**
There should be no memory or goroutine leaks.

**Additional context**
The docs from `sync.Pool` state:
> Any item stored in the Pool may be removed automatically at any time without
> notification. If the Pool holds the only reference when this happens, the
> item might be deallocated.

`zstd.Decoder`s spin up their own goroutines, which hold a strong ref to owning
decoder. When `decPool` downsizes (usually on GC runs), an arbitrary number of
decoders are evicted from the pool. Since their goroutines are still running
(observed: waiting on `*blockDec.startDecoder()`, at instruction
`for range b.input { ... }`) and thus holding references, these decoders are not
eligible for deallocation — instead becoming unreachable. As new decoders are
created and evicted, the number of running goroutines continuously increases,
eventually causing the program to run out of memory and/or peg the CPU.

I originally noticed this under heavy concurrent load, but managed to create a
trivial, serial test case where the problem is demonstrated.

This change introduces a pretty naive fix. A more robust solution should be
discussed and implemented (or at least a more configurable one). The goal here
was to minimize changes to existing code in order to help focus on the existing
issue and foster discussion.

Likewise, there isn't much value to the test case other than demonstrating the
original problem, and should probably be dropped once a robust solution is put
in place to prevent this leak.

---

I've been benchmarking a system using this patch and both memory and number of goroutines hold steady under heavy, highly concurrent load. We should probably consider a pool that is capable of downsizing (as `sync.Pool` did), or perhaps add a variant of `NewCompressionCodec` that allows specifying the size of the pool (a pool per codec?)

Think of this proposal as a conversation starter. I'll happily help drive implementation :)