### PR TITLE
ReadBatchWith bug fix and new MaxWaitTime option

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -121,6 +121,13 @@ type ReadBatchConfig struct {
 	// ReadUncommitted makes all records visible. With ReadCommitted only
 	// non-transactional and committed records are visible.
 	IsolationLevel IsolationLevel
+
+	// The amount of time for the broker while waiting to hit the min/max byte
+	// targets.  This setting is independent of any network-level timeouts or
+	// deadlines.
+	//
+	// For backward compatibility, the default value here will todo
+	MaxWaitTime time.Duration
 }
 
 type IsolationLevel int8
@@ -790,7 +797,20 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	id, err := c.doRequest(&c.rdeadline, func(deadline time.Time, id int32) error {
 		now := time.Now()
-		deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
+		var timeout time.Duration
+		if cfg.MaxWaitTime > 0 {
+			// explicitly-configured case: no changes are made to the deadline,
+			// and the timeout is sent exactly as specified.
+			timeout = cfg.MaxWaitTime
+		} else {
+			// default case: use the original logic to adjust the conn's
+			// deadline.T
+			deadline = adjustDeadlineForRTT(deadline, now, defaultRTT)
+			timeout = deadlineToTimeout(deadline, now)
+		}
+		// save this variable outside of the closure for later use in detecting
+		// truncated messages.
+		adjustedDeadline = deadline
 		switch fetchVersion {
 		case v10:
 			return c.wb.writeFetchRequestV10(
@@ -801,7 +821,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 				offset,
 				cfg.MinBytes,
 				cfg.MaxBytes+int(c.fetchMinSize),
-				deadlineToTimeout(deadline, now),
+				timeout,
 				int8(cfg.IsolationLevel),
 			)
 		case v5:
@@ -813,7 +833,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 				offset,
 				cfg.MinBytes,
 				cfg.MaxBytes+int(c.fetchMinSize),
-				deadlineToTimeout(deadline, now),
+				timeout,
 				int8(cfg.IsolationLevel),
 			)
 		default:
@@ -825,7 +845,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 				offset,
 				cfg.MinBytes,
 				cfg.MaxBytes+int(c.fetchMinSize),
-				deadlineToTimeout(deadline, now),
+				timeout,
 			)
 		}
 	})

--- a/conn.go
+++ b/conn.go
@@ -122,12 +122,13 @@ type ReadBatchConfig struct {
 	// non-transactional and committed records are visible.
 	IsolationLevel IsolationLevel
 
-	// The amount of time for the broker while waiting to hit the min/max byte
-	// targets.  This setting is independent of any network-level timeouts or
-	// deadlines.
+	// MaxWait is the amount of time for the broker while waiting to hit the
+	// min/max byte targets.  This setting is independent of any network-level
+	// timeouts or deadlines.
 	//
-	// For backward compatibility, the default value here will todo
-	MaxWaitTime time.Duration
+	// For backward compatibility, when this field is left zero, kafka-go will
+	// infer the max wait from the connection's read deadline.
+	MaxWait time.Duration
 }
 
 type IsolationLevel int8
@@ -798,10 +799,10 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 	id, err := c.doRequest(&c.rdeadline, func(deadline time.Time, id int32) error {
 		now := time.Now()
 		var timeout time.Duration
-		if cfg.MaxWaitTime > 0 {
+		if cfg.MaxWait > 0 {
 			// explicitly-configured case: no changes are made to the deadline,
 			// and the timeout is sent exactly as specified.
-			timeout = cfg.MaxWaitTime
+			timeout = cfg.MaxWait
 		} else {
 			// default case: use the original logic to adjust the conn's
 			// deadline.T

--- a/conn_test.go
+++ b/conn_test.go
@@ -557,9 +557,9 @@ func testConnReadBatchWithMaxWait(t *testing.T, conn *Conn) {
 	value := make([]byte, 10e3) // 10 KB
 
 	cfg := ReadBatchConfig{
-		MinBytes:    maxBytes, // use max for both so that we hit max wait time
-		MaxBytes:    maxBytes,
-		MaxWaitTime: 500 * time.Millisecond,
+		MinBytes: maxBytes, // use max for both so that we hit max wait time
+		MaxBytes: maxBytes,
+		MaxWait:  500 * time.Millisecond,
 	}
 
 	// set aa read deadline so the batch will succeed.


### PR DESCRIPTION
This fixes a bug where ReadBatchWith could incorrectly return `io.EOF`
in certain `errShortRead` scenarios.  Since `io.EOF` means the batch
was handled correctly, this could cause consumers to continue to use
a connection that is in a bad state.

This also adds a MaxWaitTime option that can be used to improve the
way that the conn deadline and the fetch request interact.  Instead
of trying to calculate a correct timeout and change the max wait
time, this allows the caller to explicitly configure both the wait
and the deadline independently of one another.