### PR TITLE
0.4: kafka.Writer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,12 @@ jobs:
         KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
         KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
         CUSTOM_INIT_SCRIPT: |-
-          echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-          /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
+          echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
     steps: &steps
     - checkout
-    - run: go test -v -race -cover -timeout 150s ./...
+    - run: go test -v -race -cover .
+    - run: go test -v -race -cover ./protocol
+    - run: go test -v -race -cover ./compress
 
   kafka-011:
     working_directory: *working_directory
@@ -94,8 +95,17 @@ jobs:
       ports:
       - 9092:9092
       - 9093:9093
-      environment: *environment
-    steps: *steps
+      environment:
+        <<: *environment
+        CUSTOM_INIT_SCRIPT: |-
+          echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+          /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
+    steps:
+    - checkout
+    - run: go test -v -race -cover .
+    - run: go test -v -race -cover ./protocol
+    - run: go test -v -race -cover ./compress
+    - run: go test -v -race -cover ./sasl
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
           KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
           KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-          KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN'
+          KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
           KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
           CUSTOM_INIT_SCRIPT: |-
             echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,40 +5,48 @@ jobs:
     environment:
       KAFKA_VERSION: "0.10.1"
     docker:
-      - image: circleci/golang
-      - image: wurstmeister/zookeeper
-        ports: ['2181:2181']
-      - image: wurstmeister/kafka:0.10.1.1
-        ports: ['9092:9092']
-        environment: &environment
-          KAFKA_BROKER_ID: '1'
-          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
-          KAFKA_DELETE_TOPIC_ENABLE: 'true'
-          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-          KAFKA_ADVERTISED_PORT: '9092'
-          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-          KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-          KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
-          KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-          CUSTOM_INIT_SCRIPT: |-
-            echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:0.10.1.1
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: &environment
+        KAFKA_BROKER_ID: '1'
+        KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+        KAFKA_DELETE_TOPIC_ENABLE: 'true'
+        KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+        KAFKA_ADVERTISED_PORT: '9092'
+        KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+        KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+        KAFKA_MESSAGE_MAX_BYTES: '200000000'
+        KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+        KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+        KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+        CUSTOM_INIT_SCRIPT: |-
+          echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+          /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
     steps: &steps
-      - checkout
-      - run: go test -v -race -cover -timeout 150s ./...
+    - checkout
+    - run: go test -v -race -cover -timeout 150s ./...
 
   kafka-011:
     working_directory: *working_directory
     environment:
       KAFKA_VERSION: "0.11.0"
     docker:
-      - image: circleci/golang
-      - image: wurstmeister/zookeeper
-        ports: ['2181:2181']
-      - image: wurstmeister/kafka:2.11-0.11.0.3
-        ports: ['9092:9092','9093:9093']
-        environment: *environment
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:2.11-0.11.0.3
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: *environment
     steps: *steps
 
   kafka-111:
@@ -46,12 +54,15 @@ jobs:
     environment:
       KAFKA_VERSION: "1.1.1"
     docker:
-      - image: circleci/golang
-      - image: wurstmeister/zookeeper
-        ports: ['2181:2181']
-      - image: wurstmeister/kafka:2.11-1.1.1
-        ports: ['9092:9092','9093:9093']
-        environment: *environment
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:2.11-1.1.1
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: *environment
     steps: *steps
 
   kafka-210:
@@ -59,12 +70,15 @@ jobs:
     environment:
       KAFKA_VERSION: "2.1.0"
     docker:
-      - image: circleci/golang
-      - image: wurstmeister/zookeeper
-        ports: ['2181:2181']
-      - image: wurstmeister/kafka:2.12-2.1.0
-        ports: ['9092:9092','9093:9093']
-        environment: *environment
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:2.12-2.1.0
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: *environment
     steps: *steps
 
   kafka-231:
@@ -72,20 +86,23 @@ jobs:
     environment:
       KAFKA_VERSION: "2.3.1"
     docker:
-      - image: circleci/golang
-      - image: wurstmeister/zookeeper
-        ports: ['2181:2181']
-      - image: wurstmeister/kafka:2.12-2.3.1
-        ports: ['9092:9092','9093:9093']
-        environment: *environment
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:2.12-2.3.1
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: *environment
     steps: *steps
 
 workflows:
   version: 2
   run:
     jobs:
-      - kafka-010
-      - kafka-011
-      - kafka-111
-      - kafka-210
-      - kafka-231
+    - kafka-010
+    - kafka-011
+    - kafka-111
+    - kafka-210
+    - kafka-231

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2
 jobs:
+  # The kafka 0.10 tests are maintained as a separate configuration because
+  # kafka only supported plain text SASL in this version.
   kafka-010:
     working_directory: &working_directory /go/src/github.com/segmentio/kafka-go
     environment:
@@ -10,6 +12,41 @@ jobs:
       ports:
       - 2181:2181
     - image: wurstmeister/kafka:0.10.1.1
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment:
+        KAFKA_BROKER_ID: '1'
+        KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+        KAFKA_DELETE_TOPIC_ENABLE: 'true'
+        KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+        KAFKA_ADVERTISED_PORT: '9092'
+        KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+        KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+        KAFKA_MESSAGE_MAX_BYTES: '200000000'
+        KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+        KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+        KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN'
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+        CUSTOM_INIT_SCRIPT: |-
+          echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+    steps: &steps
+    - checkout
+    - run: go test -race -cover ./...
+
+  # Starting at version 0.11, the kafka features and configuration remained
+  # mostly stable, so we can use this CI job configuration as template for other
+  # versions as well.
+  kafka-011:
+    working_directory: *working_directory
+    environment:
+      KAFKA_VERSION: "0.11.0"
+    docker:
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:0.11.0.3
       ports:
       - 9092:9092
       - 9093:9093
@@ -29,20 +66,18 @@ jobs:
         CUSTOM_INIT_SCRIPT: |-
           echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
           /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
-    steps: &steps
-    - checkout
-    - run: go test -race -cover ./...
+    steps: *steps
 
-  kafka-011:
+  kafka-101:
     working_directory: *working_directory
     environment:
-      KAFKA_VERSION: "0.11.0"
+      KAFKA_VERSION: "1.0.1"
     docker:
     - image: circleci/golang
     - image: wurstmeister/zookeeper
       ports:
       - 2181:2181
-    - image: wurstmeister/kafka:2.11-0.11.0.3
+    - image: wurstmeister/kafka:2.11-1.0.1
       ports:
       - 9092:9092
       - 9093:9093
@@ -65,16 +100,48 @@ jobs:
       environment: *environment
     steps: *steps
 
-  kafka-210:
+  kafka-201:
     working_directory: *working_directory
     environment:
-      KAFKA_VERSION: "2.1.0"
+      KAFKA_VERSION: "2.0.1"
     docker:
     - image: circleci/golang
     - image: wurstmeister/zookeeper
       ports:
       - 2181:2181
-    - image: wurstmeister/kafka:2.12-2.1.0
+    - image: wurstmeister/kafka:2.12-2.0.1
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: *environment
+    steps: *steps
+
+  kafka-211:
+    working_directory: *working_directory
+    environment:
+      KAFKA_VERSION: "2.1.1"
+    docker:
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:2.12-2.1.1
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: *environment
+    steps: *steps
+
+  kafka-222:
+    working_directory: *working_directory
+    environment:
+      KAFKA_VERSION: "2.2.2"
+    docker:
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:2.12-2.2.2
       ports:
       - 9092:9092
       - 9093:9093
@@ -103,6 +170,9 @@ workflows:
     jobs:
     - kafka-010
     - kafka-011
+    - kafka-101
     - kafka-111
-    - kafka-210
+    - kafka-201
+    - kafka-211
+    - kafka-222
     - kafka-231

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,11 @@ jobs:
         KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
         KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
         CUSTOM_INIT_SCRIPT: |-
-          echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+          echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+          /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
     steps: &steps
     - checkout
-    - run: go test -v -race -cover .
-    - run: go test -v -race -cover ./protocol
-    - run: go test -v -race -cover ./compress
+    - run: go test -race -cover ./...
 
   kafka-011:
     working_directory: *working_directory
@@ -95,28 +94,8 @@ jobs:
       ports:
       - 9092:9092
       - 9093:9093
-      environment:
-        KAFKA_BROKER_ID: '1'
-        KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
-        KAFKA_DELETE_TOPIC_ENABLE: 'true'
-        KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-        KAFKA_ADVERTISED_PORT: '9092'
-        KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
-        KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-        KAFKA_MESSAGE_MAX_BYTES: '200000000'
-        KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-        KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-        KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
-        KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-        CUSTOM_INIT_SCRIPT: |-
-          echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-          /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
-    steps:
-    - checkout
-    - run: go test -v -race -cover .
-    - run: go test -v -race -cover ./protocol
-    - run: go test -v -race -cover ./compress
-    - run: go test -v -race -cover ./sasl
+      environment: *environment
+    steps: *steps
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   kafka-010:
-    working_directory: /go/src/github.com/segmentio/kafka-go
+    working_directory: &working_directory /go/src/github.com/segmentio/kafka-go
     environment:
       KAFKA_VERSION: "0.10.1"
     docker:
@@ -10,7 +10,7 @@ jobs:
         ports: ['2181:2181']
       - image: wurstmeister/kafka:0.10.1.1
         ports: ['9092:9092']
-        environment:
+        environment: &environment
           KAFKA_BROKER_ID: '1'
           KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
           KAFKA_DELETE_TOPIC_ENABLE: 'true'
@@ -24,14 +24,12 @@ jobs:
           KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
           CUSTOM_INIT_SCRIPT: |-
             echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-    steps:
+    steps: &steps
       - checkout
-      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
-      - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
       - run: go test -v -race -cover -timeout 150s . ./gzip ./lz4 ./sasl ./snappy
 
   kafka-011:
-    working_directory: /go/src/github.com/segmentio/kafka-go
+    working_directory: *working_directory
     environment:
       KAFKA_VERSION: "0.11.0"
     docker:
@@ -40,29 +38,11 @@ jobs:
         ports: ['2181:2181']
       - image: wurstmeister/kafka:2.11-0.11.0.3
         ports: ['9092:9092','9093:9093']
-        environment:
-          KAFKA_BROKER_ID: '1'
-          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
-          KAFKA_DELETE_TOPIC_ENABLE: 'true'
-          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-          KAFKA_ADVERTISED_PORT: '9092'
-          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-          KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-          KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
-          KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-          CUSTOM_INIT_SCRIPT: |-
-            echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-            /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
-    steps:
-      - checkout
-      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
-      - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
-      - run: go test -v -race -cover -timeout 150s . ./gzip ./lz4 ./sasl ./snappy
+        environment: *environment
+    steps: *steps
 
   kafka-111:
-    working_directory: /go/src/github.com/segmentio/kafka-go
+    working_directory: *working_directory
     environment:
       KAFKA_VERSION: "1.1.1"
     docker:
@@ -71,29 +51,11 @@ jobs:
         ports: ['2181:2181']
       - image: wurstmeister/kafka:2.11-1.1.1
         ports: ['9092:9092','9093:9093']
-        environment:
-          KAFKA_BROKER_ID: '1'
-          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
-          KAFKA_DELETE_TOPIC_ENABLE: 'true'
-          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-          KAFKA_ADVERTISED_PORT: '9092'
-          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-          KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-          KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
-          KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-          CUSTOM_INIT_SCRIPT: |-
-            echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-            /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
-    steps:
-      - checkout
-      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
-      - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
-      - run: go test -v -race -cover -timeout 150s . ./gzip ./lz4 ./sasl ./snappy
+        environment: *environment
+    steps: *steps
 
   kafka-210:
-    working_directory: /go/src/github.com/segmentio/kafka-go
+    working_directory: *working_directory
     environment:
       KAFKA_VERSION: "2.1.0"
     docker:
@@ -102,29 +64,11 @@ jobs:
         ports: ['2181:2181']
       - image: wurstmeister/kafka:2.12-2.1.0
         ports: ['9092:9092','9093:9093']
-        environment:
-          KAFKA_BROKER_ID: '1'
-          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
-          KAFKA_DELETE_TOPIC_ENABLE: 'true'
-          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-          KAFKA_ADVERTISED_PORT: '9092'
-          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-          KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-          KAFKA_SASL_ENABLED_MECHANISMS: SCRAM-SHA-256,SCRAM-SHA-512,PLAIN
-          KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-          CUSTOM_INIT_SCRIPT: |-
-            echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-            /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
-    steps:
-      - checkout
-      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
-      - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
-      - run: go test -v -race -cover -timeout 150s $(go list ./... | grep -v examples)
+        environment: *environment
+    steps: *steps
 
   kafka-231:
-    working_directory: /go/src/github.com/segmentio/kafka-go
+    working_directory: *working_directory
     environment:
       KAFKA_VERSION: "2.3.1"
     docker:
@@ -133,26 +77,8 @@ jobs:
         ports: ['2181:2181']
       - image: wurstmeister/kafka:2.12-2.3.1
         ports: ['9092:9092','9093:9093']
-        environment:
-          KAFKA_BROKER_ID: '1'
-          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
-          KAFKA_DELETE_TOPIC_ENABLE: 'true'
-          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-          KAFKA_ADVERTISED_PORT: '9092'
-          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-          KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-          KAFKA_SASL_ENABLED_MECHANISMS: SCRAM-SHA-256,SCRAM-SHA-512,PLAIN
-          KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-          CUSTOM_INIT_SCRIPT: |-
-            echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-            /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
-    steps:
-      - checkout
-      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
-      - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
-      - run: go test -v -race -cover -timeout 150s $(go list ./... | grep -v examples)
+        environment: *environment
+    steps: *steps
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,13 @@ jobs:
           echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
     steps: &steps
     - checkout
