### PR TITLE
docs(writer): indicate that v0.3 does not support 0 required acks

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -108,8 +108,13 @@ type WriterConfig struct {
 	IdleConnTimeout time.Duration
 
 	// Number of acknowledges from partition replicas required before receiving
-	// a response to a produce request (default to -1, which means to wait for
-	// all replicas).
+	// a response to a produce request. The default is -1, which means to wait for
+	// all replicas, and a value above 0 is required to indicate how many replicas
+	// should acknowledge a message to be considered successful.
+	//
+	// This version of kafka-go (v0.3) does not support 0 required acks, due to
+	// some internal complexity implementing this with the Kafka protocol. If you
+	// need that functionality specifically, you'll need to upgrade to v0.4.
 	RequiredAcks int
 
 	// Setting this flag to true causes the WriteMessages method to never block.


### PR DESCRIPTION
We've decided that fixing the lack of support for 0 required acks is not going to happen in v0.3, due to the extra complexity to add this coupled with the fact that v0.4 already includes support for this. This documentation update makes this clear while recommending users upgrade if needed.