### PR TITLE
0.4: modify protocol.Bytes to expose the number of remaining bytes instead of the full size of the sequence

### DIFF
--- a/protocol/buffer.go
+++ b/protocol/buffer.go
@@ -22,10 +22,8 @@ import (
 // goroutines.
 type Bytes interface {
 	io.ReadCloser
-	// Returns the number of bytes in the sequence. The value returned is the
-	// total size of the underlying byte sequence, not the number of bytes
-	// remaining to be read.
-	Size() int64
+	// Returns the number of bytes remaining to be read from the payload.
+	Len() int
 }
 
 // NewBytes constructs a Bytes value from b.
@@ -44,13 +42,15 @@ func NewBytes(b []byte) Bytes {
 	return r
 }
 
-// ReadAll reads b in a byte slice.
+// ReadAll is similar to ioutil.ReadAll, but it takes advantage of knowing the
+// length of b to minimize the memory footprint.
+//
+// The function returns a nil slice if b is nil.
 func ReadAll(b Bytes) ([]byte, error) {
 	if b == nil {
 		return nil, nil
 	}
-	defer b.Close()
-	s := make([]byte, b.Size())
+	s := make([]byte, b.Len())
 	_, err := io.ReadFull(b, s)
 	return s, err
 }
@@ -239,7 +239,7 @@ func (pb *pageBuffer) Close() error {
 }
 
 func (pb *pageBuffer) Len() int {
-	return pb.length
+	return pb.length - pb.cursor
 }
 
 func (pb *pageBuffer) Size() int64 {
@@ -498,6 +498,8 @@ func (ref *pageRef) unref() {
 		ref.length = 0
 	}
 }
+
+func (ref *pageRef) Len() int { return int(ref.Size() - ref.cursor) }
 
 func (ref *pageRef) Size() int64 { return int64(ref.length) }
 

--- a/protocol/buffer.go
+++ b/protocol/buffer.go
@@ -579,12 +579,7 @@ func (ref *pageRef) WriteTo(w io.Writer) (wn int64, err error) {
 func (ref *pageRef) scan(off int64, f func([]byte) bool) {
 	begin := ref.offset + off
 	end := ref.offset + int64(ref.length)
-
-	for _, p := range ref.pages.slice(begin, end) {
-		if !f(p.slice(begin, end)) {
-			break
-		}
-	}
+	ref.pages.scan(begin, end, f)
 }
 
 var (

--- a/protocol/buffer.go
+++ b/protocol/buffer.go
@@ -580,11 +580,9 @@ func (ref *pageRef) scan(off int64, f func([]byte) bool) {
 	begin := ref.offset + off
 	end := ref.offset + int64(ref.length)
 
-	if begin < end {
-		for _, p := range ref.pages {
-			if !f(p.slice(begin, end)) {
-				break
-			}
+	for _, p := range ref.pages.slice(begin, end) {
+		if !f(p.slice(begin, end)) {
+			break
 		}
 	}
 }

--- a/protocol/buffer_test.go
+++ b/protocol/buffer_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -81,6 +82,27 @@ func TestPageRefWriteReadSeek(t *testing.T) {
 		}
 		if offset != 0 {
 			t.Fatalf("invalid offset after seek #%d: %d", i, offset)
+		}
+	}
+}
+
+func TestPageRefReadByte(t *testing.T) {
+	buffer := newPageBuffer()
+	defer buffer.unref()
+
+	content := bytes.Repeat([]byte("1234567890"), 10e3)
+	buffer.Write(content)
+
+	ref := buffer.ref(0, buffer.Size())
+	defer ref.unref()
+
+	for i, c := range content {
+		b, err := ref.ReadByte()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b != c {
+			t.Fatalf("byte at offset %d mismatch, expected '%c' but got '%c'", i, c, b)
 		}
 	}
 }

--- a/protocol/buffer_test.go
+++ b/protocol/buffer_test.go
@@ -1,0 +1,86 @@
+package protocol
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+func TestPageBufferWriteReadSeek(t *testing.T) {
+	buffer := newPageBuffer()
+	defer buffer.unref()
+
+	io.WriteString(buffer, "Hello World!")
+
+	if n := buffer.Size(); n != 12 {
+		t.Fatal("invalid size:", n)
+	}
+
+	for i := 0; i < 3; i++ {
+		if n := buffer.Len(); n != 12 {
+			t.Fatal("invalid length before read:", n)
+		}
+
+		b, err := ioutil.ReadAll(buffer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if n := buffer.Len(); n != 0 {
+			t.Fatal("invalid length after read:", n)
+		}
+
+		if string(b) != "Hello World!" {
+			t.Fatalf("invalid content after read #%d: %q", i, b)
+		}
+
+		offset, err := buffer.Seek(0, io.SeekStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if offset != 0 {
+			t.Fatalf("invalid offset after seek #%d: %d", i, offset)
+		}
+	}
+}
+
+func TestPageRefWriteReadSeek(t *testing.T) {
+	buffer := newPageBuffer()
+	defer buffer.unref()
+
+	io.WriteString(buffer, "Hello World!")
+
+	ref := buffer.ref(1, 11)
+	defer ref.unref()
+
+	if n := ref.Size(); n != 10 {
+		t.Fatal("invalid size:", n)
+	}
+
+	for i := 0; i < 3; i++ {
+		if n := ref.Len(); n != 10 {
+			t.Fatal("invalid length before read:", n)
+		}
+
+		b, err := ioutil.ReadAll(ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if n := ref.Len(); n != 0 {
+			t.Fatal("invalid length after read:", n)
+		}
+
+		if string(b) != "ello World" {
+			t.Fatalf("invalid content after read #%d: %q", i, b)
+		}
+
+		offset, err := ref.Seek(0, io.SeekStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if offset != 0 {
+			t.Fatalf("invalid offset after seek #%d: %d", i, offset)
+		}
+	}
+}

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -247,7 +247,7 @@ func (e *encoder) writeCompactNullBytes(b []byte) {
 }
 
 func (e *encoder) writeBytesFrom(b Bytes) error {
-	size := b.Size()
+	size := int64(b.Len())
 	e.writeInt32(int32(size))
 	n, err := io.Copy(e, b)
 	if err == nil && n != size {
@@ -261,7 +261,7 @@ func (e *encoder) writeNullBytesFrom(b Bytes) error {
 		e.writeInt32(-1)
 		return nil
 	} else {
-		size := b.Size()
+		size := int64(b.Len())
 		e.writeInt32(int32(size))
 		n, err := io.Copy(e, b)
 		if err == nil && n != size {
@@ -276,7 +276,7 @@ func (e *encoder) writeCompactNullBytesFrom(b Bytes) error {
 		e.writeVarInt(-1)
 		return nil
 	} else {
-		size := b.Size()
+		size := int64(b.Len())
 		e.writeVarInt(size)
 		n, err := io.Copy(e, b)
 		if err == nil && n != size {

--- a/protocol/prototest/prototest.go
+++ b/protocol/prototest/prototest.go
@@ -125,8 +125,8 @@ func deepEqualBytes(s1, s2 protocol.Bytes) bool {
 		return false
 	}
 
-	n1 := s1.Size()
-	n2 := s2.Size()
+	n1 := s1.Len()
+	n2 := s2.Len()
 
 	if n1 != n2 {
 		return false

--- a/protocol/prototest/reflect.go
+++ b/protocol/prototest/reflect.go
@@ -120,20 +120,23 @@ func loadRecords(r protocol.RecordReader) []memoryRecord {
 			}
 			panic(err)
 		}
-		k, err := protocol.ReadAll(rec.Key)
-		if err != nil {
-			panic(err)
-		}
-		v, err := protocol.ReadAll(rec.Value)
-		if err != nil {
-			panic(err)
-		}
 		records = append(records, memoryRecord{
 			offset:  rec.Offset,
 			time:    rec.Time,
-			key:     k,
-			value:   v,
+			key:     readAll(rec.Key),
+			value:   readAll(rec.Value),
 			headers: rec.Headers,
 		})
 	}
+}
+
+func readAll(bytes protocol.Bytes) []byte {
+	if bytes != nil {
+		defer bytes.Close()
+	}
+	b, err := protocol.ReadAll(bytes)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/protocol/record_batch.go
+++ b/protocol/record_batch.go
@@ -187,6 +187,13 @@ type ControlRecord struct {
 }
 
 func ReadControlRecord(r *Record) (*ControlRecord, error) {
+	if r.Key != nil {
+		defer r.Key.Close()
+	}
+	if r.Value != nil {
+		defer r.Value.Close()
+	}
+
 	k, err := ReadAll(r.Key)
 	if err != nil {
 		return nil, err

--- a/protocol/record_batch_test.go
+++ b/protocol/record_batch_test.go
@@ -171,19 +171,30 @@ func equalRecords(r1, r2 *Record) bool {
 		return false
 	}
 
-	k1, _ := ReadAll(r1.Key)
-	k2, _ := ReadAll(r2.Key)
+	k1 := readAll(r1.Key)
+	k2 := readAll(r2.Key)
 
 	if !reflect.DeepEqual(k1, k2) {
 		return false
 	}
 
-	v1, _ := ReadAll(r1.Value)
-	v2, _ := ReadAll(r2.Value)
+	v1 := readAll(r1.Value)
+	v2 := readAll(r2.Value)
 
 	if !reflect.DeepEqual(v1, v2) {
 		return false
 	}
 
 	return reflect.DeepEqual(r1.Headers, r2.Headers)
+}
+
+func readAll(bytes Bytes) []byte {
+	if bytes != nil {
+		defer bytes.Close()
+	}
+	b, err := ReadAll(bytes)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/protocol/size.go
+++ b/protocol/size.go
@@ -67,7 +67,7 @@ func sizeOfVarBytes(b Bytes) int {
 	if b == nil {
 		return sizeOfVarInt(-1)
 	} else {
-		n := b.Size()
-		return sizeOfVarInt(n) + int(n)
+		n := b.Len()
+		return sizeOfVarInt(int64(n)) + n
 	}
 }


### PR DESCRIPTION
This PR is making an API change to the `kafka/protocol` package, modifying the `protocol.Bytes` interface to expose the number of bytes remaining to read instead of the full size of the original byte sequence.

Using `Len` instead of `Size` is more relevant, especially in cases where a program would read a header off of the byte sequence, then hand off processing of the remaining bytes to a different part of the program. On the second stage, the original size becomes irrelevant, forcing the application to provide its own counting.