+    - restore_cache:
+        key: kafka-go-mod-{{ checksum "go.sum" }}-1
+    - run: go mod download
+    - save_cache:
+        key: kafka-go-mod-{{ checksum "go.sum" }}-1
+        paths:
+        - /go/pkg/mod
     - run: go test -race -cover ./...
 
   # Starting at version 0.11, the kafka features and configuration remained

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
     steps: &steps
       - checkout
-      - run: go test -v -race -cover -timeout 150s . ./gzip ./lz4 ./sasl ./snappy
+      - run: go test -v -race -cover -timeout 150s ./...
 
   kafka-011:
     working_directory: *working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
     - image: wurstmeister/zookeeper
       ports:
       - 2181:2181
-    - image: wurstmeister/kafka:0.11.0.3
+    - image: wurstmeister/kafka:2.11-0.11.0.3
       ports:
       - 9092:9092
       - 9093:9093

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
         KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
         CUSTOM_INIT_SCRIPT: |-
           echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-          /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
+          /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
     steps:
     - checkout
     - run: go test -v -race -cover .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,18 @@ jobs:
       - 9092:9092
       - 9093:9093
       environment:
-        <<: *environment
+        KAFKA_BROKER_ID: '1'
+        KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+        KAFKA_DELETE_TOPIC_ENABLE: 'true'
+        KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+        KAFKA_ADVERTISED_PORT: '9092'
+        KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+        KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+        KAFKA_MESSAGE_MAX_BYTES: '200000000'
+        KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+        KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+        KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
         CUSTOM_INIT_SCRIPT: |-
           echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
           /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram

--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ set when writing messages.  They are intended for read use only.
 Each writer is bound to a single topic, to write to multiple topics, a program
 must create multiple writers.
 
-We considered making the `kafka.Writer` type interpret the `Topic` field of the
-`kafka.Message` values, batching messages per partition or topic/partition is
-not so different and could be achieved. However, supporting this means we would
+We considered making the `kafka.Writer` type interpret the `Topic` field of
+`kafka.Message` values, batching messages per partition or topic/partition pairs
+does not introduce much more complexity. However, supporting this means we would
 also have to report stats broken down by topic. It would also raise the question
 of how we would manage configuration specific to each topic (e.g. different
 compression algorithms). Overall, the amount of coupling between the various

