### PR TITLE
make the dial function configurable on the kafka.Dialer type

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -23,7 +23,7 @@ type Dialer struct {
 	//
 	// When DialFunc is set, LocalAddr, DualStack, FallbackDelay, and KeepAlive
 	// are ignored.
-	DialFunc func(context.Context, string, string) (net.Conn, error)
+	DialFunc func(ctx context.Context, network string, address string) (net.Conn, error)
 
 	// Timeout is the maximum amount of time a dial will wait for a connect to
 	// complete. If Deadline is also set, it may fail earlier.


### PR DESCRIPTION
This PR adds the ability to configure the function used by `kafka.Dialer` to establish network connections. This customization is useful to add monitoring on the network connections opened by the various components (Reader, Writer, etc...),  as they can all be configured to use a `kafka.Dialer`.

I chose to name it `DialFunc` because the `kafka.Dialer` type already had methods called `Dial` and `DialContext`, but I'm open to better naming suggestions.