### PR TITLE
Add DescribeConfigs, AlterConfigs & CreatePartition implementation

### DIFF
--- a/alterconfigs.go
+++ b/alterconfigs.go
@@ -1,0 +1,202 @@
+package kafka
+
+import (
+	"bufio"
+	"time"
+)
+
+// See https://kafka.apache.org/protocol#The_Messages_AlterConfigs
+type alterConfigsRequestV0 struct {
+	Resources    []alterConfigsRequestV0Resource
+	ValidateOnly bool
+}
+
+func (t alterConfigsRequestV0) size() int32 {
+	return sizeofArray(len(t.Resources), func(i int) int32 { return t.Resources[i].size() }) +
+		sizeofBool(t.ValidateOnly)
+}
+
+func (t alterConfigsRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.Resources), func(i int) { t.Resources[i].writeTo(wb) })
+	wb.writeBool(t.ValidateOnly)
+}
+
+type alterConfigsRequestV0Resource struct {
+	ResourceType  int8
+	ResourceName  string
+	ConfigEntries []alterConfigsResponseV0ConfigEntry
+}
+
+func (t alterConfigsRequestV0Resource) size() int32 {
+	return sizeofInt8(t.ResourceType) +
+		sizeofString(t.ResourceName) +
+		sizeofArray(len(t.ConfigEntries), func(i int) int32 { return t.ConfigEntries[i].size() })
+}
+
+func (t alterConfigsRequestV0Resource) writeTo(wb *writeBuffer) {
+	wb.writeInt8(t.ResourceType)
+	wb.writeString(t.ResourceName)
+	wb.writeArray(len(t.ConfigEntries), func(i int) { t.ConfigEntries[i].writeTo(wb) })
+}
+
+type alterConfigsResponseV0ConfigEntry struct {
+	ConfigName  string
+	ConfigValue string
+}
+
+func (t alterConfigsResponseV0ConfigEntry) size() int32 {
+	return sizeofString(t.ConfigName) +
+		sizeofString(t.ConfigValue)
+}
+
+func (t alterConfigsResponseV0ConfigEntry) writeTo(wb *writeBuffer) {
+	wb.writeString(t.ConfigName)
+	wb.writeString(t.ConfigValue)
+}
+
+func (t *alterConfigsResponseV0ConfigEntry) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readString(r, size, &t.ConfigName); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ConfigValue); err != nil {
+		return
+	}
+	return
+}
+
+type alterConfigsResponseV0Resource struct {
+	ErrorCode    int16
+	ErrorMessage string
+	ResourceType int8
+	ResourceName string
+}
+
+func (t alterConfigsResponseV0Resource) size() int32 {
+	return sizeofInt16(t.ErrorCode) +
+		sizeofString(t.ErrorMessage) +
+		sizeofInt8(t.ResourceType) +
+		sizeofString(t.ResourceName)
+}
+
+func (t alterConfigsResponseV0Resource) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	wb.writeString(t.ErrorMessage)
+	wb.writeInt8(t.ResourceType)
+	wb.writeString(t.ResourceName)
+}
+
+func (t *alterConfigsResponseV0Resource) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt16(r, size, &t.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ErrorMessage); err != nil {
+		return
+	}
+	if remain, err = readInt8(r, remain, &t.ResourceType); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ResourceName); err != nil {
+		return
+	}
+
+	return
+}
+
+//alterConfigsResponseV0 descirbe configs response V0 version
+type alterConfigsResponseV0 struct {
+	ThrottleTimeMs int32
+	Resources      []alterConfigsResponseV0Resource
+}
+
+func (t alterConfigsResponseV0) size() int32 {
+	return sizeofInt32(t.ThrottleTimeMs) +
+		sizeofArray(len(t.Resources), func(i int) int32 { return t.Resources[i].size() })
+}
+
+func (t alterConfigsResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.ThrottleTimeMs)
+	wb.writeArray(len(t.Resources), func(i int) { t.Resources[i].writeTo(wb) })
+}
+
+func (t *alterConfigsResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt32(r, size, &t.ThrottleTimeMs); err != nil {
+		return
+	}
+	fn := func(r *bufio.Reader, size int) (fnRemain int, fnErr error) {
+		var resource alterConfigsResponseV0Resource
+		if fnRemain, fnErr = (&resource).readFrom(r, size); err != nil {
+			return
+		}
+		t.Resources = append(t.Resources, resource)
+		return
+	}
+	if remain, err = readArrayWith(r, remain, fn); err != nil {
+		return
+	}
+
+	return
+}
+
+type Resource struct {
+	ResourceType  int8
+	ResourceName  string
+	ConfigEntries []ConfigEntry
+}
+
+//AlterConfig
+type AlterConfig struct {
+	Resources    []Resource
+	ValidateOnly bool
+}
+
+func (c *Conn) alterConfigs(request alterConfigsRequestV0) (*alterConfigsResponseV0, error) {
+	var response alterConfigsResponseV0
+	err := c.writeOperation(
+		func(deadline time.Time, id int32) error {
+			return c.writeRequest(alterConfigs, v0, id, request)
+		},
+		func(deadline time.Time, size int) error {
+			return expectZeroSize(func() (remain int, err error) {
+				return (&response).readFrom(&c.rbuf, size)
+			}())
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+//AlterConfigs alters configuration data.
+//
+//Detailed info please look at https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs
+func (c *Conn) AlterConfigs(config AlterConfig) error {
+	var requestV0Resource []alterConfigsRequestV0Resource
+	for _, t := range config.Resources {
+		configEntries := []alterConfigsResponseV0ConfigEntry{}
+		for _, ce := range t.ConfigEntries {
+			configEntries = append(configEntries, alterConfigsResponseV0ConfigEntry{
+				ConfigName:  ce.ConfigName,
+				ConfigValue: ce.ConfigValue,
+			})
+		}
+
+		requestV0Resource = append(
+			requestV0Resource,
+			alterConfigsRequestV0Resource{
+				ResourceType:  t.ResourceType,
+				ResourceName:  t.ResourceName,
+				ConfigEntries: configEntries,
+			})
+	}
+
+	_, err := c.alterConfigs(alterConfigsRequestV0{
+		Resources:    requestV0Resource,
+		ValidateOnly: config.ValidateOnly,
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/alterconfigs.go
+++ b/alterconfigs.go
@@ -149,7 +149,7 @@ type AlterConfig struct {
 	ValidateOnly bool
 }
 
-func (c *Conn) alterConfigs(request alterConfigsRequestV0) (*alterConfigsResponseV0, error) {
+func (c *Conn) alterConfigs(request alterConfigsRequestV0) (alterConfigsResponseV0, error) {
 	var response alterConfigsResponseV0
 	err := c.writeOperation(
 		func(deadline time.Time, id int32) error {
@@ -162,9 +162,9 @@ func (c *Conn) alterConfigs(request alterConfigsRequestV0) (*alterConfigsRespons
 		},
 	)
 	if err != nil {
-		return nil, err
+		return response, err
 	}
-	return &response, nil
+	return response, nil
 }
 
 //AlterConfigs alters configuration data.

--- a/alterconfigs_test.go
+++ b/alterconfigs_test.go
@@ -1,0 +1,40 @@
+package kafka
+
+import (
+	"bufio"
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestAlterConfigsResponseV0(t *testing.T) {
+	item := alterConfigsResponseV0{
+		ThrottleTimeMs: 100,
+		Resources: []alterConfigsResponseV0Resource{
+			{
+				ErrorCode:    0,
+				ResourceType: int8(2),
+				ResourceName: "testTopic",
+			},
+		},
+	}
+
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
+	item.writeTo(w)
+
+	var found alterConfigsResponseV0
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}

--- a/alterconfigs_test.go
+++ b/alterconfigs_test.go
@@ -12,7 +12,7 @@ import (
 func TestAlterConfigsResponseV0(t *testing.T) {
 	item := alterConfigsResponseV0{
 		ThrottleTimeMs: 100,
-		Resources: []alterConfigsResponseV0Resource{
+		Responses: []alterConfigsResponseV0Response{
 			{
 				ErrorCode:    0,
 				ResourceType: int8(2),
@@ -76,12 +76,12 @@ func testAlterConfigs(t *testing.T) {
 		return
 	}
 
-	err = conncontroller.AlterConfigs(AlterConfig{
+	err = conncontroller.AlterConfigs(AlterConfigsConfig{
 		Resources: []Resource{
 			{
 				ResourceType: int8(2),
 				ResourceName: topic,
-				ConfigEntries: []ConfigEntry{{
+				Configs: []ConfigEntry{{
 					ConfigName:  "max.message.bytes",
 					ConfigValue: "200000",
 				},

--- a/createpartition.go
+++ b/createpartition.go
@@ -1,0 +1,202 @@
+package kafka
+
+import (
+	"bufio"
+	"time"
+)
+
+//createPartitionsRequestV0
+//
+//see https://kafka.apache.org/protocol#The_Messages_CreatePartitions
+type createPartitionsRequestV0 struct {
+	Topics       []createPartitionsRequestV0Topic
+	TimeoutMs    int32
+	ValidateOnly bool
+}
+
+func (t createPartitionsRequestV0) size() int32 {
+	return sizeofArray(len(t.Topics), func(i int) int32 { return t.Topics[i].size() }) +
+		sizeofInt32(t.TimeoutMs) +
+		sizeofBool(t.ValidateOnly)
+}
+
+func (t createPartitionsRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.Topics), func(i int) { t.Topics[i].writeTo(wb) })
+	wb.writeInt32(t.TimeoutMs)
+	wb.writeBool(t.ValidateOnly)
+}
+
+type createPartitionsRequestV0Topic struct {
+	Name        string
+	Count       int32
+	Assignments []brokerIds
+}
+
+func (t createPartitionsRequestV0Topic) size() int32 {
+	return sizeofString(t.Name) +
+		sizeofInt32(t.Count) +
+		sizeofArray(len(t.Assignments), func(i int) int32 { return t.Assignments[i].size() })
+}
+
+func (t createPartitionsRequestV0Topic) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Name)
+	wb.writeInt32(t.Count)
+	if t.Assignments == nil {
+		wb.writeArrayLen(-1)
+	} else {
+		wb.writeArray(len(t.Assignments), func(i int) { t.Assignments[i].writeTo(wb) })
+	}
+}
+
+type brokerIds []int32
+
+func (t brokerIds) size() int32 {
+	return sizeofInt32Array([]int32(t))
+}
+
+func (t brokerIds) writeTo(wb *writeBuffer) {
+	if t == nil {
+		wb.writeArrayLen(-1)
+	} else {
+		wb.writeInt32Array([]int32(t))
+	}
+}
+
+type createPartitionsResponseV0Result struct {
+	Name         string
+	ErrorCode    int16
+	ErrorMessage string
+}
+
+func (t createPartitionsResponseV0Result) size() int32 {
+	return sizeofString(t.Name) +
+		sizeofInt16(t.ErrorCode) +
+		sizeofString(t.ErrorMessage)
+}
+
+func (t createPartitionsResponseV0Result) writeTo(wb *writeBuffer) {
+	wb.writeString(t.Name)
+	wb.writeInt16(t.ErrorCode)
+	wb.writeString(t.ErrorMessage)
+}
+
+func (t *createPartitionsResponseV0Result) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readString(r, size, &t.Name); err != nil {
+		return
+	}
+	if remain, err = readInt16(r, remain, &t.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ErrorMessage); err != nil {
+		return
+	}
+	return
+}
+
+//createPartitionsResponseV0
+type createPartitionsResponseV0 struct {
+	ThrottleTimeMs int32
+	Results        []createPartitionsResponseV0Result
+}
+
+func (t createPartitionsResponseV0) size() int32 {
+	return sizeofInt32(t.ThrottleTimeMs) +
+		sizeofArray(len(t.Results), func(i int) int32 { return t.Results[i].size() })
+}
+
+func (t createPartitionsResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.ThrottleTimeMs)
+	wb.writeArray(len(t.Results), func(i int) { t.Results[i].writeTo(wb) })
+}
+
+func (t *createPartitionsResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt32(r, size, &t.ThrottleTimeMs); err != nil {
+		return
+	}
+	fn := func(r *bufio.Reader, size int) (fnRemain int, fnErr error) {
+		var result createPartitionsResponseV0Result
+		if fnRemain, fnErr = (&result).readFrom(r, size); err != nil {
+			return
+		}
+		t.Results = append(t.Results, result)
+		return
+	}
+	if remain, err = readArrayWith(r, remain, fn); err != nil {
+		return
+	}
+
+	return
+}
+
+func (c *Conn) createPartitions(request createPartitionsRequestV0) (*createPartitionsResponseV0, error) {
+	var response createPartitionsResponseV0
+	err := c.writeOperation(
+		func(deadline time.Time, id int32) error {
+			if request.TimeoutMs == 0 {
+				now := time.Now()
+				deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
+				request.TimeoutMs = milliseconds(deadlineToTimeout(deadline, now))
+			}
+			return c.writeRequest(createPartitions, v0, id, request)
+		},
+		func(deadline time.Time, size int) error {
+			return expectZeroSize(func() (remain int, err error) {
+				return (&response).readFrom(&c.rbuf, size)
+			}())
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, tr := range response.Results {
+		if tr.ErrorCode != 0 {
+			return &response, Error(tr.ErrorCode)
+		}
+	}
+	return &response, nil
+}
+
+//Topic is a topic config for CreatePartitionsConfig
+type Topic struct {
+	Name        string
+	Count       int32
+	Assignments [][]int32
+}
+
+//CreatePartitionsConfig is a config that passing parameters to CreatePartitions Operation
+type CreatePartitionsConfig struct {
+	Topics       []Topic
+	TimeoutMs    int32
+	ValidateOnly bool
+}
+
+//CreatePartitions update topic partitions.
+//
+//Detailed info please look at https://cwiki.apache.org/confluence/display/KAFKA/KIP-195%3A+AdminClient.createPartitions
+func (c *Conn) CreatePartitions(configs CreatePartitionsConfig) error {
+	var requestV0Topic []createPartitionsRequestV0Topic
+	for _, t := range configs.Topics {
+		var assignments []brokerIds
+		for _, b := range t.Assignments {
+			assignments = append(assignments, b)
+		}
+		requestV0Topic = append(
+			requestV0Topic,
+			createPartitionsRequestV0Topic{
+				Name:        t.Name,
+				Count:       t.Count,
+				Assignments: assignments,
+			})
+	}
+
+	_, err := c.createPartitions(createPartitionsRequestV0{
+		Topics:       requestV0Topic,
+		TimeoutMs:    configs.TimeoutMs,
+		ValidateOnly: configs.ValidateOnly,
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/createpartition.go
+++ b/createpartition.go
@@ -128,7 +128,7 @@ func (t *createPartitionsResponseV0) readFrom(r *bufio.Reader, size int) (remain
 	return
 }
 
-func (c *Conn) createPartitions(request createPartitionsRequestV0) (*createPartitionsResponseV0, error) {
+func (c *Conn) createPartitions(request createPartitionsRequestV0) (createPartitionsResponseV0, error) {
 	var response createPartitionsResponseV0
 	err := c.writeOperation(
 		func(deadline time.Time, id int32) error {
@@ -146,14 +146,14 @@ func (c *Conn) createPartitions(request createPartitionsRequestV0) (*createParti
 		},
 	)
 	if err != nil {
-		return nil, err
+		return response, err
 	}
 	for _, tr := range response.Results {
 		if tr.ErrorCode != 0 {
-			return &response, Error(tr.ErrorCode)
+			return response, Error(tr.ErrorCode)
 		}
 	}
-	return &response, nil
+	return response, nil
 }
 
 //Topic is a topic config for CreatePartitionsConfig

--- a/createpartition_test.go
+++ b/createpartition_test.go
@@ -1,0 +1,39 @@
+package kafka
+
+import (
+	"bufio"
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestCreatePartitionsResponseV0(t *testing.T) {
+	item := createPartitionsResponseV0{
+		ThrottleTimeMs: 100,
+		Results: []createPartitionsResponseV0Result{
+			{
+				Name:      "test",
+				ErrorCode: 0,
+			},
+		},
+	}
+
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
+	item.writeTo(w)
+
+	var found createPartitionsResponseV0
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}

--- a/createpartition_test.go
+++ b/createpartition_test.go
@@ -3,8 +3,13 @@ package kafka
 import (
 	"bufio"
 	"bytes"
+	"fmt"
+	"net"
 	"reflect"
+	"strconv"
 	"testing"
+
+	ktesting "github.com/segmentio/kafka-go/testing"
 )
 
 func TestCreatePartitionsResponseV0(t *testing.T) {
@@ -35,5 +40,69 @@ func TestCreatePartitionsResponseV0(t *testing.T) {
 	if !reflect.DeepEqual(item, found) {
 		t.Error("expected item and found to be the same")
 		t.FailNow()
+	}
+}
+
+func TestCreatePartitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		scenario   string
+		minVersion string
+		function   func(*testing.T)
+	}{
+
+		{
+			scenario:   "create partitions",
+			minVersion: "1.0.1",
+			function:   testCreatePartitions,
+		},
+	}
+
+	for _, test := range tests {
+		if !ktesting.KafkaIsAtLeast(test.minVersion) {
+			t.Log("skipping " + test.scenario + " because broker is not at least version " + test.minVersion)
+			continue
+		}
+		testFunc := test.function
+		t.Run(test.scenario, func(t *testing.T) {
+			t.Parallel()
+			testFunc(t)
+		})
+	}
+}
+func testCreatePartitions(t *testing.T) {
+	const topic = "test-1"
+	createTopic(t, topic, 1)
+	conn, err := Dial("tcp", "localhost:9092")
+	if err != nil {
+		return
+	}
+	controller, _ := conn.Controller()
+	conncontroller, err := Dial("tcp", net.JoinHostPort(controller.Host, strconv.Itoa(controller.Port)))
+	if err != nil {
+		return
+	}
+	brokers, err := conn.Brokers()
+	if err != nil {
+		return
+	}
+	brokerIds := []int32{}
+	for _, b := range brokers {
+		brokerIds = append(brokerIds, int32(b.ID))
+	}
+
+	err = conncontroller.CreatePartitions(CreatePartitionsConfig{
+		Topics: []Topic{{
+			Name:        topic,
+			Count:       2,
+			Assignments: [][]int32{brokerIds},
+		},
+		},
+		TimeoutMs:    20,
+		ValidateOnly: false,
+	})
+	if err != nil {
+		fmt.Println(err)
 	}
 }

--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -14,7 +14,7 @@ type describeConfigsRequestV0Resource struct {
 func (t describeConfigsRequestV0Resource) size() int32 {
 	return sizeofInt8(t.ResourceType) +
 		sizeofString(t.ResourceName) +
-		sizeofStringArray([]string(t.ConfigNames))
+		sizeofStringArray(t.ConfigNames)
 }
 
 func (t describeConfigsRequestV0Resource) writeTo(wb *writeBuffer) {

--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -1,0 +1,237 @@
+package kafka
+
+import (
+	"bufio"
+	"time"
+)
+
+type describeConfigsRequestV0Resource struct {
+	ResourceType int8
+	ResourceName string
+	ConfigNames  []string
+}
+
+func (t describeConfigsRequestV0Resource) size() int32 {
+	return sizeofInt8(t.ResourceType) +
+		sizeofString(t.ResourceName) +
+		sizeofStringArray([]string(t.ConfigNames))
+}
+
+func (t describeConfigsRequestV0Resource) writeTo(wb *writeBuffer) {
+	wb.writeInt8(t.ResourceType)
+	wb.writeString(t.ResourceName)
+	if t.ConfigNames == nil {
+		wb.writeArrayLen(-1)
+	} else {
+		wb.writeStringArray([]string(t.ConfigNames))
+	}
+}
+
+// See https://kafka.apache.org/protocol#The_Messages_DescribeConfigs
+type describeConfigsRequestV0 struct {
+	Resources []describeConfigsRequestV0Resource
+}
+
+func (t describeConfigsRequestV0) size() int32 {
+	return sizeofArray(len(t.Resources), func(i int) int32 { return t.Resources[i].size() })
+}
+
+func (t describeConfigsRequestV0) writeTo(wb *writeBuffer) {
+	wb.writeArray(len(t.Resources), func(i int) { t.Resources[i].writeTo(wb) })
+}
+
+type describeConfigsResponseV0ConfigEntry struct {
+	ConfigName  string
+	ConfigValue string
+	ReadOnly    bool
+	IsDefault   bool
+	IsSensitive bool
+}
+
+func (t describeConfigsResponseV0ConfigEntry) size() int32 {
+	return sizeofString(t.ConfigName) +
+		sizeofString(t.ConfigValue) +
+		sizeofBool(t.ReadOnly) +
+		sizeofBool(t.IsDefault) +
+		sizeofBool(t.IsSensitive)
+}
+
+func (t describeConfigsResponseV0ConfigEntry) writeTo(wb *writeBuffer) {
+	wb.writeString(t.ConfigName)
+	wb.writeString(t.ConfigValue)
+	wb.writeBool(t.ReadOnly)
+	wb.writeBool(t.IsDefault)
+	wb.writeBool(t.IsSensitive)
+}
+
+func (t *describeConfigsResponseV0ConfigEntry) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readString(r, size, &t.ConfigName); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ConfigValue); err != nil {
+		return
+	}
+	if remain, err = readBool(r, remain, &t.ReadOnly); err != nil {
+		return
+	}
+	if remain, err = readBool(r, remain, &t.IsDefault); err != nil {
+		return
+	}
+	if remain, err = readBool(r, remain, &t.IsSensitive); err != nil {
+		return
+	}
+	return
+}
+
+type describeConfigsResponseV0Resource struct {
+	ErrorCode     int16
+	ErrorMessage  string
+	ResourceType  int8
+	ResourceName  string
+	ConfigEntries []describeConfigsResponseV0ConfigEntry
+}
+
+func (t describeConfigsResponseV0Resource) size() int32 {
+	return sizeofInt16(t.ErrorCode) +
+		sizeofString(t.ErrorMessage) +
+		sizeofInt8(t.ResourceType) +
+		sizeofString(t.ResourceName) +
+		sizeofArray(len(t.ConfigEntries), func(i int) int32 { return t.ConfigEntries[i].size() })
+}
+
+func (t describeConfigsResponseV0Resource) writeTo(wb *writeBuffer) {
+	wb.writeInt16(t.ErrorCode)
+	wb.writeString(t.ErrorMessage)
+	wb.writeInt8(t.ResourceType)
+	wb.writeString(t.ResourceName)
+	wb.writeArray(len(t.ConfigEntries), func(i int) { t.ConfigEntries[i].writeTo(wb) })
+}
+
+func (t *describeConfigsResponseV0Resource) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt16(r, size, &t.ErrorCode); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ErrorMessage); err != nil {
+		return
+	}
+
+	if remain, err = readInt8(r, remain, &t.ResourceType); err != nil {
+		return
+	}
+	if remain, err = readString(r, remain, &t.ResourceName); err != nil {
+		return
+	}
+	fn := func(r *bufio.Reader, size int) (fnRemain int, fnErr error) {
+		var entry describeConfigsResponseV0ConfigEntry
+		if fnRemain, fnErr = (&entry).readFrom(r, size); err != nil {
+			return
+		}
+		t.ConfigEntries = append(t.ConfigEntries, entry)
+		return
+	}
+	if remain, err = readArrayWith(r, remain, fn); err != nil {
+		return
+	}
+
+	return
+}
+
+//DescribeConfigsResponseV0 descirbe configs response V0 version
+type DescribeConfigsResponseV0 struct {
+	ThrottleTimeMs int32
+	Resources      []describeConfigsResponseV0Resource
+}
+
+func (t DescribeConfigsResponseV0) size() int32 {
+	return sizeofInt32(t.ThrottleTimeMs) +
+		sizeofArray(len(t.Resources), func(i int) int32 { return t.Resources[i].size() })
+}
+
+func (t DescribeConfigsResponseV0) writeTo(wb *writeBuffer) {
+	wb.writeInt32(t.ThrottleTimeMs)
+	wb.writeArray(len(t.Resources), func(i int) { t.Resources[i].writeTo(wb) })
+}
+
+func (t *DescribeConfigsResponseV0) readFrom(r *bufio.Reader, size int) (remain int, err error) {
+	if remain, err = readInt32(r, size, &t.ThrottleTimeMs); err != nil {
+		return
+	}
+	fn := func(r *bufio.Reader, size int) (fnRemain int, fnErr error) {
+		var resource describeConfigsResponseV0Resource
+		if fnRemain, fnErr = (&resource).readFrom(r, size); err != nil {
+			return
+		}
+		t.Resources = append(t.Resources, resource)
+		return
+	}
+	if remain, err = readArrayWith(r, remain, fn); err != nil {
+		return
+	}
+
+	return
+}
+
+//DescribeConfig
+type DescribeConfig struct {
+	//ResourceType
+	//0: Unknown
+	//1: Any
+	//2: Topic
+	//3: Group
+	//4: Cluster
+	//5: Broker (new)
+	ResourceType int8
+
+	ResourceName string
+
+	ConfigNames []string
+}
+
+func (c *Conn) describeConfigs(request describeConfigsRequestV0) (*DescribeConfigsResponseV0, error) {
+	var response DescribeConfigsResponseV0
+	err := c.writeOperation(
+		func(deadline time.Time, id int32) error {
+			return c.writeRequest(describeConfigs, v0, id, request)
+		},
+		func(deadline time.Time, size int) error {
+			return expectZeroSize(func() (remain int, err error) {
+				return (&response).readFrom(&c.rbuf, size)
+			}())
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, tr := range response.Resources {
+		if tr.ErrorCode != 0 {
+			return &response, Error(tr.ErrorCode)
+		}
+	}
+	return &response, nil
+}
+
+//DescribeConfigs gets configuration data.
+//
+//Detailed info please look at https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs
+func (c *Conn) DescribeConfigs(configs ...DescribeConfig) (*DescribeConfigsResponseV0, error) {
+	var requestV0Resource []describeConfigsRequestV0Resource
+	for _, t := range configs {
+		requestV0Resource = append(
+			requestV0Resource,
+			describeConfigsRequestV0Resource{
+				ResourceType: t.ResourceType,
+				ResourceName: t.ResourceName,
+				ConfigNames:  t.ConfigNames,
+			})
+	}
+
+	res, err := c.describeConfigs(describeConfigsRequestV0{
+		Resources: requestV0Resource,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/describeconfigs_test.go
+++ b/describeconfigs_test.go
@@ -1,0 +1,49 @@
+package kafka
+
+import (
+	"bufio"
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestDescribeConfigsResponseV0(t *testing.T) {
+	item := DescribeConfigsResponseV0{
+		ThrottleTimeMs: 100,
+		Resources: []describeConfigsResponseV0Resource{
+			{
+				ErrorCode:    0,
+				ResourceType: int8(2),
+				ResourceName: "testTopic",
+				ConfigEntries: []describeConfigsResponseV0ConfigEntry{
+					{
+						ConfigName:  "max.message.bytes",
+						ConfigValue: "100000",
+						ReadOnly:    false,
+						IsDefault:   true,
+						IsSensitive: false,
+					},
+				},
+			},
+		},
+	}
+
+	b := bytes.NewBuffer(nil)
+	w := &writeBuffer{w: b}
+	item.writeTo(w)
+
+	var found DescribeConfigsResponseV0
+	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if remain != 0 {
+		t.Errorf("expected 0 remain, got %v", remain)
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(item, found) {
+		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}

--- a/describeconfigs_test.go
+++ b/describeconfigs_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDescribeConfigsResponseV0(t *testing.T) {
-	item := DescribeConfigsResponseV0{
+	item := describeConfigsResponseV0{
 		ThrottleTimeMs: 100,
 		Resources: []describeConfigsResponseV0Resource{
 			{
@@ -32,7 +32,7 @@ func TestDescribeConfigsResponseV0(t *testing.T) {
 	w := &writeBuffer{w: b}
 	item.writeTo(w)
 
-	var found DescribeConfigsResponseV0
+	var found describeConfigsResponseV0
 	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Implemented DescribeConfigs, AlterConfigs and CreatePartition functionalities for fixing  [496](https://github.com/segmentio/kafka-go/issues/469) and  [310](https://github.com/segmentio/kafka-go/issues/310).

Kafka Improvement Proposals :
 https://cwiki.apache.org/confluence/display/KAFKA/KIP-195%3A+AdminClient.createPartitions .
 https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs.

APIs: 
[The_Messages_DescribeConfigs](https://kafka.apache.org/protocol#The_Messages_DescribeConfigs).
[The_Messages_AlterConfigs](https://kafka.apache.org/protocol#The_Messages_AlterConfigs)
[The_Messages_CreatePartitions](https://kafka.apache.org/protocol#The_Messages_CreatePartitions)