--- a/address.go
+++ b/address.go
@@ -50,7 +50,7 @@ type Addr struct {
 // Network returns a.Net, satisfies the net.Addr interface.
 func (a *Addr) Network() string { return a.Net }
 
-// String returns a.Addr, satisifes the net.Addr interface.
+// String returns a.Addr, satisfies the net.Addr interface.
 func (a *Addr) String() string { return a.Addr }
 
 // MultiAddr is an implementation of the net.Addr interface for a set of network

--- a/address.go
+++ b/address.go
@@ -27,43 +27,36 @@ func makeAddr(network, address string) net.Addr {
 	if host == "" {
 		host = address
 	}
-	return &Addr{
-		Net:  network,
-		Addr: net.JoinHostPort(host, port),
+	return &networkAddress{
+		network: network,
+		address: net.JoinHostPort(host, port),
 	}
 }
 
 func makeMultiAddr(network string, addresses []string) net.Addr {
-	multi := make(MultiAddr, len(addresses))
+	multi := make(multiAddr, len(addresses))
 	for i, address := range addresses {
 		multi[i] = makeAddr(network, address)
 	}
 	return multi
 }
 
-// Addr is a generic implementation of the net.Addr interface.
-type Addr struct {
-	Net  string
-	Addr string
+type networkAddress struct {
+	network string
+	address string
 }
 
-// Network returns a.Net, satisfies the net.Addr interface.
-func (a *Addr) Network() string { return a.Net }
+func (a *networkAddress) Network() string { return a.network }
 
-// String returns a.Addr, satisfies the net.Addr interface.
-func (a *Addr) String() string { return a.Addr }
+func (a *networkAddress) String() string { return a.address }
 
-// MultiAddr is an implementation of the net.Addr interface for a set of network
-// addresses.
-type MultiAddr []net.Addr
+type multiAddr []net.Addr
 
-// Network returns the comma-separated list of networks included in m.
-func (m MultiAddr) Network() string { return m.join(net.Addr.Network) }
+func (m multiAddr) Network() string { return m.join(net.Addr.Network) }
 
-// String returns the comma-separated list of addresses included in m.
-func (m MultiAddr) String() string { return m.join(net.Addr.String) }
+func (m multiAddr) String() string { return m.join(net.Addr.String) }
 
-func (m MultiAddr) join(f func(net.Addr) string) string {
+func (m multiAddr) join(f func(net.Addr) string) string {
 	switch len(m) {
 	case 0:
 		return ""

--- a/address.go
+++ b/address.go
@@ -1,26 +1,78 @@
 package kafka
 
-import "net"
+import (
+	"net"
+	"strings"
+)
 
 // TCP constructs an address with the network set to "tcp".
-func TCP(address string) net.Addr { return Addr("tcp", address) }
+func TCP(address ...string) net.Addr { return makeNetAddr("tcp", address) }
 
-// TLS constructs an address with the network set to "tls".
-func TLS(address string) net.Addr { return Addr("tls", address) }
-
-// Addr returns a net.Addr from a pair of network and address.
-func Addr(network, address string) net.Addr {
-	return &networkAddress{
-		network: network,
-		address: address,
+func makeNetAddr(network string, addresses []string) net.Addr {
+	switch len(addresses) {
+	case 0:
+		return nil // maybe panic instead?
+	case 1:
+		return makeAddr(network, addresses[0])
+	default:
+		return makeMultiAddr(network, addresses)
 	}
 }
 
-type networkAddress struct {
-	network string
-	address string
+func makeAddr(network, address string) net.Addr {
+	host, port, _ := net.SplitHostPort(address)
+	if port == "" {
+		port = "9092"
+	}
+	if host == "" {
+		host = address
+	}
+	return &Addr{
+		Net:  network,
+		Addr: net.JoinHostPort(host, port),
+	}
 }
 
-func (a *networkAddress) Network() string { return a.network }
+func makeMultiAddr(network string, addresses []string) net.Addr {
+	multi := make(MultiAddr, len(addresses))
+	for i, address := range addresses {
+		multi[i] = makeAddr(network, address)
+	}
+	return multi
+}
 
-func (a *networkAddress) String() string { return a.address }
+// Addr is a generic implementation of the net.Addr interface.
+type Addr struct {
+	Net  string
+	Addr string
+}
+
+// Network returns a.Net, satisfies the net.Addr interface.
+func (a *Addr) Network() string { return a.Net }
+
+// String returns a.Addr, satisifes the net.Addr interface.
+func (a *Addr) String() string { return a.Addr }
+
+// MultiAddr is an implementation of the net.Addr interface for a set of network
+// addresses.
+type MultiAddr []net.Addr
+
+// Network returns the comma-separated list of networks included in m.
+func (m MultiAddr) Network() string { return m.join(net.Addr.Network) }
+
+// String returns the comma-separated list of addresses included in m.
+func (m MultiAddr) String() string { return m.join(net.Addr.String) }
+
+func (m MultiAddr) join(f func(net.Addr) string) string {
+	switch len(m) {
+	case 0:
+		return ""
+	case 1:
+		return f(m[0])
+	}
+	s := make([]string, len(m))
+	for i, a := range m {
+		s[i] = f(a)
+	}
+	return strings.Join(s, ",")
+}

--- a/address_test.go
+++ b/address_test.go
@@ -40,16 +40,6 @@ func TestNetworkAddress(t *testing.T) {
 			network: "tcp,tcp,tcp",
 			address: "localhost:9092,localhost:9093,localhost:9094",
 		},
-
-		{
-			addr: MultiAddr{
-				TCP("localhost:9092"),
-				TCP("localhost:9093"),
-				TCP("localhost:9094"),
-			},
-			network: "tcp,tcp,tcp",
-			address: "localhost:9092,localhost:9093,localhost:9094",
-		},
 	}
 
 	for _, test := range tests {

--- a/address_test.go
+++ b/address_test.go
@@ -1,0 +1,65 @@
+package kafka
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNetworkAddress(t *testing.T) {
+	tests := []struct {
+		addr    net.Addr
+		network string
+		address string
+	}{
+		{
+			addr:    TCP("127.0.0.1"),
+			network: "tcp",
+			address: "127.0.0.1:9092",
+		},
+
+		{
+			addr:    TCP("::1"),
+			network: "tcp",
+			address: "[::1]:9092",
+		},
+
+		{
+			addr:    TCP("localhost"),
+			network: "tcp",
+			address: "localhost:9092",
+		},
+
+		{
+			addr:    TCP("localhost:9092"),
+			network: "tcp",
+			address: "localhost:9092",
+		},
+
+		{
+			addr:    TCP("localhost", "localhost:9093", "localhost:9094"),
+			network: "tcp,tcp,tcp",
+			address: "localhost:9092,localhost:9093,localhost:9094",
+		},
+
+		{
+			addr: MultiAddr{
+				TCP("localhost:9092"),
+				TCP("localhost:9093"),
+				TCP("localhost:9094"),
+			},
+			network: "tcp,tcp,tcp",
+			address: "localhost:9092,localhost:9093,localhost:9094",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.network+"+"+test.address, func(t *testing.T) {
+			if s := test.addr.Network(); s != test.network {
+				t.Errorf("network mismatch: want %q but got %q", test.network, s)
+			}
+			if s := test.addr.String(); s != test.address {
+				t.Errorf("network mismatch: want %q but got %q", test.address, s)
+			}
+		})
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -121,12 +121,6 @@ func TestClient(t *testing.T) {
 	}
 }
 
-type testLogger struct{ *testing.T }
-
-func (log testLogger) Printf(msg string, args ...interface{}) {
-	log.Logf(msg, args...)
-}
-
 func testConsumerGroupFetchOffsets(t *testing.T, ctx context.Context, c *Client) {
 	const totalMessages = 144
 	const partitions = 12

--- a/client_test.go
+++ b/client_test.go
@@ -1,11 +1,16 @@
 package kafka
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"math/rand"
 	"net"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/segmentio/kafka-go/compress"
 )
 
 func newLocalClientAndTopic() (*Client, string, func()) {
@@ -182,4 +187,116 @@ func testConsumerGroupFetchOffsets(t *testing.T, ctx context.Context, c *Client)
 			t.Errorf("expected partition %d with committed offset of %d but received %d", i, msgPerPartition, committedOffset)
 		}
 	}
+}
+
+func TestClientProduceAndConsume(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// Tests a typical kafka use case, data is produced to a partition,
+	// then consumed back sequentially. We use snappy compression because
+	// kafka stream are often compressed, and verify that each record
+	// produced is exposed to the consumer, and order is preserved.
+	client, topic, shutdown := newLocalClientAndTopic()
+	defer shutdown()
+
+	epoch := time.Now()
+	seed := int64(0) // deterministic
+	prng := rand.New(rand.NewSource(seed))
+	offset := int64(0)
+
+	const numBatches = 100
+	const recordsPerBatch = 320
+	t.Logf("producing %d batches of %d records...", numBatches, recordsPerBatch)
+
+	for i := 0; i < numBatches; i++ { // produce 100 batches
+		records := make([]Record, recordsPerBatch)
+
+		for i := range records {
+			v := make([]byte, prng.Intn(999)+1)
+			io.ReadFull(prng, v)
+			records[i].Time = epoch
+			records[i].Value = NewBytes(v)
+		}
+
+		res, err := client.Produce(ctx, &ProduceRequest{
+			Topic:        topic,
+			Partition:    0,
+			RequiredAcks: -1,
+			Records:      NewRecordReader(records...),
+			Compression:  compress.Snappy,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Error != nil {
+			t.Fatal(res.Error)
+		}
+		if res.BaseOffset != offset {
+			t.Fatalf("records were produced at an unexpected offset, want %d but got %d", offset, res.BaseOffset)
+		}
+		offset += int64(len(records))
+	}
+
+	prng.Seed(seed)
+	offset = 0 // reset
+	numFetches := 0
+	numRecords := 0
+
+	for numRecords < (numBatches * recordsPerBatch) {
+		res, err := client.Fetch(ctx, &FetchRequest{
+			Topic:     topic,
+			Partition: 0,
+			Offset:    offset,
+			MinBytes:  1,
+			MaxBytes:  256 * 1024,
+			MaxWait:   100 * time.Millisecond, // should only hit on the last fetch
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Error != nil {
+			t.Fatal(err)
+		}
+
+		for {
+			r, err := res.Records.ReadRecord()
+			if err != nil {
+				if err != io.EOF {
+					t.Fatal(err)
+				}
+				break
+			}
+
+			if r.Key != nil {
+				r.Key.Close()
+				t.Error("unexpected non-null key on record at offset", r.Offset)
+			}
+
+			n := prng.Intn(999) + 1
+			a := make([]byte, n)
+			b := make([]byte, n)
+			io.ReadFull(prng, a)
+
+			_, err = io.ReadFull(r.Value, b)
+			r.Value.Close()
+			if err != nil {
+				t.Fatalf("reading record at offset %d: %v", r.Offset, err)
+			}
+
+			if !bytes.Equal(a, b) {
+				t.Fatalf("value of record at offset %d mismatches", r.Offset)
+			}
+
+			if r.Offset != offset {
+				t.Fatalf("record at offset %d was expected to have offset %d", r.Offset, offset)
+			}
+
+			offset = r.Offset + 1
+			numRecords++
+		}
+
+		numFetches++
+	}
+
+	t.Logf("%d records were read in %d fetches", numRecords, numFetches)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -125,9 +125,12 @@ func testConsumerGroupFetchOffsets(t *testing.T, ctx context.Context, c *Client)
 	const totalMessages = 144
 	const partitions = 12
 	const msgPerPartition = totalMessages / partitions
+
 	topic := makeTopic()
-	groupId := makeGroupID()
 	createTopic(t, topic, partitions)
+	defer deleteTopic(t, topic)
+
+	groupId := makeGroupID()
 	brokers := []string{"localhost:9092"}
 
 	writer := NewWriter(WriterConfig{

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -110,8 +110,6 @@ func TestCompressedMessages(t *testing.T) {
 
 func testCompressedMessages(t *testing.T, codec pkg.Codec) {
 	t.Run("produce/consume with"+codec.Name(), func(t *testing.T) {
-		t.Parallel()
-
 		topic := createTopic(t, 1)
 		w := kafka.NewWriter(kafka.WriterConfig{
 			Brokers:          []string{"127.0.0.1:9092"},
@@ -178,8 +176,6 @@ func testCompressedMessages(t *testing.T, codec pkg.Codec) {
 }
 
 func TestMixedCompressedMessages(t *testing.T) {
-	t.Parallel()
-
 	topic := createTopic(t, 1)
 
 	offset := 0

--- a/conn_test.go
+++ b/conn_test.go
@@ -105,8 +105,6 @@ func makeGroupID() string {
 }
 
 func TestConn(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		scenario   string
 		function   func(*testing.T, *Conn)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1025,7 +1025,7 @@ func testBrokers(t *testing.T, conn *Conn) {
 func TestReadPartitionsNoTopic(t *testing.T) {
 	conn, err := Dial("tcp", "127.0.0.1:9092")
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer conn.Close()
 

--- a/consumergroup_test.go
+++ b/consumergroup_test.go
@@ -237,8 +237,6 @@ func TestReaderAssignTopicPartitions(t *testing.T) {
 }
 
 func TestConsumerGroup(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		scenario string
 		function func(*testing.T, context.Context, *ConsumerGroup)

--- a/consumergroup_test.go
+++ b/consumergroup_test.go
@@ -312,11 +312,10 @@ func TestConsumerGroup(t *testing.T) {
 
 	topic := makeTopic()
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			t.Parallel()
-
 			group, err := NewConsumerGroup(ConsumerGroupConfig{
 				ID:                makeGroupID(),
 				Topics:            []string{topic},
@@ -340,8 +339,6 @@ func TestConsumerGroup(t *testing.T) {
 }
 
 func TestConsumerGroupErrors(t *testing.T) {
-	t.Parallel()
-
 	var left []string
 	var lock sync.Mutex
 	mc := mockCoordinator{

--- a/crc32_test.go
+++ b/crc32_test.go
@@ -7,8 +7,6 @@ import (
 )
 
 func TestMessageCRC32(t *testing.T) {
-	t.Parallel()
-
 	m := message{
 		MagicByte: 1,
 		Timestamp: 42,

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -26,8 +26,6 @@ func TestDialer(t *testing.T) {
 	for _, test := range tests {
 		testFunc := test.function
 		t.Run(test.scenario, func(t *testing.T) {
-			t.Parallel()
-
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
@@ -37,9 +35,9 @@ func TestDialer(t *testing.T) {
 }
 
 func testDialerLookupPartitions(t *testing.T, ctx context.Context, d *Dialer) {
-	const topic = "test-dialer-LookupPartitions"
-
+	topic := makeTopic()
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
 
 	// Write a message to ensure the partition gets created.
 	w := NewWriter(WriterConfig{
@@ -61,7 +59,7 @@ func testDialerLookupPartitions(t *testing.T, ctx context.Context, d *Dialer) {
 
 	want := []Partition{
 		{
-			Topic:    "test-dialer-LookupPartitions",
+			Topic:    topic,
 			Leader:   Broker{Host: "localhost", Port: 9092, ID: 1},
 			Replicas: []Broker{{Host: "localhost", Port: 9092, ID: 1}},
 			Isr:      []Broker{{Host: "localhost", Port: 9092, ID: 1}},
@@ -170,11 +168,9 @@ wE3YmpC3Q0g9r44nEbz4Bw==
 }
 
 func TestDialerTLS(t *testing.T) {
-	t.Parallel()
-
-	const topic = "test-dialer-LookupPartitions"
-
+	topic := makeTopic()
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
 
 	// Write a message to ensure the partition gets created.
 	w := NewWriter(WriterConfig{

--- a/docker-compose.010.yml
+++ b/docker-compose.010.yml
@@ -1,0 +1,29 @@
+version: "3"
+services:
+  kafka:
+    image: wurstmeister/kafka:0.10.1.1
+    links:
+    - zookeeper
+    ports:
+    - 9092:9092
+    - 9093:9093
+    environment:
+      KAFKA_BROKER_ID: '1'
+      KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
+      KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+      KAFKA_ADVERTISED_PORT: '9092'
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_MESSAGE_MAX_BYTES: '200000000'
+      KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN'
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+      CUSTOM_INIT_SCRIPT: |-
+        echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+    - 2181:2181

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,20 @@ services:
     image: wurstmeister/kafka:2.12-2.3.1
     restart: on-failure:3
     links:
-      - zookeeper
+    - zookeeper
     ports:
-      - "9092:9092"
-      - "9093:9093"
+    - 9092:9092
+    - 9093:9093
     environment:
       KAFKA_VERSION: '2.3.1'
-      KAFKA_BROKER_ID: 1
+      KAFKA_BROKER_ID: '1'
       KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
       KAFKA_ADVERTISED_HOST_NAME: 'localhost'
       KAFKA_ADVERTISED_PORT: '9092'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-      KAFKA_MESSAGE_MAX_BYTES: 200000000
+      KAFKA_MESSAGE_MAX_BYTES: '200000000'
       KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
       KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
@@ -29,4 +29,4 @@ services:
   zookeeper:
     image: wurstmeister/zookeeper
     ports:
-      - "2181:2181"
+    - 2181:2181

--- a/error_test.go
+++ b/error_test.go
@@ -6,8 +6,6 @@ import (
 )
 
 func TestError(t *testing.T) {
-	t.Parallel()
-
 	errorCodes := []Error{
 		Unknown,
 		OffsetOutOfRange,

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -31,12 +31,9 @@ func copyRecords(records []Record) []Record {
 }
 
 func produceRecords(t *testing.T, n int, addr net.Addr, topic string, compression compress.Codec) []Record {
-	network := addr.Network()
-	address := net.JoinHostPort(addr.String(), "9092")
-
 	conn, err := (&Dialer{
 		Resolver: &net.Resolver{},
-	}).DialLeader(context.Background(), network, address, topic, 0)
+	}).DialLeader(context.Background(), addr.Network(), addr.String(), topic, 0)
 
 	if err != nil {
 		t.Fatal("failed to open a new kafka connection:", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/segmentio/kafka-go
 
-go 1.11
+go 1.13
 
 require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21

--- a/message.go
+++ b/message.go
@@ -40,7 +40,7 @@ func (msg Message) message(cw *crc32Writer) message {
 
 const timestampSize = 8
 
-func (msg Message) size() int32 {
+func (msg *Message) size() int32 {
 	return 4 + 1 + 1 + sizeofBytes(msg.Key) + sizeofBytes(msg.Value) + timestampSize
 }
 

--- a/protocol/buffer.go
+++ b/protocol/buffer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"sort"
 	"sync"
 	"sync/atomic"
 )
@@ -461,9 +460,10 @@ func (pages contiguousPages) slice(begin, end int64) contiguousPages {
 }
 
 func (pages contiguousPages) indexOf(offset int64) int {
-	return sort.Search(len(pages), func(i int) bool {
-		return offset < (pages[i].offset + pages[i].Size())
-	})
+	if len(pages) == 0 {
+		return 0
+	}
+	return int((offset - pages[0].offset) / pageSize)
 }
 
 func (pages contiguousPages) scan(begin, end int64, f func([]byte) bool) {

--- a/protocol/buffer_test.go
+++ b/protocol/buffer_test.go
@@ -1,0 +1,108 @@
+package protocol
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+func TestPageBufferWriteReadSeek(t *testing.T) {
+	buffer := newPageBuffer()
+	defer buffer.unref()
+
+	io.WriteString(buffer, "Hello World!")
+
+	if n := buffer.Size(); n != 12 {
+		t.Fatal("invalid size:", n)
+	}
+
+	for i := 0; i < 3; i++ {
+		if n := buffer.Len(); n != 12 {
+			t.Fatal("invalid length before read:", n)
+		}
+
+		b, err := ioutil.ReadAll(buffer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if n := buffer.Len(); n != 0 {
+			t.Fatal("invalid length after read:", n)
+		}
+
+		if string(b) != "Hello World!" {
+			t.Fatalf("invalid content after read #%d: %q", i, b)
+		}
+
+		offset, err := buffer.Seek(0, io.SeekStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if offset != 0 {
+			t.Fatalf("invalid offset after seek #%d: %d", i, offset)
+		}
+	}
+}
+
+func TestPageRefWriteReadSeek(t *testing.T) {
+	buffer := newPageBuffer()
+	defer buffer.unref()
+
+	io.WriteString(buffer, "Hello World!")
+
+	ref := buffer.ref(1, 11)
+	defer ref.unref()
+
+	if n := ref.Size(); n != 10 {
+		t.Fatal("invalid size:", n)
+	}
+
+	for i := 0; i < 3; i++ {
+		if n := ref.Len(); n != 10 {
+			t.Fatal("invalid length before read:", n)
+		}
+
+		b, err := ioutil.ReadAll(ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if n := ref.Len(); n != 0 {
+			t.Fatal("invalid length after read:", n)
+		}
+
+		if string(b) != "ello World" {
+			t.Fatalf("invalid content after read #%d: %q", i, b)
+		}
+
+		offset, err := ref.Seek(0, io.SeekStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if offset != 0 {
+			t.Fatalf("invalid offset after seek #%d: %d", i, offset)
+		}
+	}
+}
+
+func TestPageRefReadByte(t *testing.T) {
+	buffer := newPageBuffer()
+	defer buffer.unref()
+
+	content := bytes.Repeat([]byte("1234567890"), 10e3)
+	buffer.Write(content)
+
+	ref := buffer.ref(0, buffer.Size())
+	defer ref.unref()
+
+	for i, c := range content {
+		b, err := ref.ReadByte()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b != c {
+			t.Fatalf("byte at offset %d mismatch, expected '%c' but got '%c'", i, c, b)
+		}
+	}
+}

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -247,7 +247,7 @@ func (e *encoder) writeCompactNullBytes(b []byte) {
 }
 
 func (e *encoder) writeBytesFrom(b Bytes) error {
-	size := b.Size()
+	size := int64(b.Len())
 	e.writeInt32(int32(size))
 	n, err := io.Copy(e, b)
 	if err == nil && n != size {
@@ -261,7 +261,7 @@ func (e *encoder) writeNullBytesFrom(b Bytes) error {
 		e.writeInt32(-1)
 		return nil
 	} else {
-		size := b.Size()
+		size := int64(b.Len())
 		e.writeInt32(int32(size))
 		n, err := io.Copy(e, b)
 		if err == nil && n != size {
@@ -276,7 +276,7 @@ func (e *encoder) writeCompactNullBytesFrom(b Bytes) error {
 		e.writeVarInt(-1)
 		return nil
 	} else {
-		size := b.Size()
+		size := int64(b.Len())
 		e.writeVarInt(size)
 		n, err := io.Copy(e, b)
 		if err == nil && n != size {

--- a/protocol/produce/produce.go
+++ b/protocol/produce/produce.go
@@ -84,6 +84,10 @@ func (r *Request) Prepare(apiVersion int16) {
 	}
 }
 
+func (r *Request) HasResponse() bool {
+	return r.Acks != 0
+}
+
 type RequestTopic struct {
 	Topic      string             `kafka:"min=v0,max=v8"`
 	Partitions []RequestPartition `kafka:"min=v0,max=v8"`

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -357,10 +357,6 @@ type Broker struct {
 	ID   int
 }
 
-func (b Broker) Network() string {
-	return "tcp"
-}
-
 func (b Broker) String() string {
 	return net.JoinHostPort(b.Host, strconv.Itoa(b.Port))
 }

--- a/protocol/prototest/prototest.go
+++ b/protocol/prototest/prototest.go
@@ -125,8 +125,8 @@ func deepEqualBytes(s1, s2 protocol.Bytes) bool {
 		return false
 	}
 
-	n1 := s1.Size()
-	n2 := s2.Size()
+	n1 := s1.Len()
+	n2 := s2.Len()
 
 	if n1 != n2 {
 		return false

--- a/protocol/prototest/reflect.go
+++ b/protocol/prototest/reflect.go
@@ -120,20 +120,23 @@ func loadRecords(r protocol.RecordReader) []memoryRecord {
 			}
 			panic(err)
 		}
-		k, err := protocol.ReadAll(rec.Key)
-		if err != nil {
-			panic(err)
-		}
-		v, err := protocol.ReadAll(rec.Value)
-		if err != nil {
-			panic(err)
-		}
 		records = append(records, memoryRecord{
 			offset:  rec.Offset,
 			time:    rec.Time,
-			key:     k,
-			value:   v,
+			key:     readAll(rec.Key),
+			value:   readAll(rec.Value),
 			headers: rec.Headers,
 		})
 	}
+}
+
+func readAll(bytes protocol.Bytes) []byte {
+	if bytes != nil {
+		defer bytes.Close()
+	}
+	b, err := protocol.ReadAll(bytes)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/protocol/record_batch.go
+++ b/protocol/record_batch.go
@@ -187,6 +187,13 @@ type ControlRecord struct {
 }
 
 func ReadControlRecord(r *Record) (*ControlRecord, error) {
+	if r.Key != nil {
+		defer r.Key.Close()
+	}
+	if r.Value != nil {
+		defer r.Value.Close()
+	}
+
 	k, err := ReadAll(r.Key)
 	if err != nil {
 		return nil, err

--- a/protocol/record_batch_test.go
+++ b/protocol/record_batch_test.go
@@ -171,19 +171,30 @@ func equalRecords(r1, r2 *Record) bool {
 		return false
 	}
 
-	k1, _ := ReadAll(r1.Key)
-	k2, _ := ReadAll(r2.Key)
+	k1 := readAll(r1.Key)
+	k2 := readAll(r2.Key)
 
 	if !reflect.DeepEqual(k1, k2) {
 		return false
 	}
 
-	v1, _ := ReadAll(r1.Value)
-	v2, _ := ReadAll(r2.Value)
+	v1 := readAll(r1.Value)
+	v2 := readAll(r2.Value)
 
 	if !reflect.DeepEqual(v1, v2) {
 		return false
 	}
 
 	return reflect.DeepEqual(r1.Headers, r2.Headers)
+}
+
+func readAll(bytes Bytes) []byte {
+	if bytes != nil {
+		defer bytes.Close()
+	}
+	b, err := ReadAll(bytes)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/protocol/record_v1.go
+++ b/protocol/record_v1.go
@@ -174,7 +174,7 @@ func (rs *RecordSet) writeToVersion1(buffer *pageBuffer, bufferOffset int64) err
 			var err error
 			buffer.pages.scan(bufferOffset, buffer.Size(), func(b []byte) bool {
 				_, err = compressor.Write(b)
-				return err != nil
+				return err == nil
 			})
 			if err != nil {
 				return err

--- a/protocol/roundtrip.go
+++ b/protocol/roundtrip.go
@@ -9,6 +9,9 @@ func RoundTrip(rw io.ReadWriter, apiVersion int16, correlationID int32, clientID
 	if err := WriteRequest(rw, apiVersion, correlationID, clientID, req); err != nil {
 		return nil, err
 	}
+	if !hasResponse(req) {
+		return nil, nil
+	}
 	id, res, err := ReadResponse(rw, req.ApiKey(), apiVersion)
 	if err != nil {
 		return nil, err
@@ -17,4 +20,9 @@ func RoundTrip(rw io.ReadWriter, apiVersion int16, correlationID int32, clientID
 		return nil, Errorf("correlation id mismatch (expected=%d, found=%d)", correlationID, id)
 	}
 	return res, nil
+}
+
+func hasResponse(msg Message) bool {
+	x, _ := msg.(interface{ HasResponse() bool })
+	return x == nil || x.HasResponse()
 }

--- a/protocol/size.go
+++ b/protocol/size.go
@@ -67,7 +67,7 @@ func sizeOfVarBytes(b Bytes) int {
 	if b == nil {
 		return sizeOfVarInt(-1)
 	} else {
-		n := b.Size()
-		return sizeOfVarInt(n) + int(n)
+		n := b.Len()
+		return sizeOfVarInt(int64(n)) + n
 	}
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -32,8 +32,6 @@ func TestApiVersionsFormat(t *testing.T) {
 }
 
 func TestProtocol(t *testing.T) {
-	t.Parallel()
-
 	tests := []interface{}{
 		int8(42),
 		int16(42),

--- a/reader_test.go
+++ b/reader_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestReader(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		scenario string
 		function func(*testing.T, context.Context, *Reader)
@@ -331,8 +329,6 @@ func deleteTopic(t *testing.T, topic ...string) {
 }
 
 func TestReaderOnNonZeroPartition(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		scenario string
 		function func(*testing.T, context.Context, *Reader)
@@ -406,7 +402,6 @@ func TestReadTruncatedMessages(t *testing.T) {
 	//        include it in CI unit tests.
 	t.Skip()
 
-	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	r := NewReader(ReaderConfig{
@@ -698,8 +693,6 @@ func TestExtractTopics(t *testing.T) {
 }
 
 func TestReaderConsumerGroup(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		scenario       string
 		partitions     int
@@ -1240,8 +1233,6 @@ func TestCommitOffsetsWithRetry(t *testing.T) {
 // than partitions in a group.
 // https://github.com/segmentio/kafka-go/issues/200
 func TestRebalanceTooManyConsumers(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	conf := ReaderConfig{
 		Brokers: []string{"localhost:9092"},
@@ -1272,7 +1263,6 @@ func TestRebalanceTooManyConsumers(t *testing.T) {
 }
 
 func TestConsumerGroupWithMissingTopic(t *testing.T) {
-	t.Parallel()
 	t.Skip("this test doesn't work when the cluster is configured to auto-create topics")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/sasl/sasl_test.go
+++ b/sasl/sasl_test.go
@@ -18,9 +18,6 @@ const (
 )
 
 func TestSASL(t *testing.T) {
-
-	t.Parallel()
-
 	tests := []struct {
 		valid    func() sasl.Mechanism
 		invalid  func() sasl.Mechanism

--- a/time.go
+++ b/time.go
@@ -12,6 +12,9 @@ const (
 )
 
 func makeTime(t int64) time.Time {
+	if t <= 0 {
+		return time.Time{}
+	}
 	return time.Unix(t/1000, (t%1000)*int64(time.Millisecond)).UTC()
 }
 

--- a/transport.go
+++ b/transport.go
@@ -350,6 +350,9 @@ func (p *connPool) roundTrip(ctx context.Context, req Request) (Response, error)
 		//
 		// This reduces the number of round trips to kafka brokers while keeping
 		// the logic simple when applying partitioning strategies.
+		if state.err != nil {
+			return nil, state.err
+		}
 		return filterMetadataResponse(m, state.metadata), nil
 
 	case *createtopics.Request:
@@ -469,6 +472,7 @@ func (p *connPool) update(ctx context.Context, metadata *meta.Response, err erro
 		if state.metadata != nil {
 			return
 		}
+		state.err = err
 	} else {
 		for id, b2 := range layout.Brokers {
 			if b1, ok := state.layout.Brokers[id]; !ok {

--- a/transport.go
+++ b/transport.go
@@ -982,7 +982,7 @@ func (g *connGroup) connect() (*conn, error) {
 	var addrs []net.Addr
 	var err error
 
-	if m, ok := g.addr.(MultiAddr); ok {
+	if m, _ := g.addr.(MultiAddr); len(m) != 0 {
 		addrs = append([]net.Addr{}, m...)
 		// Shuffle the list of addresses to randomize the order in which
 		// connections are attempted. This prevents routing all connections

--- a/transport.go
+++ b/transport.go
@@ -997,6 +997,10 @@ func (g *connGroup) connect(ctx context.Context) (*conn, error) {
 	for i := range address {
 		netConn, err = g.pool.dial(ctx, network[i], address[i])
 		if err == nil {
+			netAddr = &networkAddress{
+				network: network[i],
+				address: address[i],
+			}
 			break
 		}
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,34 @@
+package kafka
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+)
+
+func TestIssue477(t *testing.T) {
+	// This test verifies that a connection attempt with a minimal TLS
+	// configuration does not panic.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	cg := connGroup{
+		addr: l.Addr(),
+		pool: &connPool{
+			dial: defaultDialer.DialContext,
+			tls:  &tls.Config{},
+		},
+	}
+
+	if _, err := cg.connect(context.Background()); err != nil {
+		// An error is expected here because we are not actually establishing
+		// a TLS connection to a kafka broker.
+		t.Log(err)
+	} else {
+		t.Error("no error was reported when attempting to establish a TLS connection to a non-TLS endpoint")
+	}
+}

--- a/write_test.go
+++ b/write_test.go
@@ -47,7 +47,6 @@ func TestWriteVarInt(t *testing.T) {
 }
 
 func TestWriteOptimizations(t *testing.T) {
-	t.Parallel()
 	t.Run("writeFetchRequestV2", testWriteFetchRequestV2)
 	t.Run("writeListOffsetRequestV1", testWriteListOffsetRequestV1)
 	t.Run("writeProduceRequestV2", testWriteProduceRequestV2)

--- a/writer.go
+++ b/writer.go
@@ -208,7 +208,7 @@ type Writer struct {
 // WriterConfig is a configuration type used to create new instances of Writer.
 //
 // DEPRECATED: writer values should be configured directly by assigning their
-// exported fields. This type is kept for backward compatibilty, and will be
+// exported fields. This type is kept for backward compatibility, and will be
 // removed in version 1.0.
 type WriterConfig struct {
 	// The list of brokers used to discover the partitions available on the

--- a/writer.go
+++ b/writer.go
@@ -815,6 +815,9 @@ func (w *Writer) partitions(ctx context.Context) (int, error) {
 	// Here we use the transport directly as an optimization to avoid the
 	// construction of temporary request and response objects made by the
 	// (*Client).Metadata API.
+	//
+	// It is expected that the transport will optimize this request by
+	// caching recent results (the kafka.Transport types does).
 	r, err := client.transport().RoundTrip(ctx, client.Addr, &metadataAPI.Request{
 		TopicNames: []string{w.Topic},
 	})

--- a/writer.go
+++ b/writer.go
@@ -680,10 +680,10 @@ func (w *Writer) batchMessages(messages []Message, assignments map[int32][]int32
 func (w *Writer) newWriteBatch(partition int32) *writeBatch {
 	batch := newWriteBatch(time.Now(), w.batchTimeout())
 	w.group.Add(1)
-	go func(partition int32) {
+	go func() {
 		defer w.group.Done()
 		w.writeBatch(partition, batch)
-	}(partition)
+	}()
 	return batch
 }
 

--- a/writer.go
+++ b/writer.go
@@ -468,7 +468,7 @@ func NewWriter(config WriterConfig) *Writer {
 	}
 
 	w := &Writer{
-		Addr:         TCP(config.Brokers[0]), // Should we do something more complex here?
+		Addr:         TCP(config.Brokers...),
 		Topic:        config.Topic,
 		MaxAttempts:  config.MaxAttempts,
 		BatchSize:    config.BatchSize,

--- a/writer.go
+++ b/writer.go
@@ -1,37 +1,215 @@
 package kafka
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
-	"math/rand"
-	"sort"
+	"net"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	metadataAPI "github.com/segmentio/kafka-go/protocol/metadata"
 )
 
 // The Writer type provides the implementation of a producer of kafka messages
 // that automatically distributes messages across partitions of a single topic
 // using a configurable balancing policy.
 //
-// Instances of Writer are safe to use concurrently from multiple goroutines.
+// Writes manage the dispatch of messages across partitions of the topic they
+// are configured to write to using a Balancer, and aggregate batches to
+// optimize the writes to kafka.
+//
+// Writers may be configured to be used synchronously or asynchronously. When
+// use synchronously, calls to WriteMessages block until the messages have been
+// written to kafka. In this mode, the program should inspect the error returned
+// by the function and test if it an instance of kafka.WriteErrors in order to
+// identify which messages have succeeded or failed, for example:
+//
+//	// Construct a synchronous writer (the default mode).
+//	w := &kafka.Writer{
+//		Addr:         kafka.TCP("localhost:9092"),
+//		Topic:        "topic-A",
+//		RequiredAcks: kafka.RequireAll,
+//	}
+//
+//	...
+//
+//  // Passing a context can prevent the operation from blocking indefinitely.
+//	switch err := w.WriteMessages(ctx, msgs...).(type) {
+//	case nil:
+//	case kafka.WriteErrors:
+//		for i := range msgs {
+//			if err[i] != nil {
+//				// handle the error writing msgs[i]
+//				...
+//			}
+//		}
+//	default:
+//		// handle other errors
+//		...
+//	}
+//
+// In asynchronous mode, the program may configure a completion handler on the
+// writer to receive notifications of messages being written to kafka:
+//
+//	w := &kafka.Writer{
+//		Addr:         kafka.TCP("localhost:9092"),
+//		Topic:        "topic-A",
+//		RequiredAcks: kafka.RequireAll,
+//		Async:        true, // make the writer asynchronous
+//		Completion: func(messages []kafka.Message, err error) {
+//			...
+//		},
+//	}
+//
+//	...
+//
+//	// Because the writer is asynchronous, there is no need for the context to
+//	// be cancelled, the call will never block.
+//	if err := w.WriteMessages(context.Background(), msgs...); err != nil {
+//		// Only validation errors would be reported in this case.
+//		...
+//	}
+//
+// Methods of Writer are safe to use concurrently from multiple goroutines,
+// however the writer configuration should not be modified after first use.
 type Writer struct {
-	config WriterConfig
+	// Address of the kafka cluster that this writer is configured to send
+	// messages to.
+	//
+	// This feild is required, attempting to write messages to a writer with a
+	// nil address will error.
+	Addr net.Addr
 
-	mutex  sync.RWMutex
-	closed bool
+	// The topic that the writer will produce messages to.
+	//
+	// This field is required, attempting to write messages to a writer with no
+	// topic will error.
+	Topic string
 
-	join sync.WaitGroup
-	msgs chan writerMessage
-	done chan struct{}
+	// The balancer used to distribute messages across partitions.
+	//
+	// The default is to use a round-robin distribution.
+	Balancer Balancer
+
+	// Limit on how many attempts will be made to deliver a message.
+	//
+	// The default is to try at most 10 times.
+	MaxAttempts int
+
+	// Limit on how many messages will be buffered before being sent to a
+	// partition.
+	//
+	// The default is to use a target batch size of 100 messages.
+	BatchSize int
+
+	// Limit the maximum size of a request in bytes before being sent to
+	// a partition.
+	//
+	// The default is to use a kafka default value of 1048576.
+	BatchBytes int64
+
+	// Time limit on how often incomplete message batches will be flushed to
+	// kafka.
+	//
+	// The default is to flush at least every second.
+	BatchTimeout time.Duration
+
+	// Timeout for read operations performed by the Writer.
+	//
+	// Defaults to 10 seconds.
+	ReadTimeout time.Duration
+
+	// Timeout for write operation performed by the Writer.
+	//
+	// Defaults to 10 seconds.
+	WriteTimeout time.Duration
+
+	// Number of acknowledges from partition replicas required before receiving
+	// a response to a produce request, the following values are supported:
+	//
+	//  RequireNone (0)  fire-and-forget, do not wait for acknowledgements from the
+	//  RequireOne  (1)  wait for the leader to acknowledge the writes
+	//  RequireAll  (-1) wait for the full ISR to acknowledge the writes
+	//
+	RequiredAcks RequiredAcks
+
+	// Setting this flag to true causes the WriteMessages method to never block.
+	// It also means that errors are ignored since the caller will not receive
+	// the returned value. Use this only if you don't care about guarantees of
+	// whether the messages were written to kafka.
+	Async bool
+
+	// An optional function called when the writer succeeds or fails the
+	// delivery of messages to a kafka partition. When writing the messages
+	// fails, the `err` parameter will be non-nil.
+	//
+	// The messages that the Completion function is called with have their
+	// topic, partition, offset, and time set based on the Produce responses
+	// received from kafka. All messages passed to a call to the function have
+	// been written to the same partition. The keys and values of messages are
+	// referencing the original byte slices carried by messages in the calls to
+	// WriteMessages.
+	//
+	// The function is called from goroutines started by the writer. Calls to
+	// Close will block on the Completion function calls. When the Writer is
+	// not writing asynchronously, the WriteMessages call will also block on
+	// Completion function, which is a useful guarantee if the byte slices
+	// for the message keys and values are intended to be reused after the
+	// WriteMessages call returned.
+	//
+	// If a completion function panics, the program terminates because the
+	// panic is not recovered by the writer and bubbles up to the top of the
+	// goroutine's call stack.
+	Completion func(messages []Message, err error)
+
+	// Compression set the compression codec to be used to compress messages.
+	Compression Compression
+
+	// If not nil, specifies a logger used to report internal changes within the
+	// writer.
+	Logger Logger
+
+	// ErrorLogger is the logger used to report errors. If nil, the writer falls
+	// back to using Logger instead.
+	ErrorLogger Logger
+
+	// A transport used to send messages to kafka clusters.
+	//
+	// If nil, DefaultTransport is used.
+	Transport RoundTripper
+
+	// Atomic flag indicating whether the writer has been closed.
+	closed uint32
+	group  sync.WaitGroup
+
+	// Manages the current batch being aggregated on the writer.
+	mutex   sync.Mutex
+	batches map[int32]*writeBatch
 
 	// writer stats are all made of atomic values, no need for synchronization.
-	// Use a pointer to ensure 64-bit alignment of the values.
-	stats *writerStats
+	// Use a pointer to ensure 64-bit alignment of the values. The once value is
+	// used to lazily create the value when first used, allowing programs to use
+	// the zero-value value of Writer.
+	once sync.Once
+	*writerStats
+
+	// If no balancer is configured, the writer uses this one. RoundRobin values
+	// are safe to use concurrently from multiple goroutines, there is no need
+	// for extra synchronization to access this field.
+	roundRobin RoundRobin
+
+	// non-nil when a transport was created by NewWriter, remove in 1.0.
+	transport *Transport
 }
 
 // WriterConfig is a configuration type used to create new instances of Writer.
+//
+// DEPRECATED: writer values should be configured directly by assigning their
+// exported fields. This type is kept for backward compatibilty, and will be
+// removed in version 1.0.
 type WriterConfig struct {
 	// The list of brokers used to discover the partitions available on the
 	// kafka cluster.
@@ -62,9 +240,10 @@ type WriterConfig struct {
 	// The default is to try at most 10 times.
 	MaxAttempts int
 
-	// A hint on the capacity of the writer's internal message queue.
-	//
-	// The default is to use a queue capacity of 100 messages.
+	// DEPRECATED: in versions prior to 0.4, the writer used channels internally
+	// to dispatch messages to partitions. This has been replaced by an in-memory
+	// aggregation of batches which uses shared state instead of message passing,
+	// making this option unnecessary.
 	QueueCapacity int
 
 	// Limit on how many messages will be buffered before being sent to a
@@ -95,16 +274,15 @@ type WriterConfig struct {
 	// Defaults to 10 seconds.
 	WriteTimeout time.Duration
 
-	// This interval defines how often the list of partitions is refreshed from
-	// kafka. It allows the writer to automatically handle when new partitions
-	// are added to a topic.
-	//
-	// The default is to refresh partitions every 15 seconds.
+	// DEPRECATED: in versions prior to 0.4, the writer used to maintain a cache
+	// the topic layout. With the change to use a transport to manage connections,
+	// the responsibility of syncing the cluster layout has been delegated to the
+	// transport.
 	RebalanceInterval time.Duration
 
-	// Connections that were idle for this duration will not be reused.
-	//
-	// Defaults to 9 minutes.
+	// DEPRECACTED: in versions prior to 0.4, the writer used to manage connections
+	// to the kafka cluster directly. With the change to use a transport to manage
+	// connections, the writer has no connections to manage directly anymore.
 	IdleConnTimeout time.Duration
 
 	// Number of acknowledges from partition replicas required before receiving
@@ -119,7 +297,6 @@ type WriterConfig struct {
 	Async bool
 
 	// CompressionCodec set the codec to be used to compress Kafka messages.
-	// Note that messages are allowed to overwrite the compression codec individually.
 	CompressionCodec
 
 	// If not nil, specifies a logger used to report internal changes within the
@@ -129,40 +306,60 @@ type WriterConfig struct {
 	// ErrorLogger is the logger used to report errors. If nil, the writer falls
 	// back to using Logger instead.
 	ErrorLogger Logger
+}
 
-	newPartitionWriter func(partition int, config WriterConfig, stats *writerStats) partitionWriter
+// Validate method validates WriterConfig properties.
+func (config *WriterConfig) Validate() error {
+	if len(config.Brokers) == 0 {
+		return errors.New("cannot create a kafka writer with an empty list of brokers")
+	}
+	if len(config.Topic) == 0 {
+		return errors.New("cannot create a kafka writer with an empty topic")
+	}
+	return nil
 }
 
 // WriterStats is a data structure returned by a call to Writer.Stats that
 // exposes details about the behavior of the writer.
 type WriterStats struct {
-	Dials      int64 `metric:"kafka.writer.dial.count"      type:"counter"`
-	Writes     int64 `metric:"kafka.writer.write.count"     type:"counter"`
-	Messages   int64 `metric:"kafka.writer.message.count"   type:"counter"`
-	Bytes      int64 `metric:"kafka.writer.message.bytes"   type:"counter"`
-	Rebalances int64 `metric:"kafka.writer.rebalance.count" type:"counter"`
-	Errors     int64 `metric:"kafka.writer.error.count"     type:"counter"`
+	Writes   int64 `metric:"kafka.writer.write.count"     type:"counter"`
+	Messages int64 `metric:"kafka.writer.message.count"   type:"counter"`
+	Bytes    int64 `metric:"kafka.writer.message.bytes"   type:"counter"`
+	Errors   int64 `metric:"kafka.writer.error.count"     type:"counter"`
 
-	DialTime   DurationStats `metric:"kafka.writer.dial.seconds"`
+	BatchTime  DurationStats `metric:"kafka.writer.batch.seconds"`
 	WriteTime  DurationStats `metric:"kafka.writer.write.seconds"`
 	WaitTime   DurationStats `metric:"kafka.writer.wait.seconds"`
 	Retries    SummaryStats  `metric:"kafka.writer.retries.count"`
 	BatchSize  SummaryStats  `metric:"kafka.writer.batch.size"`
 	BatchBytes SummaryStats  `metric:"kafka.writer.batch.bytes"`
 
-	MaxAttempts       int64         `metric:"kafka.writer.attempts.max"       type:"gauge"`
-	MaxBatchSize      int64         `metric:"kafka.writer.batch.max"          type:"gauge"`
-	BatchTimeout      time.Duration `metric:"kafka.writer.batch.timeout"      type:"gauge"`
-	ReadTimeout       time.Duration `metric:"kafka.writer.read.timeout"       type:"gauge"`
-	WriteTimeout      time.Duration `metric:"kafka.writer.write.timeout"      type:"gauge"`
-	RebalanceInterval time.Duration `metric:"kafka.writer.rebalance.interval" type:"gauge"`
-	RequiredAcks      int64         `metric:"kafka.writer.acks.required"      type:"gauge"`
-	Async             bool          `metric:"kafka.writer.async"              type:"gauge"`
-	QueueLength       int64         `metric:"kafka.writer.queue.length"       type:"gauge"`
-	QueueCapacity     int64         `metric:"kafka.writer.queue.capacity"     type:"gauge"`
+	MaxAttempts  int64         `metric:"kafka.writer.attempts.max"  type:"gauge"`
+	MaxBatchSize int64         `metric:"kafka.writer.batch.max"     type:"gauge"`
+	BatchTimeout time.Duration `metric:"kafka.writer.batch.timeout" type:"gauge"`
+	ReadTimeout  time.Duration `metric:"kafka.writer.read.timeout"  type:"gauge"`
+	WriteTimeout time.Duration `metric:"kafka.writer.write.timeout" type:"gauge"`
+	RequiredAcks int64         `metric:"kafka.writer.acks.required" type:"gauge"`
+	Async        bool          `metric:"kafka.writer.async"         type:"gauge"`
 
-	ClientID string `tag:"client_id"`
-	Topic    string `tag:"topic"`
+	Topic string `tag:"topic"`
+
+	// DEPRECATED: these fields will only be reported for backward compatibility
+	// if the Writer was constructed with NewWriter.
+	Dials    int64         `metric:"kafka.writer.dial.count" type:"counter"`
+	DialTime DurationStats `metric:"kafka.writer.dial.seconds"`
+
+	// DEPRECATED: these fields were meaningful prior to kafka-go 0.4, changes
+	// to the internal implementation and the introduction of the transport type
+	// made them unnecessary.
+	//
+	// The values will be zero but are left for backward compatibility to avoid
+	// breaking programs that used these fields.
+	Rebalances        int64
+	RebalanceInterval time.Duration
+	QueueLength       int64
+	QueueCapacity     int64
+	ClientID          string
 }
 
 // writerStats is a struct that contains statistics on a writer.
@@ -175,9 +372,9 @@ type writerStats struct {
 	writes         counter
 	messages       counter
 	bytes          counter
-	rebalances     counter
 	errors         counter
 	dialTime       summary
+	batchTime      summary
 	writeTime      summary
 	waitTime       summary
 	retries        summary
@@ -185,23 +382,12 @@ type writerStats struct {
 	batchSizeBytes summary
 }
 
-// Validate method validates WriterConfig properties.
-func (config *WriterConfig) Validate() error {
-
-	if len(config.Brokers) == 0 {
-		return errors.New("cannot create a kafka writer with an empty list of brokers")
-	}
-
-	if len(config.Topic) == 0 {
-		return errors.New("cannot create a kafka writer with an empty topic")
-	}
-
-	return nil
-}
-
 // NewWriter creates and returns a new Writer configured with config.
+//
+// DEPRECATED: Writer value can be instantiated and configured directly,
+// this function is retained for backward compatibility and will be removed
+// in version 1.0.
 func NewWriter(config WriterConfig) *Writer {
-
 	if err := config.Validate(); err != nil {
 		panic(err)
 	}
@@ -210,67 +396,133 @@ func NewWriter(config WriterConfig) *Writer {
 		config.Dialer = DefaultDialer
 	}
 
-	if config.Balancer == nil {
-		config.Balancer = &RoundRobin{}
+	// Converts the pre-0.4 Dialer API into a Transport.
+	kafkaDialer := DefaultDialer
+	if config.Dialer != nil {
+		kafkaDialer = config.Dialer
 	}
 
-	if config.newPartitionWriter == nil {
-		config.newPartitionWriter = func(partition int, config WriterConfig, stats *writerStats) partitionWriter {
-			return newWriter(partition, config, stats)
+	dialer := (&net.Dialer{
+		Timeout:       kafkaDialer.Timeout,
+		Deadline:      kafkaDialer.Deadline,
+		LocalAddr:     kafkaDialer.LocalAddr,
+		DualStack:     kafkaDialer.DualStack,
+		FallbackDelay: kafkaDialer.FallbackDelay,
+		KeepAlive:     kafkaDialer.KeepAlive,
+	})
+
+	var resolver Resolver
+	if r, ok := kafkaDialer.Resolver.(*net.Resolver); ok {
+		dialer.Resolver = r
+	} else {
+		resolver = kafkaDialer.Resolver
+	}
+
+	stats := new(writerStats)
+	// For backward compatibility with the pre-0.4 APIs, support custom
+	// resolvers by wrapping the dial function.
+	dial := func(ctx context.Context, network, address string) (net.Conn, error) {
+		start := time.Now()
+		defer func() {
+			stats.dials.observe(1)
+			stats.dialTime.observe(int64(time.Since(start)))
+		}()
+		if resolver != nil {
+			host, port := splitHostPort(address)
+			addrs, err := resolver.LookupHost(ctx, host)
+			if err != nil {
+				return nil, err
+			}
+			if len(addrs) != 0 {
+				address = addrs[0]
+			}
+			if len(port) != 0 {
+				address, _ = splitHostPort(address)
+				address = net.JoinHostPort(address, port)
+			}
 		}
+		return dialer.DialContext(ctx, network, address)
 	}
 
-	if config.MaxAttempts == 0 {
-		config.MaxAttempts = 10
+	idleTimeout := config.IdleConnTimeout
+	if idleTimeout == 0 {
+		// Historical default value of WriterConfig.IdleTimeout, 9 minutes seems
+		// like it is way too long when there is no ping mechanism in the kafka
+		// protocol.
+		idleTimeout = 9 * time.Minute
 	}
 
-	if config.QueueCapacity == 0 {
-		config.QueueCapacity = 100
+	metadataTTL := config.RebalanceInterval
+	if metadataTTL == 0 {
+		// Historical default value of WriterConfig.RebalanceInterval.
+		metadataTTL = 15 * time.Second
 	}
 
-	if config.BatchSize == 0 {
-		config.BatchSize = 100
-	}
-
-	if config.BatchBytes == 0 {
-		// 1048576 == 1MB which is the Kafka default.
-		config.BatchBytes = 1048576
-	}
-
-	if config.BatchTimeout == 0 {
-		config.BatchTimeout = 1 * time.Second
-	}
-
-	if config.ReadTimeout == 0 {
-		config.ReadTimeout = 10 * time.Second
-	}
-
-	if config.WriteTimeout == 0 {
-		config.WriteTimeout = 10 * time.Second
-	}
-
-	if config.RebalanceInterval == 0 {
-		config.RebalanceInterval = 15 * time.Second
-	}
-	if config.IdleConnTimeout == 0 {
-		config.IdleConnTimeout = 9 * time.Minute
+	transport := &Transport{
+		Dial:        dial,
+		SASL:        kafkaDialer.SASLMechanism,
+		TLS:         kafkaDialer.TLS,
+		ClientID:    kafkaDialer.ClientID,
+		IdleTimeout: idleTimeout,
+		MetadataTTL: metadataTTL,
 	}
 
 	w := &Writer{
-		config: config,
-		msgs:   make(chan writerMessage, config.QueueCapacity),
-		done:   make(chan struct{}),
-		stats: &writerStats{
-			dialTime:  makeSummary(),
-			writeTime: makeSummary(),
-			waitTime:  makeSummary(),
-			retries:   makeSummary(),
-		},
+		Addr:         TCP(config.Brokers[0]), // Should we do something more complex here?
+		Topic:        config.Topic,
+		MaxAttempts:  config.MaxAttempts,
+		BatchSize:    config.BatchSize,
+		BatchBytes:   int64(config.BatchBytes),
+		BatchTimeout: config.BatchTimeout,
+		ReadTimeout:  config.ReadTimeout,
+		WriteTimeout: config.WriteTimeout,
+		RequiredAcks: RequiredAcks(config.RequiredAcks),
+		Async:        config.Async,
+		Logger:       config.Logger,
+		ErrorLogger:  config.ErrorLogger,
+		Transport:    transport,
+		transport:    transport,
+		writerStats:  stats,
 	}
 
-	w.join.Add(1)
-	go w.run()
+	if config.RequiredAcks == 0 {
+		// Historically the writers created by NewWriter have used "all" as the
+		// default value when 0 was specified.
+		w.RequiredAcks = RequireAll
+	}
+
+	if config.CompressionCodec != nil {
+		w.Compression = Compression(config.CompressionCodec.Code())
+	}
+
 	return w
+}
+
+// Close flushes pending writes, and waits for all writes to complete before
+// returning. Calling Close also prevents new writes from being submitted to
+// the writer, further calls to WriteMessages and the like will fail with
+// io.ErrClosedPipe.
+func (w *Writer) Close() error {
+	w.markClosed()
+	// If batches are pending, trigger them so messages get sent.
+	w.mutex.Lock()
+
+	for _, batch := range w.batches {
+		batch.trigger()
+	}
+
+	for partition := range w.batches {
+		delete(w.batches, partition)
+	}
+
+	w.mutex.Unlock()
+	w.group.Wait()
+
+	if w.transport != nil {
+		w.transport.CloseIdleConnections()
+	}
+
+	return nil
 }
 
 // WriteMessages writes a batch of messages to the kafka topic configured on this
@@ -289,8 +541,8 @@ func NewWriter(config WriterConfig) *Writer {
 // best way to achieve good batching behavior is to share one Writer amongst
 // multiple go routines.
 //
-// When the method returns an error, there's no way to know yet which messages
-// have succeeded of failed.
+// When the method returns an error, it may be of type kafka.WriteError to allow
+// the caller to determine the status of each message.
 //
 // The context passed as first argument may also be used to asynchronously
 // cancel the operation. Note that in this case there are no guarantees made on
@@ -298,61 +550,381 @@ func NewWriter(config WriterConfig) *Writer {
 // whole batch failed and re-write the messages later (which could then cause
 // duplicates).
 func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
+	if w.Addr == nil {
+		return errors.New("kafka.(*Writer).WriteMessages: cannot create a kafka writer with a nil address")
+	}
+
+	if w.Topic == "" {
+		return errors.New("kafka.(*Writer).WriteMessages: cannot create a kafka writer with an empty topic")
+	}
+
+	w.group.Add(1)
+	defer w.group.Done()
+
+	if w.isClosed() {
+		return io.ErrClosedPipe
+	}
+
 	if len(msgs) == 0 {
 		return nil
 	}
 
-	var err error
-	var res chan error
-	if !w.config.Async {
-		res = make(chan error, len(msgs))
-	}
-	t0 := time.Now()
-	defer w.stats.writeTime.observeDuration(time.Since(t0))
+	balancer := w.balancer()
+	batchBytes := w.batchBytes()
 
-	w.mutex.RLock()
-	closed := w.closed
-	w.mutex.RUnlock()
-
-	if closed {
-		return io.ErrClosedPipe
+	for i := range msgs {
+		n := int64(msgs[i].size())
+		if n > batchBytes {
+			// This error is left for backward compatibility with historical
+			// behavior, but it can yield O(N^2) behaviors. The expectations
+			// are that the program will check if WriteMessages returned a
+			// MessageTooLargeError, discard the message that was exceeding
+			// the maximum size, and try again.
+			return messageTooLarge(msgs, i)
+		}
 	}
+
+	numPartitions, err := w.partitions(ctx)
+	if err != nil {
+		return err
+	}
+
+	// We use int32 here to half the memory footprint (compared to using int
+	// on 64 bits architectures). We map lists of the message indexes instead
+	// of the message values for the same reason, int32 is 4 bytes, vs a full
+	// Message value which is 100+ bytes and contains pointers and contributes
+	// to increasing GC work.
+	assignments := make(map[int32][]int32, numPartitions)
+	partitions := loadCachedPartitions(numPartitions)
 
 	for i, msg := range msgs {
-
-		if int(msg.size()) > w.config.BatchBytes {
-			err := MessageTooLargeError{
-				Message:   msg,
-				Remaining: msgs[i+1:],
-			}
-			return err
-		}
-
-		wm := writerMessage{msg: msg, res: res}
-
-		select {
-		case w.msgs <- wm:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		partition := balancer.Balance(msg, partitions...)
+		assignments[int32(partition)] = append(assignments[int32(partition)], int32(i))
 	}
 
-	if w.config.Async {
+	batches := w.batchMessages(msgs, assignments)
+	if w.Async {
 		return nil
 	}
 
-	for i := 0; i != len(msgs); i++ {
+	done := ctx.Done()
+	hasErrors := false
+	for batch := range batches {
 		select {
-		case e := <-res:
-			if e != nil {
-				err = e
-			}
-		case <-ctx.Done():
+		case <-done:
 			return ctx.Err()
+		case <-batch.done:
+			if batch.err != nil {
+				hasErrors = true
+			}
 		}
 	}
 
-	return err
+	if !hasErrors {
+		return nil
+	}
+
+	werr := make(WriteErrors, len(msgs))
+
+	for batch, indexes := range batches {
+		for _, i := range indexes {
+			werr[i] = batch.err
+		}
+	}
+
+	return werr
+}
+
+func (w *Writer) batchMessages(messages []Message, assignments map[int32][]int32) map[*writeBatch][]int32 {
+	var batches map[*writeBatch][]int32
+	if !w.Async {
+		batches = make(map[*writeBatch][]int32, len(assignments))
+	}
+
+	batchSize := w.batchSize()
+	batchBytes := w.batchBytes()
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if w.batches == nil {
+		w.batches = map[int32]*writeBatch{}
+	}
+
+	for partition, indexes := range assignments {
+		for _, i := range indexes {
+		assignMessage:
+			batch := w.batches[partition]
+			if batch == nil {
+				batch = w.newWriteBatch(partition)
+				w.batches[partition] = batch
+			}
+			if !batch.add(messages[i], batchSize, batchBytes) {
+				batch.trigger()
+				delete(w.batches, partition)
+				goto assignMessage
+			}
+			if batch.full(batchSize, batchBytes) {
+				batch.trigger()
+				delete(w.batches, partition)
+			}
+			if !w.Async {
+				batches[batch] = append(batches[batch], i)
+			}
+		}
+	}
+
+	return batches
+}
+
+func (w *Writer) newWriteBatch(partition int32) *writeBatch {
+	batch := newWriteBatch(time.Now(), w.batchTimeout())
+	w.group.Add(1)
+	go func(partition int32) {
+		defer w.group.Done()
+		w.writeBatch(partition, batch)
+	}(partition)
+	return batch
+}
+
+func (w *Writer) writeBatch(partition int32, batch *writeBatch) {
+	// This goroutine has taken ownership of the batch, it is responsible
+	// for waiting for the batch to be ready (because it became full), or
+	// to timeout.
+	select {
+	case <-batch.timer.C:
+		// The batch timed out, we want to detach it from the writer to
+		// prevent more messages from being added.
+		w.mutex.Lock()
+		if batch == w.batches[partition] {
+			delete(w.batches, partition)
+		}
+		w.mutex.Unlock()
+
+	case <-batch.ready:
+		// The batch became full, it was removed from the writer and its
+		// ready channel was closed. We need to close the timer to avoid
+		// having it leak until it expires.
+		batch.timer.Stop()
+	}
+
+	stats := w.stats()
+	stats.batchTime.observe(int64(time.Since(batch.time)))
+	stats.batchSize.observe(int64(len(batch.msgs)))
+	stats.batchSizeBytes.observe(batch.bytes)
+
+	var res *ProduceResponse
+	var err error
+
+	for attempt, maxAttempts := 0, w.maxAttempts(); attempt < maxAttempts; attempt++ {
+		if attempt != 0 {
+			stats.retries.observe(1)
+			// TODO: should there be a way to asynchronously cancel this
+			// operation?
+			//
+			// * If all goroutines that added message to this batch have stopped
+			//   waiting for it, should we abort?
+			//
+			// * If the writer has been closed? It reduces the durability
+			//   guarantees to abort, but may be better to avoid long wait times
+			//   on close.
+			//
+			delay := backoff(attempt, 100*time.Millisecond, 1*time.Second)
+			w.withLogger(func(log Logger) {
+				log.Printf("backing off %s writing %d messages to %s (partition: %d)", delay, len(batch.msgs), w.Topic, partition)
+			})
+			time.Sleep(delay)
+		}
+
+		w.withLogger(func(log Logger) {
+			log.Printf("writing %d messages to %s (partition: %d)", len(batch.msgs), w.Topic, partition)
+		})
+
+		start := time.Now()
+		res, err = w.produce(partition, batch)
+
+		stats.writes.observe(1)
+		stats.messages.observe(int64(len(batch.msgs)))
+		stats.bytes.observe(batch.bytes)
+		// stats.writeTime used to report the duration of WriteMessages, but the
+		// implementation was broken and reporting values in the nanoseconds
+		// range. In kafka-go 0.4, we recylced this value to instead report the
+		// duration of produce requests, and changed the stats.waitTime value to
+		// report the time that kafka has throttled the requests for.
+		stats.writeTime.observe(int64(time.Since(start)))
+
+		if res != nil {
+			err = res.Error
+			stats.waitTime.observe(int64(res.Throttle))
+		}
+
+		if err == nil {
+			break
+		}
+
+		stats.errors.observe(1)
+
+		w.withErrorLogger(func(log Logger) {
+			log.Printf("error writing messages to %s (partition %d): %s", w.Topic, partition, err)
+		})
+
+		if !isTemporary(err) {
+			break
+		}
+	}
+
+	if res != nil {
+		for i := range batch.msgs {
+			m := &batch.msgs[i]
+			m.Topic = w.Topic
+			m.Partition = int(partition)
+			m.Offset = res.BaseOffset + int64(i)
+
+			if m.Time.IsZero() {
+				m.Time = res.LogAppendTime
+			}
+		}
+	}
+
+	if w.Completion != nil {
+		w.Completion(batch.msgs, err)
+	}
+
+	batch.complete(err)
+}
+
+func (w *Writer) produce(partition int32, batch *writeBatch) (*ProduceResponse, error) {
+	timeout := w.writeTimeout()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return w.client(timeout).Produce(ctx, &ProduceRequest{
+		Partition:    int(partition),
+		Topic:        w.Topic,
+		RequiredAcks: w.RequiredAcks,
+		Compression:  w.Compression,
+		Records: &writerRecords{
+			msgs: batch.msgs,
+		},
+	})
+}
+
+func (w *Writer) partitions(ctx context.Context) (int, error) {
+	client := w.client(w.readTimeout())
+	// Here we use the transport directly as an optimization to avoid the
+	// construction of temporary request and response objects made by the
+	// (*Client).Metadata API.
+	r, err := client.transport().RoundTrip(ctx, client.Addr, &metadataAPI.Request{
+		TopicNames: []string{w.Topic},
+	})
+	if err != nil {
+		return 0, err
+	}
+	for _, t := range r.(*metadataAPI.Response).Topics {
+		if t.Name == w.Topic {
+			// This should always hit, unless kafka has a bug.
+			if t.ErrorCode != 0 {
+				return 0, Error(t.ErrorCode)
+			}
+			return len(t.Partitions), nil
+		}
+	}
+	return 0, UnknownTopicOrPartition
+}
+
+func (w *Writer) markClosed() {
+	atomic.StoreUint32(&w.closed, 1)
+}
+
+func (w *Writer) isClosed() bool {
+	return atomic.LoadUint32(&w.closed) != 0
+}
+
+func (w *Writer) client(timeout time.Duration) *Client {
+	return &Client{
+		Addr:      w.Addr,
+		Transport: w.Transport,
+		Timeout:   timeout,
+	}
+}
+
+func (w *Writer) balancer() Balancer {
+	if w.Balancer != nil {
+		return w.Balancer
+	}
+	return &w.roundRobin
+}
+
+func (w *Writer) maxAttempts() int {
+	if w.MaxAttempts > 0 {
+		return w.MaxAttempts
+	}
+	// TODO: this is a very high default, if something has failed 9 times it
+	// seems unlikely it will succeed on the 10th attempt. However, it does
+	// carry the risk to greatly increase the volume of requests sent to the
+	// kafka cluster. We should consider reducing this default (3?).
+	return 10
+}
+
+func (w *Writer) batchSize() int {
+	if w.BatchSize > 0 {
+		return w.BatchSize
+	}
+	return 100
+}
+
+func (w *Writer) batchBytes() int64 {
+	if w.BatchBytes > 0 {
+		return w.BatchBytes
+	}
+	return 1048576
+}
+
+func (w *Writer) batchTimeout() time.Duration {
+	if w.BatchTimeout > 0 {
+		return w.BatchTimeout
+	}
+	return 1 * time.Second
+}
+
+func (w *Writer) readTimeout() time.Duration {
+	if w.ReadTimeout > 0 {
+		return w.ReadTimeout
+	}
+	return 10 * time.Second
+}
+
+func (w *Writer) writeTimeout() time.Duration {
+	if w.WriteTimeout > 0 {
+		return w.WriteTimeout
+	}
+	return 10 * time.Second
+}
+
+func (w *Writer) withLogger(do func(Logger)) {
+	if w.Logger != nil {
+		do(w.Logger)
+	}
+}
+
+func (w *Writer) withErrorLogger(do func(Logger)) {
+	if w.ErrorLogger != nil {
+		do(w.ErrorLogger)
+	} else {
+		w.withLogger(do)
+	}
+}
+
+func (w *Writer) stats() *writerStats {
+	w.once.Do(func() {
+		// This field is not nil when the writer was constructed with NewWriter
+		// to share the value with the dial function and count dials.
+		if w.writerStats == nil {
+			w.writerStats = new(writerStats)
+		}
+	})
+	return w.writerStats
 }
 
 // Stats returns a snapshot of the writer stats since the last time the method
@@ -363,449 +935,137 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 // call Stats on a kafka writer and report the metrics to a stats collection
 // system.
 func (w *Writer) Stats() WriterStats {
+	stats := w.stats()
 	return WriterStats{
-		Dials:             w.stats.dials.snapshot(),
-		Writes:            w.stats.writes.snapshot(),
-		Messages:          w.stats.messages.snapshot(),
-		Bytes:             w.stats.bytes.snapshot(),
-		Rebalances:        w.stats.rebalances.snapshot(),
-		Errors:            w.stats.errors.snapshot(),
-		DialTime:          w.stats.dialTime.snapshotDuration(),
-		WriteTime:         w.stats.writeTime.snapshotDuration(),
-		WaitTime:          w.stats.waitTime.snapshotDuration(),
-		Retries:           w.stats.retries.snapshot(),
-		BatchSize:         w.stats.batchSize.snapshot(),
-		BatchBytes:        w.stats.batchSizeBytes.snapshot(),
-		MaxAttempts:       int64(w.config.MaxAttempts),
-		MaxBatchSize:      int64(w.config.BatchSize),
-		BatchTimeout:      w.config.BatchTimeout,
-		ReadTimeout:       w.config.ReadTimeout,
-		WriteTimeout:      w.config.WriteTimeout,
-		RebalanceInterval: w.config.RebalanceInterval,
-		RequiredAcks:      int64(w.config.RequiredAcks),
-		Async:             w.config.Async,
-		QueueLength:       int64(len(w.msgs)),
-		QueueCapacity:     int64(cap(w.msgs)),
-		ClientID:          w.config.Dialer.ClientID,
-		Topic:             w.config.Topic,
+		Dials:        stats.dials.snapshot(),
+		Writes:       stats.writes.snapshot(),
+		Messages:     stats.messages.snapshot(),
+		Bytes:        stats.bytes.snapshot(),
+		Errors:       stats.errors.snapshot(),
+		DialTime:     stats.dialTime.snapshotDuration(),
+		BatchTime:    stats.batchTime.snapshotDuration(),
+		WriteTime:    stats.writeTime.snapshotDuration(),
+		WaitTime:     stats.waitTime.snapshotDuration(),
+		Retries:      stats.retries.snapshot(),
+		BatchSize:    stats.batchSize.snapshot(),
+		BatchBytes:   stats.batchSizeBytes.snapshot(),
+		MaxAttempts:  int64(w.MaxAttempts),
+		MaxBatchSize: int64(w.BatchSize),
+		BatchTimeout: w.BatchTimeout,
+		ReadTimeout:  w.ReadTimeout,
+		WriteTimeout: w.WriteTimeout,
+		RequiredAcks: int64(w.RequiredAcks),
+		Async:        w.Async,
+		Topic:        w.Topic,
 	}
 }
 
-// Close flushes all buffered messages and closes the writer. The call to Close
-// aborts any concurrent calls to WriteMessages, which then return with the
-// io.ErrClosedPipe error.
-func (w *Writer) Close() (err error) {
-	w.mutex.Lock()
-
-	if !w.closed {
-		w.closed = true
-		close(w.msgs)
-		close(w.done)
-	}
-
-	w.mutex.Unlock()
-	w.join.Wait()
-	return
+type writeBatch struct {
+	time  time.Time
+	msgs  []Message
+	size  int
+	bytes int64
+	ready chan struct{}
+	done  chan struct{}
+	timer *time.Timer
+	err   error // result of the batch completion
 }
 
-func (w *Writer) run() {
-	defer w.join.Done()
-
-	ticker := time.NewTicker(w.config.RebalanceInterval)
-	defer ticker.Stop()
-
-	var rebalance = true
-	var writers = make(map[int]partitionWriter)
-	var partitions []int
-	var err error
-
-	for {
-		if rebalance {
-			w.stats.rebalances.observe(1)
-			rebalance = false
-
-			var newPartitions []int
-			var oldPartitions = partitions
-
-			if newPartitions, err = w.partitions(); err == nil {
-				for _, partition := range diffp(oldPartitions, newPartitions) {
-					w.close(writers[partition])
-					delete(writers, partition)
-				}
-
-				for _, partition := range diffp(newPartitions, oldPartitions) {
-					writers[partition] = w.open(partition)
-				}
-
-				partitions = newPartitions
-			}
-		}
-
-		select {
-		case wm, ok := <-w.msgs:
-			if !ok {
-				for _, writer := range writers {
-					w.close(writer)
-				}
-				return
-			}
-
-			if len(partitions) != 0 {
-				selectedPartition := w.config.Balancer.Balance(wm.msg, partitions...)
-				writers[selectedPartition].messages() <- wm
-			} else {
-				// No partitions were found because the topic doesn't exist.
-				if err == nil {
-					err = fmt.Errorf("failed to find any partitions for topic %s", w.config.Topic)
-				}
-				if wm.res != nil {
-					wm.res <- &writerError{msg: wm.msg, err: err}
-				}
-			}
-
-		case <-ticker.C:
-			rebalance = true
-		}
+func newWriteBatch(now time.Time, timeout time.Duration) *writeBatch {
+	return &writeBatch{
+		time:  now,
+		ready: make(chan struct{}),
+		done:  make(chan struct{}),
+		timer: time.NewTimer(timeout),
 	}
 }
 
-func (w *Writer) partitions() (partitions []int, err error) {
-	for _, broker := range shuffledStrings(w.config.Brokers) {
-		var conn *Conn
-		var plist []Partition
+func (b *writeBatch) add(msg Message, maxSize int, maxBytes int64) bool {
+	bytes := int64(msg.size())
 
-		if conn, err = w.config.Dialer.Dial("tcp", broker); err != nil {
-			continue
-		}
-
-		conn.SetReadDeadline(time.Now().Add(w.config.ReadTimeout))
-		plist, err = conn.ReadPartitions(w.config.Topic)
-		conn.Close()
-
-		if err == nil {
-			partitions = make([]int, len(plist))
-			for i, p := range plist {
-				partitions[i] = p.ID
-			}
-			break
-		}
+	if b.size > 0 && (b.bytes+bytes) > maxBytes {
+		return false
 	}
 
-	sort.Ints(partitions)
-	return
-}
-
-func (w *Writer) open(partition int) partitionWriter {
-	return w.config.newPartitionWriter(partition, w.config, w.stats)
-}
-
-func (w *Writer) close(writer partitionWriter) {
-	w.join.Add(1)
-	go func() {
-		writer.close()
-		w.join.Done()
-	}()
-}
-
-func diffp(new []int, old []int) (diff []int) {
-	for _, p := range new {
-		if i := sort.SearchInts(old, p); i == len(old) || old[i] != p {
-			diff = append(diff, p)
-		}
-	}
-	return
-}
-
-type partitionWriter interface {
-	messages() chan<- writerMessage
-	close()
-}
-
-type writer struct {
-	brokers         []string
-	topic           string
-	partition       int
-	requiredAcks    int
-	batchSize       int
-	maxMessageBytes int
-	batchTimeout    time.Duration
-	writeTimeout    time.Duration
-	idleConnTimeout time.Duration
-	dialer          *Dialer
-	msgs            chan writerMessage
-	join            sync.WaitGroup
-	stats           *writerStats
-	codec           CompressionCodec
-	logger          Logger
-	errorLogger     Logger
-	maxAttempts     int
-}
-
-func newWriter(partition int, config WriterConfig, stats *writerStats) *writer {
-	w := &writer{
-		brokers:         config.Brokers,
-		topic:           config.Topic,
-		partition:       partition,
-		requiredAcks:    config.RequiredAcks,
-		batchSize:       config.BatchSize,
-		maxMessageBytes: config.BatchBytes,
-		batchTimeout:    config.BatchTimeout,
-		writeTimeout:    config.WriteTimeout,
-		idleConnTimeout: config.IdleConnTimeout,
-		dialer:          config.Dialer,
-		msgs:            make(chan writerMessage, config.QueueCapacity),
-		stats:           stats,
-		codec:           config.CompressionCodec,
-		logger:          config.Logger,
-		errorLogger:     config.ErrorLogger,
-		maxAttempts:     config.MaxAttempts,
-	}
-	w.join.Add(1)
-	go w.run()
-	return w
-}
-
-func (w *writer) close() {
-	close(w.msgs)
-	w.join.Wait()
-}
-
-func (w *writer) messages() chan<- writerMessage {
-	return w.msgs
-}
-
-func (w *writer) withLogger(do func(Logger)) {
-	if w.logger != nil {
-		do(w.logger)
-	}
-}
-
-func (w *writer) withErrorLogger(do func(Logger)) {
-	if w.errorLogger != nil {
-		do(w.errorLogger)
-	} else {
-		w.withLogger(do)
-	}
-}
-
-func (w *writer) run() {
-	defer w.join.Done()
-
-	batchTimer := time.NewTimer(0)
-	<-batchTimer.C
-	batchTimerRunning := false
-	defer batchTimer.Stop()
-
-	var conn *Conn
-	var done bool
-	var batch = make([]Message, 0, w.batchSize)
-	var resch = make([](chan<- error), 0, w.batchSize)
-	var lastMsg writerMessage
-	var batchSizeBytes int
-	var idleConnDeadline time.Time
-
-	defer func() {
-		if conn != nil {
-			conn.Close()
-		}
-	}()
-
-	for !done {
-		var mustFlush bool
-		// lstMsg gets set when the next message would put the maxMessageBytes  over the limit.
-		// If a lstMsg exists we need to add it to the batch so we don't lose it.
-		if len(lastMsg.msg.Value) != 0 {
-			batch = append(batch, lastMsg.msg)
-			if lastMsg.res != nil {
-				resch = append(resch, lastMsg.res)
-			}
-			batchSizeBytes += int(lastMsg.msg.size())
-			lastMsg = writerMessage{}
-			if !batchTimerRunning {
-				batchTimer.Reset(w.batchTimeout)
-				batchTimerRunning = true
-			}
-		}
-		select {
-		case wm, ok := <-w.msgs:
-			if !ok {
-				done, mustFlush = true, true
-			} else {
-				if int(wm.msg.size())+batchSizeBytes > w.maxMessageBytes {
-					// If the size of the current message puts us over the maxMessageBytes limit,
-					// store the message but don't send it in this batch.
-					mustFlush = true
-					lastMsg = wm
-					break
-				}
-				batch = append(batch, wm.msg)
-				if wm.res != nil {
-					resch = append(resch, wm.res)
-				}
-				batchSizeBytes += int(wm.msg.size())
-				mustFlush = len(batch) >= w.batchSize || batchSizeBytes >= w.maxMessageBytes
-			}
-			if !batchTimerRunning {
-				batchTimer.Reset(w.batchTimeout)
-				batchTimerRunning = true
-			}
-
-		case <-batchTimer.C:
-			mustFlush = true
-			batchTimerRunning = false
-		}
-
-		if mustFlush {
-			w.stats.batchSizeBytes.observe(int64(batchSizeBytes))
-			if batchTimerRunning {
-				if stopped := batchTimer.Stop(); !stopped {
-					<-batchTimer.C
-				}
-				batchTimerRunning = false
-			}
-			if conn != nil && time.Now().After(idleConnDeadline) {
-				conn.Close()
-				conn = nil
-			}
-			if len(batch) == 0 {
-				continue
-			}
-
-			var err error
-			if conn, err = w.writeWithRetries(conn, batch, resch); err != nil {
-				if conn != nil {
-					conn.Close()
-					conn = nil
-				}
-			}
-
-			idleConnDeadline = time.Now().Add(w.idleConnTimeout)
-			for i := range batch {
-				batch[i] = Message{}
-			}
-
-			for i := range resch {
-				resch[i] = nil
-			}
-			batch = batch[:0]
-			resch = resch[:0]
-			batchSizeBytes = 0
-		}
-	}
-}
-
-func (w *writer) dial() (conn *Conn, err error) {
-	for _, broker := range shuffledStrings(w.brokers) {
-		t0 := time.Now()
-		if conn, err = w.dialer.DialLeader(context.Background(), "tcp", broker, w.topic, w.partition); err == nil {
-			t1 := time.Now()
-			w.stats.dials.observe(1)
-			w.stats.dialTime.observeDuration(t1.Sub(t0))
-			conn.SetRequiredAcks(w.requiredAcks)
-			break
-		}
-	}
-	return
-}
-
-func (w *writer) writeWithRetries(conn *Conn, batch []Message, resch [](chan<- error)) (*Conn, error) {
-	var err error
-
-	for attempt := 0; attempt < w.maxAttempts; attempt++ {
-		conn, err = w.write(conn, batch, resch)
-		if err == nil {
-			break
-		}
-		w.stats.retries.observe(1)
-		time.Sleep(backoff(attempt+1, 100*time.Millisecond, 1*time.Second))
-	}
-	return conn, err
-}
-
-func (w *writer) write(conn *Conn, batch []Message, resch [](chan<- error)) (ret *Conn, err error) {
-	w.stats.writes.observe(1)
-	if conn == nil {
-		if conn, err = w.dial(); err != nil {
-			w.stats.errors.observe(1)
-			w.withErrorLogger(func(logger Logger) {
-				logger.Printf("error dialing kafka brokers for topic %s (partition %d): %s", w.topic, w.partition, err)
-			})
-			for i, res := range resch {
-				res <- &writerError{msg: batch[i], err: err}
-			}
-			return
-		}
+	if cap(b.msgs) == 0 {
+		b.msgs = make([]Message, 0, maxSize)
 	}
 
-	t0 := time.Now()
-	conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
-	if _, err = conn.WriteCompressedMessages(w.codec, batch...); err != nil {
-		w.stats.errors.observe(1)
-		w.withErrorLogger(func(logger Logger) {
-			logger.Printf("error writing messages to %s (partition %d): %s", w.topic, w.partition, err)
-		})
-		for i, res := range resch {
-			res <- &writerError{msg: batch[i], err: err}
+	b.msgs = append(b.msgs, msg)
+	b.size++
+	b.bytes += bytes
+	return true
+}
+
+func (b *writeBatch) full(maxSize int, maxBytes int64) bool {
+	return b.size >= maxSize || b.bytes >= maxBytes
+}
+
+func (b *writeBatch) trigger() {
+	close(b.ready)
+}
+
+func (b *writeBatch) complete(err error) {
+	b.err = err
+	close(b.done)
+}
+
+type writerRecords struct {
+	msgs   []Message
+	index  int
+	record Record
+	key    bytesReadCloser
+	value  bytesReadCloser
+}
+
+func (r *writerRecords) ReadRecord() (*Record, error) {
+	if r.index >= 0 && r.index < len(r.msgs) {
+		m := &r.msgs[r.index]
+		r.index++
+		r.record = Record{
+			Time:    m.Time,
+			Headers: m.Headers,
 		}
-	} else {
-		for _, m := range batch {
-			w.stats.messages.observe(1)
-			w.stats.bytes.observe(int64(len(m.Key) + len(m.Value)))
+		if m.Key != nil {
+			r.key.Reset(m.Key)
+			r.record.Key = &r.key
 		}
-		for _, res := range resch {
-			res <- nil
+		if m.Value != nil {
+			r.value.Reset(m.Value)
+			r.record.Value = &r.value
 		}
+		return &r.record, nil
 	}
-	t1 := time.Now()
-	w.stats.waitTime.observeDuration(t1.Sub(t0))
-	w.stats.batchSize.observe(int64(len(batch)))
-
-	ret = conn
-	return
+	return nil, io.EOF
 }
 
-type writerMessage struct {
-	msg Message
-	res chan<- error
-}
+type bytesReadCloser struct{ bytes.Reader }
 
-type writerError struct {
-	msg Message
-	err error
-}
+func (*bytesReadCloser) Close() error { return nil }
 
-func (e *writerError) Cause() error {
-	return e.err
-}
+// A cache of []int values passed to balancers of writers, used to amortize the
+// heap allocation of the partition index lists.
+//
+// With hindsight, the use of `...int` to pass the partition list to Balancers
+// was not the best design choice: kafka partition numbers are monotonically
+// increasing, we could have simply passed the number of partitions instead.
+// If we ever revisit this API, we can hopefully remove this cache.
+var partitionsCache atomic.Value
 
-func (e *writerError) Error() string {
-	return e.err.Error()
-}
-
-func (e *writerError) Temporary() bool {
-	return isTemporary(e.err)
-}
-
-func (e *writerError) Timeout() bool {
-	return isTimeout(e.err)
-}
-
-func shuffledStrings(list []string) []string {
-	shuffledList := make([]string, len(list))
-	copy(shuffledList, list)
-
-	shufflerMutex.Lock()
-
-	for i := range shuffledList {
-		j := shuffler.Intn(i + 1)
-		shuffledList[i], shuffledList[j] = shuffledList[j], shuffledList[i]
+func loadCachedPartitions(numPartitions int) []int {
+	partitions, ok := partitionsCache.Load().([]int)
+	if ok && len(partitions) >= numPartitions {
+		return partitions[:numPartitions]
 	}
 
-	shufflerMutex.Unlock()
-	return shuffledList
-}
+	const alignment = 128
+	n := ((numPartitions / alignment) + 1) * alignment
 
-var (
-	shufflerMutex = sync.Mutex{}
-	shuffler      = rand.New(rand.NewSource(time.Now().Unix()))
-)
+	partitions = make([]int, n)
+	for i := range partitions {
+		partitions[i] = i
+	}
+
+	partitionsCache.Store(partitions)
+	return partitions[:numPartitions]
+}

--- a/writer.go
+++ b/writer.go
@@ -396,6 +396,10 @@ func NewWriter(config WriterConfig) *Writer {
 		config.Dialer = DefaultDialer
 	}
 
+	if config.Balancer == nil {
+		config.Balancer = &RoundRobin{}
+	}
+
 	// Converts the pre-0.4 Dialer API into a Transport.
 	kafkaDialer := DefaultDialer
 	if config.Dialer != nil {
@@ -472,6 +476,7 @@ func NewWriter(config WriterConfig) *Writer {
 		Topic:        config.Topic,
 		MaxAttempts:  config.MaxAttempts,
 		BatchSize:    config.BatchSize,
+		Balancer:     config.Balancer,
 		BatchBytes:   int64(config.BatchBytes),
 		BatchTimeout: config.BatchTimeout,
 		ReadTimeout:  config.ReadTimeout,

--- a/writer_test.go
+++ b/writer_test.go
@@ -47,6 +47,10 @@ func TestWriter(t *testing.T) {
 			scenario: "writing messsages with a small batch byte size",
 			function: testWriterSmallBatchBytes,
 		},
+		{
+			scenario: "setting a non default balancer on the writer",
+			function: testWriterSetsRightBalancer,
+		},
 	}
 
 	for _, test := range tests {
@@ -76,6 +80,20 @@ func testWriterClose(t *testing.T) {
 
 	if err := w.Close(); err != nil {
 		t.Error(err)
+	}
+}
+
+func testWriterSetsRightBalancer(t *testing.T) {
+	const topic = "test-writer-1"
+	balancer := &CRC32Balancer{}
+	w := newTestWriter(WriterConfig{
+		Topic:    topic,
+		Balancer: balancer,
+	})
+	defer w.Close()
+
+	if w.Balancer != balancer {
+		t.Errorf("Balancer not set correctly")
 	}
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -2,10 +2,8 @@ package kafka
 
 import (
 	"context"
-	"errors"
 	"io"
 	"math"
-	"strings"
 	"testing"
 	"time"
 )
@@ -27,10 +25,12 @@ func TestWriter(t *testing.T) {
 			function: testWriterRoundRobin1,
 		},
 
-		{
-			scenario: "running out of max attempts should return an error",
-			function: testWriterMaxAttemptsErr,
-		},
+		/*
+			{
+				scenario: "running out of max attempts should return an error",
+				function: testWriterMaxAttemptsErr,
+			},
+		*/
 
 		{
 			scenario: "writing a message larger then the max bytes should return an error",
@@ -144,6 +144,7 @@ func TestValidateWriter(t *testing.T) {
 	}
 }
 
+/*
 type fakeWriter struct{}
 
 func (f *fakeWriter) messages() chan<- writerMessage {
@@ -191,6 +192,7 @@ func testWriterMaxAttemptsErr(t *testing.T) {
 		}
 	}
 }
+*/
 
 func testWriterMaxBytes(t *testing.T) {
 	topic := makeTopic()

--- a/writer_test.go
+++ b/writer_test.go
@@ -23,12 +23,10 @@ func TestWriter(t *testing.T) {
 			function: testWriterRoundRobin1,
 		},
 
-		/*
-			{
-				scenario: "running out of max attempts should return an error",
-				function: testWriterMaxAttemptsErr,
-			},
-		*/
+		{
+			scenario: "running out of max attempts should return an error",
+			function: testWriterMaxAttemptsErr,
+		},
 
 		{
 			scenario: "writing a message larger then the max bytes should return an error",
@@ -144,40 +142,16 @@ func TestValidateWriter(t *testing.T) {
 	}
 }
 
-/*
-type fakeWriter struct{}
-
-func (f *fakeWriter) messages() chan<- writerMessage {
-	ch := make(chan writerMessage, 1)
-
-	go func() {
-		for {
-			msg := <-ch
-			msg.res <- &writerError{
-				err: errors.New("bad attempt"),
-			}
-		}
-	}()
-
-	return ch
-}
-
-func (f *fakeWriter) close() {
-
-}
-
 func testWriterMaxAttemptsErr(t *testing.T) {
-	const topic = "test-writer-2"
+	topic := makeTopic()
 	createTopic(t, topic, 1)
 	defer deleteTopic(t, topic)
 
 	w := newTestWriter(WriterConfig{
+		Brokers:     []string{"localhost:9999"}, // nothing is listening here
 		Topic:       topic,
-		MaxAttempts: 1,
+		MaxAttempts: 3,
 		Balancer:    &RoundRobin{},
-		newPartitionWriter: func(p int, config WriterConfig, stats *writerStats) partitionWriter {
-			return &fakeWriter{}
-		},
 	})
 	defer w.Close()
 
@@ -186,14 +160,8 @@ func testWriterMaxAttemptsErr(t *testing.T) {
 	}); err == nil {
 		t.Error("expected error")
 		return
-	} else if err != nil {
-		if !strings.Contains(err.Error(), "bad attempt") {
-			t.Errorf("unexpected error: %s", err)
-			return
-		}
 	}
 }
-*/
 
 func testWriterMaxBytes(t *testing.T) {
 	topic := makeTopic()

--- a/writer_test.go
+++ b/writer_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestWriter(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		scenario string
 		function func(*testing.T)
@@ -56,7 +54,6 @@ func TestWriter(t *testing.T) {
 	for _, test := range tests {
 		testFunc := test.function
 		t.Run(test.scenario, func(t *testing.T) {
-			t.Parallel()
 			testFunc(t)
 		})
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -54,6 +54,7 @@ func TestWriter(t *testing.T) {
 	for _, test := range tests {
 		testFunc := test.function
 		t.Run(test.scenario, func(t *testing.T) {
+			t.Parallel()
 			testFunc(t)
 		})
 	}
@@ -68,8 +69,9 @@ func newTestWriter(config WriterConfig) *Writer {
 
 func testWriterClose(t *testing.T) {
 	const topic = "test-writer-0"
-
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
 	w := newTestWriter(WriterConfig{
 		Topic: topic,
 	})
@@ -81,8 +83,9 @@ func testWriterClose(t *testing.T) {
 
 func testWriterRoundRobin1(t *testing.T) {
 	const topic = "test-writer-1"
-
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
 	offset, err := readOffset(topic, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -165,8 +168,9 @@ func (f *fakeWriter) close() {
 
 func testWriterMaxAttemptsErr(t *testing.T) {
 	const topic = "test-writer-2"
-
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
 	w := newTestWriter(WriterConfig{
 		Topic:       topic,
 		MaxAttempts: 1,
@@ -193,8 +197,9 @@ func testWriterMaxAttemptsErr(t *testing.T) {
 
 func testWriterMaxBytes(t *testing.T) {
 	topic := makeTopic()
-
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
 	w := newTestWriter(WriterConfig{
 		Topic:      topic,
 		BatchBytes: 25,
@@ -285,9 +290,11 @@ func readPartition(topic string, partition int, offset int64) (msgs []Message, e
 func testWriterBatchBytes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	const topic = "test-writer-1-bytes"
 
+	const topic = "test-writer-1-bytes"
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
 	offset, err := readOffset(topic, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -339,6 +346,8 @@ func testWriterBatchSize(t *testing.T) {
 
 	topic := makeTopic()
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
 	offset, err := readOffset(topic, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -390,6 +399,8 @@ func testWriterSmallBatchBytes(t *testing.T) {
 
 	topic := makeTopic()
 	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
 	offset, err := readOffset(topic, 0)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR modifies the implementation of the `kafka.Writer` type to adopt the 0.4 APIs and leverage connection pooling of `kafka.Transport` in the writers.

I am also introducing a couple new APIs to address known flaws of the existing API:
* Enhanced errors returned by `WriteMessages` so programs can distinguish which messages have succeeded and failed.
* An asynchronous completion API to support reporting the status of writes when the writers are configured with `Async: true`.

A major change in the implementation is the removal of all queuing, and with it the need for blocking and synchronizing error reporting. Batches are now aggregated in a shared state instead of using message passing to aggregate batches in each partition writer.

I've also done documentation work, which hopefully is going to help address some of the open issues as well.

Here are a couple of issues that this PR will likely address:
https://github.com/segmentio/kafka-go/issues/53
https://github.com/segmentio/kafka-go/issues/131
https://github.com/segmentio/kafka-go/issues/298
https://github.com/segmentio/kafka-go/issues/342
https://github.com/segmentio/kafka-go/issues/350
https://github.com/segmentio/kafka-go/issues/356
https://github.com/segmentio/kafka-go/issues/364
https://github.com/segmentio/kafka-go/issues/391
https://github.com/segmentio/kafka-go/issues/419
https://github.com/segmentio/kafka-go/issues/445
https://github.com/segmentio/kafka-go/issues/451
https://github.com/segmentio/kafka-go/issues/459
https://github.com/segmentio/kafka-go/pull/176
https://github.com/segmentio/kafka-go/pull/420
https://github.com/segmentio/kafka-go/pull/452