### PR TITLE
add docs on how to list topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ if err := conn.Close(); err != nil {
 }
 ```
 
-### create topics
+### To Create Topics
 ```go
 // to create topics
 topic := "my-topic"
@@ -125,7 +125,7 @@ if err != nil {
 }
 ```
 
-### Connect to leader via non-leader connection
+### To Connect To Leader Via a Non-leader Connection
 ```go
 // to connect to the kafka leader via an existing non-leader connection rather than using DialLeader
 conn, err := kafka.Dial("tcp", "localhost:9092")

--- a/README.md
+++ b/README.md
@@ -147,29 +147,24 @@ defer connLeader.Close()
 
 ### To list topics
 ```go
-// to list topics
 conn, err := kafka.Dial("tcp", "localhost:9092")
 if err != nil {
     panic(err.Error())
 }
 defer conn.Close()
-controller, err := conn.Controller()
-if err != nil {
-    panic(err.Error())
-}
-var connLeader *kafka.Conn
-connLeader, err = kafka.Dial("tcp", net.JoinHostPort(controller.Host, strconv.Itoa(controller.Port)))
+
+partitions, err := conn.ReadPartitions()
 if err != nil {
     panic(err.Error())
 }
 
-partitions, err := connLeader.ReadPartitions()
-if err != nil {
-    panic(err.Error())
-}
+m := map[string]struct{}{}
 
 for _, p := range partitions {
-    fmt.Println(p.Topic)
+    m[p.Topic] = struct{}{}
+}
+for k := range m {
+    fmt.Println(k)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ if err := conn.Close(); err != nil {
 }
 ```
 
+### create topics
 ```go
 // to create topics
 topic := "my-topic"
@@ -124,6 +125,7 @@ if err != nil {
 }
 ```
 
+### Connect to leader via non-leader connection
 ```go
 // to connect to the kafka leader via an existing non-leader connection rather than using DialLeader
 conn, err := kafka.Dial("tcp", "localhost:9092")
@@ -141,6 +143,34 @@ if err != nil {
     panic(err.Error())
 }
 defer connLeader.Close()
+```
+
+### To list topics
+```go
+// to list topics
+conn, err := kafka.Dial("tcp", "localhost:9092")
+if err != nil {
+    panic(err.Error())
+}
+defer conn.Close()
+controller, err := conn.Controller()
+if err != nil {
+    panic(err.Error())
+}
+var connLeader *kafka.Conn
+connLeader, err = kafka.Dial("tcp", net.JoinHostPort(controller.Host, strconv.Itoa(controller.Port)))
+if err != nil {
+    panic(err.Error())
+}
+
+partitions, err := connLeader.ReadPartitions()
+if err != nil {
+    panic(err.Error())
+}
+
+for _, p := range partitions {
+    fmt.Println(p.Topic)
+}
 ```
 
 


### PR DESCRIPTION
This pull request adds documentation on how to get a list of all topics in kafka.

This documentation addresses how to list topics in the current version of kafka-go without adding new functionality.
This removes the need for this PR: https://github.com/segmentio/kafka-go/pull/520