### PR TITLE
Add PartitionBalancer to sepcific a single partition in single topic

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -283,3 +283,16 @@ func murmur2(data []byte) uint32 {
 
 	return h
 }
+
+
+// PartitionBalancer is a Balancer that always write Message to a specific partition
+//
+// Note that if you specific a none exist partition, write func will return an error,
+// and the logger of the Writer instance will write down this error.
+type PartitionBalancer struct {
+	p int
+}
+
+func (p *PartitionBalancer) Balance(_ Message, _ ...int) (partition int) {
+	return p.p
+}

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -354,7 +354,7 @@ func TestLeastBytes(t *testing.T) {
 }
 
 func TestPartitionBalancer(t *testing.T) {
-	soecificPartition:=2
+	specificPartition:=2
 
 	testCases := map[string]struct {
 		Keys       [][]byte
@@ -368,7 +368,7 @@ func TestPartitionBalancer(t *testing.T) {
 			Partitions: [][]int{
 				{0, 1, 2},
 			},
-			Partition: soecificPartition,
+			Partition: specificPartition,
 		},
 		"multiple messages": {
 			Keys: [][]byte{
@@ -383,7 +383,7 @@ func TestPartitionBalancer(t *testing.T) {
 				{0, 1, 2},
 				{0, 1, 2},
 			},
-			Partition: soecificPartition,
+			Partition: specificPartition,
 		},
 		"partition lost": {
 			Keys: [][]byte{
@@ -396,13 +396,13 @@ func TestPartitionBalancer(t *testing.T) {
 				{0, 1},
 				{0, 1, 2},
 			},
-			Partition: soecificPartition,
+			Partition: specificPartition,
 		},
 	}
 
 	for label, test := range testCases {
 		t.Run(label, func(t *testing.T) {
-			pb := &PartitionBalancer{soecificPartition}
+			pb := &PartitionBalancer{specificPartition}
 
 			var partition int
 			for i, key := range test.Keys {

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -352,3 +352,67 @@ func TestLeastBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestPartitionBalancer(t *testing.T) {
+	soecificPartition:=2
+
+	testCases := map[string]struct {
+		Keys       [][]byte
+		Partitions [][]int
+		Partition  int
+	}{
+		"single message": {
+			Keys: [][]byte{
+				[]byte("key"),
+			},
+			Partitions: [][]int{
+				{0, 1, 2},
+			},
+			Partition: soecificPartition,
+		},
+		"multiple messages": {
+			Keys: [][]byte{
+				[]byte("a"),
+				[]byte("ab"),
+				[]byte("abc"),
+				[]byte("abcd"),
+			},
+			Partitions: [][]int{
+				{0, 1, 2},
+				{0, 1, 2},
+				{0, 1, 2},
+				{0, 1, 2},
+			},
+			Partition: soecificPartition,
+		},
+		"partition lost": {
+			Keys: [][]byte{
+				[]byte("hello world 1"),
+				[]byte("hello world 2"),
+				[]byte("hello world 3"),
+			},
+			Partitions: [][]int{
+				{0, 1},
+				{0, 1},
+				{0, 1, 2},
+			},
+			Partition: soecificPartition,
+		},
+	}
+
+	for label, test := range testCases {
+		t.Run(label, func(t *testing.T) {
+			pb := &PartitionBalancer{soecificPartition}
+
+			var partition int
+			for i, key := range test.Keys {
+				msg := Message{Key: key}
+				partition = pb.Balance(msg, test.Partitions[i]...)
+			}
+
+			if partition != test.Partition {
+				t.Errorf("expected %v; got %v", test.Partition, partition)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I need write messages to a specific partition, and I noticed that the `Partition` field in `Message` is readonly ( I don't understand why design as this...), so I provide this balancer.  

I don't know whether this is a good idea...

How about use `Message.Partition` when  using specific a `NoneBalancer` like this:

```go
type NoneBalancer struct {
}

func (p *PartitionBalancer) Balance(msg Message, _ ...int) (partition int) {
	return msg.Partition
}
```