### PR TITLE
fix zstd decoder leak

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -15,7 +15,7 @@ import (
 
 func newLocalClientAndTopic() (*Client, string, func()) {
 	topic := makeTopic()
-	client, shutdown := newClient(TCP("localhost"))
+	client, shutdown := newLocalClient()
 
 	_, err := client.CreateTopics(context.Background(), &CreateTopicsRequest{
 		Topics: []TopicConfig{{

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -417,7 +417,7 @@ func makeTopic() string {
 
 func createTopic(t *testing.T, topic string, partitions int) {
 	client := kafka.Client{
-		Addr: kafka.TCP("localhost:9092"),
+		Addr: kafka.TCP("127.0.0.1:9092"),
 	}
 
 	_, err := client.CreateTopics(context.Background(), &kafka.CreateTopicsRequest{
@@ -435,9 +435,6 @@ func createTopic(t *testing.T, topic string, partitions int) {
 	// layout in the cluster is available in the controller before being synced
 	// with the other brokers, which causes "Error:[3] Unknown Topic Or Partition"
 	// when sending requests to the partition leaders.
-	//
-	// This loop will wait up to 2 seconds polling the cluster until no errors
-	// are returned.
 	for i := 0; i < 20; i++ {
 		r, err := client.Fetch(context.Background(), &kafka.FetchRequest{
 			Topic:     topic,
@@ -453,7 +450,7 @@ func createTopic(t *testing.T, topic string, partitions int) {
 
 func deleteTopic(t *testing.T, topic string) {
 	client := kafka.Client{
-		Addr: kafka.TCP("localhost:9092"),
+		Addr: kafka.TCP("127.0.0.1:9092"),
 	}
 	client.DeleteTopics(context.Background(), &kafka.DeleteTopicsRequest{
 		Topics: []string{topic},

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -465,9 +465,12 @@ func newLocalClient() (*kafka.Client, func()) {
 }
 
 func newClient(addr net.Addr) (*kafka.Client, func()) {
+	conns := &ktesting.ConnWaitGroup{
+		DialFunc: (&net.Dialer{}).DialContext,
+	}
+
 	transport := &kafka.Transport{
-		IdleTimeout: 1 * time.Minute,
-		MetadataTTL: 1 * time.Minute,
+		Dial: conns.Dial,
 	}
 
 	client := &kafka.Client{
@@ -476,5 +479,5 @@ func newClient(addr net.Addr) (*kafka.Client, func()) {
 		Transport: transport,
 	}
 
-	return client, func() { transport.CloseIdleConnections() }
+	return client, func() { transport.CloseIdleConnections(); conns.Wait() }
 }

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -465,7 +465,10 @@ func newLocalClient() (*kafka.Client, func()) {
 }
 
 func newClient(addr net.Addr) (*kafka.Client, func()) {
-	transport := &kafka.Transport{}
+	transport := &kafka.Transport{
+		IdleTimeout: 1 * time.Minute,
+		MetadataTTL: 1 * time.Minute,
+	}
 
 	client := &kafka.Client{
 		Addr:      addr,

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -88,19 +88,24 @@ func testEncodeDecode(t *testing.T, m kafka.Message, codec pkg.Codec) {
 	t.Run("encode with "+codec.Name(), func(t *testing.T) {
 		r1, err = compress(codec, m.Value)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 
 	t.Run("decode with "+codec.Name(), func(t *testing.T) {
+		if r1 == nil {
+			if r1, err = compress(codec, m.Value); err != nil {
+				t.Fatal(err)
+			}
+		}
 		r2, err = decompress(codec, r1)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		if string(r2) != "message" {
 			t.Error("bad message")
-			t.Log("got: ", string(r2))
-			t.Log("expected: ", string(m.Value))
+			t.Logf("expected: %q", string(m.Value))
+			t.Logf("got:      %q", string(r2))
 		}
 	})
 }

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -157,6 +157,9 @@ func (w *writer) Write(p []byte) (int, error) {
 	if w.err != nil {
 		return 0, w.err
 	}
+	if w.enc == nil {
+		return 0, io.ErrClosedPipe
+	}
 	return w.enc.Write(p)
 }
 
@@ -164,6 +167,9 @@ func (w *writer) Write(p []byte) (int, error) {
 func (w *writer) ReadFrom(r io.Reader) (int64, error) {
 	if w.err != nil {
 		return 0, w.err
+	}
+	if w.enc == nil {
+		return 0, io.ErrClosedPipe
 	}
 	return w.enc.ReadFrom(r)
 }

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -139,7 +139,7 @@ func (w *writer) Close() error {
 	if w.enc != nil {
 		// Close needs to be called to write the end of stream marker and flush
 		// the buffers. The zstd package documents that the encoder is re-usable
-		// fater being closed.
+		// after being closed.
 		err := w.enc.Close()
 		if err != nil {
 			w.err = err

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -101,7 +101,7 @@ func (r *reader) WriteTo(w io.Writer) (n int64, err error) {
 // NewWriter implements the compress.Codec interface.
 func (c *Codec) NewWriter(w io.Writer) io.WriteCloser {
 	p := new(writer)
-	if enc := c.encoderPool.Get().(*encoder); enc == nil {
+	if enc, _ := c.encoderPool.Get().(*encoder); enc == nil {
 		z, err := zstd.NewWriter(w, zstd.WithEncoderLevel(c.zstdLevel()))
 		if err != nil {
 			p.err = err

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -35,14 +35,14 @@ func TestDialer(t *testing.T) {
 }
 
 func testDialerLookupPartitions(t *testing.T, ctx context.Context, d *Dialer) {
-	topic := makeTopic()
-	createTopic(t, topic, 1)
-	defer deleteTopic(t, topic)
+	client, topic, shutdown := newLocalClientAndTopic()
+	defer shutdown()
 
 	// Write a message to ensure the partition gets created.
 	w := &Writer{
-		Addr:  TCP("localhost:9092"),
-		Topic: topic,
+		Addr:      TCP("localhost:9092"),
+		Topic:     topic,
+		Transport: client.Transport,
 	}
 	w.WriteMessages(ctx, Message{})
 	w.Close()
@@ -168,14 +168,14 @@ wE3YmpC3Q0g9r44nEbz4Bw==
 }
 
 func TestDialerTLS(t *testing.T) {
-	topic := makeTopic()
-	createTopic(t, topic, 1)
-	defer deleteTopic(t, topic)
+	client, topic, shutdown := newLocalClientAndTopic()
+	defer shutdown()
 
 	// Write a message to ensure the partition gets created.
 	w := &Writer{
-		Addr:  TCP("localhost:9092"),
-		Topic: topic,
+		Addr:      TCP("localhost:9092"),
+		Topic:     topic,
+		Transport: client.Transport,
 	}
 	w.WriteMessages(context.Background(), Message{})
 	w.Close()

--- a/testing/conn.go
+++ b/testing/conn.go
@@ -1,0 +1,32 @@
+package testing
+
+import (
+	"context"
+	"net"
+	"sync"
+)
+
+type ConnWaitGroup struct {
+	DialFunc func(context.Context, string, string) (net.Conn, error)
+	sync.WaitGroup
+}
+
+func (g *ConnWaitGroup) Dial(ctx context.Context, network, address string) (net.Conn, error) {
+	c, err := g.DialFunc(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	g.Add(1)
+	return &groupConn{Conn: c, group: g}, nil
+}
+
+type groupConn struct {
+	net.Conn
+	group *ConnWaitGroup
+	once  sync.Once
+}
+
+func (c *groupConn) Close() error {
+	defer c.once.Do(c.group.Done)
+	return c.Conn.Close()
+}


### PR DESCRIPTION
This PR aims to resolve a memory leak that would occur under some circumstances when reading from partitions containing batches compressed with zstd.

The zstd encoders and decoders are retained by the goroutines they start internally, which causes their finalizers to never go called. The solution implemented here consists in adding a layer of indirection by wrapping the encoders and decoders with an intermediary object on which we install the finalizers.

Related issue https://github.com/klauspost/compress/issues/264