### PR TITLE
Add DescribeConfigs, AlterConfigs & CreatePartition implementation

### DIFF
--- a/alterconfigs.go
+++ b/alterconfigs.go
@@ -1,0 +1,101 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol/alterconfigs"
+)
+
+// AlterConfigsRequest represents a request sent to a kafka broker to alter configs
+type AlterConfigsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	// List of resources to update
+	Resources []AlterConfigRequestResource
+
+	// When set to true, topics are not created but the configuration is
+	// validated as if they were.
+	ValidateOnly bool
+}
+
+type AlterConfigRequestResource struct {
+	// Resource Type
+	ResourceType int8
+
+	// Resource Name
+	ResourceName string
+
+	// Configs is a List of configurations that need to update
+	Configs []AlterConfigRequestConfig
+}
+
+type AlterConfigRequestConfig struct {
+	// Configuration key name
+	Name string
+
+	// The value to set for the configuration key.
+	Value string
+}
+
+// AlterConfigsResponse represents a response from a kafka broker to a alter config request.
+type AlterConfigsResponse struct {
+	// The amount of time that the broker throttled the request.
+	//
+	// This field will be zero if the kafka broker did no support the
+	// AlterConfigs API in version 2 or above.
+	Throttle time.Duration
+
+	// Mapping of topic names to errors that occurred while attempting to create
+	// the topics.
+	//
+	// The errors contain the kafka error code. Programs may use the standard
+	// errors.Is function to test the error against kafka error codes.
+	Errors map[string]error
+}
+
+// AlterConfigs sends a config altering request to a kafka broker and returns the
+// response.
+func (c *Client) AlterConfigs(ctx context.Context, req *AlterConfigsRequest) (*AlterConfigsResponse, error) {
+	resources := make([]alterconfigs.RequestResources, len(req.Resources))
+
+	for i, t := range req.Resources {
+		configs := make([]alterconfigs.RequestConfig, len(t.Configs))
+		for _, v := range t.Configs {
+			config := alterconfigs.RequestConfig{
+				Name:  v.Name,
+				Value: v.Value,
+			}
+			configs = append(configs, config)
+		}
+		resources[i] = alterconfigs.RequestResources{
+			ResourceType: t.ResourceType,
+			ResourceName: t.ResourceName,
+			Configs:      configs,
+		}
+	}
+
+	m, err := c.roundTrip(ctx, req.Addr, &alterconfigs.Request{
+		Resources:    resources,
+		ValidateOnly: req.ValidateOnly,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("kafka.(*Client).AlterConfigs: %w", err)
+	}
+
+	res := m.(*alterconfigs.Response)
+	ret := &AlterConfigsResponse{
+		Throttle: makeDuration(res.ThrottleTimeMs),
+		Errors:   make(map[string]error, len(res.Responses)),
+	}
+
+	for _, t := range res.Responses {
+		ret.Errors[t.ResourceName] = makeError(t.ErrorCode, t.ErrorMessage)
+	}
+
+	return ret, nil
+}

--- a/alterconfigs.go
+++ b/alterconfigs.go
@@ -24,7 +24,7 @@ type AlterConfigsRequest struct {
 
 type AlterConfigRequestResource struct {
 	// Resource Type
-	ResourceType int8
+	ResourceType ResourceType
 
 	// Resource Name
 	ResourceName string
@@ -63,10 +63,10 @@ type AlterConfigsResponseResource struct {
 // AlterConfigs sends a config altering request to a kafka broker and returns the
 // response.
 func (c *Client) AlterConfigs(ctx context.Context, req *AlterConfigsRequest) (*AlterConfigsResponse, error) {
-	resources := make([]alterconfigs.RequestResources, 0, len(req.Resources))
+	resources := make([]alterconfigs.RequestResources, len(req.Resources))
 
 	for i, t := range req.Resources {
-		configs := make([]alterconfigs.RequestConfig, 0, len(t.Configs))
+		configs := make([]alterconfigs.RequestConfig, len(t.Configs))
 		for j, v := range t.Configs {
 			configs[j] = alterconfigs.RequestConfig{
 				Name:  v.Name,
@@ -74,7 +74,7 @@ func (c *Client) AlterConfigs(ctx context.Context, req *AlterConfigsRequest) (*A
 			}
 		}
 		resources[i] = alterconfigs.RequestResources{
-			ResourceType: t.ResourceType,
+			ResourceType: int8(t.ResourceType),
 			ResourceName: t.ResourceName,
 			Configs:      configs,
 		}

--- a/alterconfigs.go
+++ b/alterconfigs.go
@@ -63,10 +63,10 @@ type AlterConfigsResponseResource struct {
 // AlterConfigs sends a config altering request to a kafka broker and returns the
 // response.
 func (c *Client) AlterConfigs(ctx context.Context, req *AlterConfigsRequest) (*AlterConfigsResponse, error) {
-	resources := make([]alterconfigs.RequestResources, len(req.Resources))
+	resources := make([]alterconfigs.RequestResources, 0, len(req.Resources))
 
 	for i, t := range req.Resources {
-		configs := make([]alterconfigs.RequestConfig, len(t.Configs))
+		configs := make([]alterconfigs.RequestConfig, 0, len(t.Configs))
 		for j, v := range t.Configs {
 			configs[j] = alterconfigs.RequestConfig{
 				Name:  v.Name,

--- a/alterconfigs_test.go
+++ b/alterconfigs_test.go
@@ -1,0 +1,34 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+)
+
+func TestClientAlterConfigs(t *testing.T) {
+
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
+	topic := makeTopic()
+	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
+	res, err := client.AlterConfigs(context.Background(), &AlterConfigsRequest{
+		Resources: []AlterConfigRequestResource{{
+			ResourceType: ResourceTypeTopic,
+			ResourceName: topic,
+			Configs: []AlterConfigRequestConfig{{
+				Name:  "max.message.bytes",
+				Value: "200000",
+			},
+			},
+		}},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Client.DescribeConfigs() = %v", res)
+}

--- a/client.go
+++ b/client.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	defaultCreateTopicsTimeout = 2 * time.Second
-	defaultDeleteTopicsTimeout = 2 * time.Second
-	defaultProduceTimeout      = 500 * time.Millisecond
-	defaultMaxWait             = 500 * time.Millisecond
+	defaultCreateTopicsTimeout     = 2 * time.Second
+	defaultDeleteTopicsTimeout     = 2 * time.Second
+	defaultCreatePartitionsTimeout = 2 * time.Second
+	defaultProduceTimeout          = 500 * time.Millisecond
+	defaultMaxWait                 = 500 * time.Millisecond
 )
 
 // Client is a high-level API to interract with kafka brokers.

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -1,0 +1,101 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol/createpartitions"
+)
+
+// CreatePartitionsRequest represents a request sent to a kafka broker to create
+// and update topic parititions.
+type CreatePartitionsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	// List of topics to create and their configuration.
+	Topics []TopicPartitionsConfig
+
+	// When set to true, topics are not created but the configuration is
+	// validated as if they were.
+	ValidateOnly bool
+}
+
+// CreatePartitionsResponse represents a response from a kafka broker to a partitions
+// creation request.
+type CreatePartitionsResponse struct {
+	// The amount of time that the broker throttled the request.
+	//
+	// This field will be zero if the kafka broker did no support the
+	// CreatePartitions API in version 2 or above.
+	Throttle time.Duration
+
+	// Mapping of topic names to errors that occurred while attempting to create
+	// the topics.
+	//
+	// The errors contain the kafka error code. Programs may use the standard
+	// errors.Is function to test the error against kafka error codes.
+	Errors map[string]error
+}
+
+// CreatePartitions sends a partitions creation request to a kafka broker and returns the
+// response.
+func (c *Client) CreatePartitions(ctx context.Context, req *CreatePartitionsRequest) (*CreatePartitionsResponse, error) {
+	topics := make([]createpartitions.RequestTopic, len(req.Topics))
+
+	for i, t := range req.Topics {
+		topics[i] = createpartitions.RequestTopic{
+			Name:        t.Name,
+			Count:       t.Count,
+			Assignments: t.assignments(),
+		}
+	}
+
+	m, err := c.roundTrip(ctx, req.Addr, &createpartitions.Request{
+		Topics:       topics,
+		TimeoutMs:    c.timeoutMs(ctx, defaultCreatePartitionsTimeout),
+		ValidateOnly: req.ValidateOnly,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("kafka.(*Client).CreatePartitions: %w", err)
+	}
+
+	res := m.(*createpartitions.Response)
+	ret := &CreatePartitionsResponse{
+		Throttle: makeDuration(res.ThrottleTimeMs),
+		Errors:   make(map[string]error, len(res.Results)),
+	}
+
+	for _, t := range res.Results {
+		ret.Errors[t.Name] = makeError(t.ErrorCode, t.ErrorMessage)
+	}
+
+	return ret, nil
+}
+
+type TopicPartitionsConfig struct {
+	// Topic name
+	Name string
+
+	// Topic partition's count.
+	Count int32
+
+	// ReplicaAssignments among kafka brokers for this topic partitions.
+	ReplicaAssignments []ReplicaAssignment
+}
+
+func (t *TopicPartitionsConfig) assignments() []createpartitions.RequestAssignment {
+	if len(t.ReplicaAssignments) == 0 {
+		return nil
+	}
+	assignments := make([]createpartitions.RequestAssignment, len(t.ReplicaAssignments))
+	for i, a := range t.ReplicaAssignments {
+		assignments[i] = createpartitions.RequestAssignment{
+			BrokerIDs: a.brokerIDs(),
+		}
+	}
+	return assignments
+}

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -40,7 +40,7 @@ type CreatePartitionsResponse struct {
 // CreatePartitions sends a partitions creation request to a kafka broker and returns the
 // response.
 func (c *Client) CreatePartitions(ctx context.Context, req *CreatePartitionsRequest) (*CreatePartitionsResponse, error) {
-	topics := make([]createpartitions.RequestTopic, len(req.Topics))
+	topics := make([]createpartitions.RequestTopic, 0, len(req.Topics))
 
 	for i, t := range req.Topics {
 		topics[i] = createpartitions.RequestTopic{
@@ -88,7 +88,7 @@ func (t *TopicPartitionsConfig) assignments() []createpartitions.RequestAssignme
 	if len(t.ReplicaAssignments) == 0 {
 		return nil
 	}
-	assignments := make([]createpartitions.RequestAssignment, len(t.ReplicaAssignments))
+	assignments := make([]createpartitions.RequestAssignment, 0, len(t.ReplicaAssignments))
 	for i, a := range t.ReplicaAssignments {
 		assignments[i] = createpartitions.RequestAssignment{
 			BrokerIDs: a.brokerIDs(),

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -23,13 +23,10 @@ type CreatePartitionsRequest struct {
 	ValidateOnly bool
 }
 
-// CreatePartitionsResponse represents a response from a kafka broker to a partitions
+// CreatePartitionsResponse represents a response from a kafka broker to a partition
 // creation request.
 type CreatePartitionsResponse struct {
 	// The amount of time that the broker throttled the request.
-	//
-	// This field will be zero if the kafka broker did no support the
-	// CreatePartitions API in version 2 or above.
 	Throttle time.Duration
 
 	// Mapping of topic names to errors that occurred while attempting to create

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -80,38 +80,24 @@ type TopicPartitionsConfig struct {
 	// Topic partition's count.
 	Count int32
 
-	// PartitionReplicaAssignments among kafka brokers for this topic partitions.
-	PartitionReplicaAssignments []PartitionReplicaAssignment
+	// TopicPartitionAssignments among kafka brokers for this topic partitions.
+	TopicPartitionAssignments []TopicPartitionAssignment
 }
 
 func (t *TopicPartitionsConfig) assignments() []createpartitions.RequestAssignment {
-	if len(t.PartitionReplicaAssignments) == 0 {
+	if len(t.TopicPartitionAssignments) == 0 {
 		return nil
 	}
-	assignments := make([]createpartitions.RequestAssignment, len(t.PartitionReplicaAssignments))
-	for i, a := range t.PartitionReplicaAssignments {
+	assignments := make([]createpartitions.RequestAssignment, len(t.TopicPartitionAssignments))
+	for i, a := range t.TopicPartitionAssignments {
 		assignments[i] = createpartitions.RequestAssignment{
-			BrokerIDs: a.brokerIDs(),
+			BrokerIDs: a.BrokerIDs,
 		}
 	}
 	return assignments
 }
 
-type PartitionReplicaAssignment struct {
-	// The list of brokers where the partition should be allocated. There must
-	// be as many entries in thie list as there are replicas of the partition.
-	// The first entry represents the broker that will be the preferred leader
-	// for the partition.
-	Replicas []int
-}
-
-func (a *PartitionReplicaAssignment) brokerIDs() []int32 {
-	if len(a.Replicas) == 0 {
-		return nil
-	}
-	replicas := make([]int32, len(a.Replicas))
-	for i, r := range a.Replicas {
-		replicas[i] = int32(r)
-	}
-	return replicas
+type TopicPartitionAssignment struct {
+	// Broker IDs
+	BrokerIDs []int32
 }

--- a/createpartitions_test.go
+++ b/createpartitions_test.go
@@ -19,9 +19,9 @@ func TestClientCreatePartitions(t *testing.T) {
 			TopicPartitionsConfig{
 				Name:  topic,
 				Count: 2,
-				PartitionReplicaAssignments: []PartitionReplicaAssignment{
-					PartitionReplicaAssignment{
-						Replicas: []int{0},
+				TopicPartitionAssignments: []TopicPartitionAssignment{
+					TopicPartitionAssignment{
+						BrokerIDs: []int32{0},
 					},
 				},
 			},

--- a/createpartitions_test.go
+++ b/createpartitions_test.go
@@ -1,0 +1,39 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+)
+
+func TestClientCreatePartitions(t *testing.T) {
+
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
+	topic := makeTopic()
+	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
+	res, err := client.CreatePartitions(context.Background(), &CreatePartitionsRequest{
+		Topics: []TopicPartitionsConfig{
+			TopicPartitionsConfig{
+				Name:  topic,
+				Count: 2,
+				PartitionReplicaAssignments: []PartitionReplicaAssignment{
+					PartitionReplicaAssignment{
+						Replicas: []int{0},
+					},
+				},
+			},
+		},
+		ValidateOnly: false,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := res.Errors[topic]; err != nil {
+		t.Error(err)
+	}
+}

--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -1,0 +1,157 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol/describeconfigs"
+)
+
+// DescribeConfigsRequest represents a request sent to a kafka broker to describe configs
+type DescribeConfigsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	// List of resources to update
+	Resources []DescribeConfigRequestResource
+
+	// required API version is no less than v1
+	IncludeSynonyms bool
+
+	// required API version is no less than v3
+	IncludeDocumentation bool
+}
+
+type DescribeConfigRequestResource struct {
+	// Resource Type
+	ResourceType int8
+
+	// Resource Name
+	ResourceName string
+
+	// Configs is a List of configurations that need to update
+	ConfigNames []string
+}
+
+// DescribeConfigsResponse represents a response from a kafka broker to a describe config request.
+type DescribeConfigsResponse struct {
+	// The amount of time that the broker throttled the request.
+	//
+	// This field will be zero if the kafka broker did no support the
+	// DescribeConfigs API in version 2 or above.
+	Throttle time.Duration
+
+	// Resources
+	Resources []DescribeConfigResponseResource
+}
+
+// DescribeConfigResponseResource
+type DescribeConfigResponseResource struct {
+	// Resource Type
+	ResourceType int8
+
+	// Resource Name
+	ResourceName string
+
+	// ErrorCode
+	ErrorCode int16
+
+	// ErrorMessage
+	ErrorMessage string
+
+	// ConfigEntries
+	ConfigEntries []DescribeConfigResponseConfigEntry
+}
+
+// DescribeConfigResponseConfigEntry
+type DescribeConfigResponseConfigEntry struct {
+	ConfigName          string
+	ConfigValue         string
+	ReadOnly            bool
+	IsDefault           bool
+	IsSensitive         bool
+	ConfigSynonyms      []DescribeConfigResponseConfigSynonym
+	ConfigType          int8
+	ConfigDocumentation string
+}
+
+// DescribeConfigResponseConfigSynonym
+type DescribeConfigResponseConfigSynonym struct {
+	ConfigName   string
+	ConfigValue  string
+	ConfigSource int8
+}
+
+// DescribeConfigs sends a config altering request to a kafka broker and returns the
+// response.
+func (c *Client) DescribeConfigs(ctx context.Context, req *DescribeConfigsRequest) (*DescribeConfigsResponse, error) {
+	resources := make([]describeconfigs.RequestResource, len(req.Resources))
+
+	for i, t := range req.Resources {
+		configNames := make([]string, len(t.ConfigNames))
+		for _, v := range t.ConfigNames {
+			configNames = append(configNames, v)
+		}
+		resources[i] = describeconfigs.RequestResource{
+			ResourceType: t.ResourceType,
+			ResourceName: t.ResourceName,
+			ConfigNames:  configNames,
+		}
+	}
+
+	m, err := c.roundTrip(ctx, req.Addr, &describeconfigs.Request{
+		Resources:            resources,
+		IncludeSynonyms:      req.IncludeSynonyms,
+		IncludeDocumentation: req.IncludeDocumentation,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("kafka.(*Client).DescribeConfigs: %w", err)
+	}
+
+	res := m.(*describeconfigs.Response)
+	ret := &DescribeConfigsResponse{
+		Throttle:  makeDuration(res.ThrottleTimeMs),
+		Resources: make([]DescribeConfigResponseResource, len(res.Resources)),
+	}
+
+	for _, t := range res.Resources {
+
+		configEntries := make([]DescribeConfigResponseConfigEntry, len(t.ConfigEntries))
+		for _, v := range t.ConfigEntries {
+
+			configSynonyms := make([]DescribeConfigResponseConfigSynonym, len(v.ConfigSynonyms))
+			for _, cs := range v.ConfigSynonyms {
+				configSynonyms = append(configSynonyms, DescribeConfigResponseConfigSynonym{
+					ConfigName:   cs.ConfigName,
+					ConfigValue:  cs.ConfigValue,
+					ConfigSource: cs.ConfigSource,
+				})
+			}
+
+			configEntries = append(configEntries, DescribeConfigResponseConfigEntry{
+				ConfigName:          v.ConfigName,
+				ConfigValue:         v.ConfigValue,
+				ReadOnly:            v.ReadOnly,
+				IsDefault:           v.IsDefault,
+				IsSensitive:         v.IsSensitive,
+				ConfigSynonyms:      configSynonyms,
+				ConfigType:          v.ConfigType,
+				ConfigDocumentation: v.ConfigDocumentation,
+			})
+		}
+
+		resource := DescribeConfigResponseResource{
+			ResourceType:  t.ResourceType,
+			ResourceName:  t.ResourceName,
+			ErrorCode:     t.ErrorCode,
+			ErrorMessage:  t.ErrorMessage,
+			ConfigEntries: configEntries,
+		}
+		ret.Resources = append(ret.Resources, resource)
+	}
+
+	return ret, nil
+}

--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -61,28 +61,44 @@ type DescribeConfigResponseResource struct {
 
 // DescribeConfigResponseConfigEntry
 type DescribeConfigResponseConfigEntry struct {
-	ConfigName          string
-	ConfigValue         string
-	ReadOnly            bool
-	IsDefault           bool
-	ConfigSource        int8
-	IsSensitive         bool
-	ConfigSynonyms      []DescribeConfigResponseConfigSynonym
-	ConfigType          int8
+	ConfigName  string
+	ConfigValue string
+	ReadOnly    bool
+
+	// Ignored if API version is greater than v0
+	IsDefault bool
+
+	// Ignored if API version is less than v1
+	ConfigSource int8
+
+	IsSensitive bool
+
+	// Ignored if API version is less than v1
+	ConfigSynonyms []DescribeConfigResponseConfigSynonym
+
+	// Ignored if API version is less than v3
+	ConfigType int8
+
+	// Ignored if API version is less than v3
 	ConfigDocumentation string
 }
 
 // DescribeConfigResponseConfigSynonym
 type DescribeConfigResponseConfigSynonym struct {
-	ConfigName   string
-	ConfigValue  string
+	// Ignored if API version is less than v1
+	ConfigName string
+
+	// Ignored if API version is less than v1
+	ConfigValue string
+
+	// Ignored if API version is less than v1
 	ConfigSource int8
 }
 
 // DescribeConfigs sends a config altering request to a kafka broker and returns the
 // response.
 func (c *Client) DescribeConfigs(ctx context.Context, req *DescribeConfigsRequest) (*DescribeConfigsResponse, error) {
-	resources := make([]describeconfigs.RequestResource, len(req.Resources))
+	resources := make([]describeconfigs.RequestResource, 0, len(req.Resources))
 
 	for i, t := range req.Resources {
 		resources[i] = describeconfigs.RequestResource{
@@ -105,15 +121,15 @@ func (c *Client) DescribeConfigs(ctx context.Context, req *DescribeConfigsReques
 	res := m.(*describeconfigs.Response)
 	ret := &DescribeConfigsResponse{
 		Throttle:  makeDuration(res.ThrottleTimeMs),
-		Resources: make([]DescribeConfigResponseResource, len(res.Resources)),
+		Resources: make([]DescribeConfigResponseResource, 0, len(res.Resources)),
 	}
 
 	for i, t := range res.Resources {
 
-		configEntries := make([]DescribeConfigResponseConfigEntry, len(t.ConfigEntries))
+		configEntries := make([]DescribeConfigResponseConfigEntry, 0, len(t.ConfigEntries))
 		for j, v := range t.ConfigEntries {
 
-			configSynonyms := make([]DescribeConfigResponseConfigSynonym, len(v.ConfigSynonyms))
+			configSynonyms := make([]DescribeConfigResponseConfigSynonym, 0, len(v.ConfigSynonyms))
 			for k, cs := range v.ConfigSynonyms {
 				configSynonyms[k] = DescribeConfigResponseConfigSynonym{
 					ConfigName:   cs.ConfigName,

--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -24,9 +24,20 @@ type DescribeConfigsRequest struct {
 	IncludeDocumentation bool
 }
 
+type ResourceType int8
+
+const (
+	ResourceTypeUnknown ResourceType = 0
+	ResourceTypeAny     ResourceType = 1
+	ResourceTypeTopic   ResourceType = 2
+	ResourceTypeGroup   ResourceType = 3
+	ResourceTypeCluster ResourceType = 4
+	ResourceTypeBroker  ResourceType = 5
+)
+
 type DescribeConfigRequestResource struct {
 	// Resource Type
-	ResourceType int8
+	ResourceType ResourceType
 
 	// Resource Name
 	ResourceName string
@@ -98,11 +109,11 @@ type DescribeConfigResponseConfigSynonym struct {
 // DescribeConfigs sends a config altering request to a kafka broker and returns the
 // response.
 func (c *Client) DescribeConfigs(ctx context.Context, req *DescribeConfigsRequest) (*DescribeConfigsResponse, error) {
-	resources := make([]describeconfigs.RequestResource, 0, len(req.Resources))
+	resources := make([]describeconfigs.RequestResource, len(req.Resources))
 
 	for i, t := range req.Resources {
 		resources[i] = describeconfigs.RequestResource{
-			ResourceType: t.ResourceType,
+			ResourceType: int8(t.ResourceType),
 			ResourceName: t.ResourceName,
 			ConfigNames:  t.ConfigNames,
 		}
@@ -121,15 +132,15 @@ func (c *Client) DescribeConfigs(ctx context.Context, req *DescribeConfigsReques
 	res := m.(*describeconfigs.Response)
 	ret := &DescribeConfigsResponse{
 		Throttle:  makeDuration(res.ThrottleTimeMs),
-		Resources: make([]DescribeConfigResponseResource, 0, len(res.Resources)),
+		Resources: make([]DescribeConfigResponseResource, len(res.Resources)),
 	}
 
 	for i, t := range res.Resources {
 
-		configEntries := make([]DescribeConfigResponseConfigEntry, 0, len(t.ConfigEntries))
+		configEntries := make([]DescribeConfigResponseConfigEntry, len(t.ConfigEntries))
 		for j, v := range t.ConfigEntries {
 
-			configSynonyms := make([]DescribeConfigResponseConfigSynonym, 0, len(v.ConfigSynonyms))
+			configSynonyms := make([]DescribeConfigResponseConfigSynonym, len(v.ConfigSynonyms))
 			for k, cs := range v.ConfigSynonyms {
 				configSynonyms[k] = DescribeConfigResponseConfigSynonym{
 					ConfigName:   cs.ConfigName,

--- a/describeconfigs_test.go
+++ b/describeconfigs_test.go
@@ -1,0 +1,30 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+)
+
+func TestClientDescribeConfigs(t *testing.T) {
+
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
+	topic := makeTopic()
+	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
+	res, err := client.DescribeConfigs(context.Background(), &DescribeConfigsRequest{
+		Resources: []DescribeConfigRequestResource{{
+			ResourceType: ResourceTypeTopic,
+			ResourceName: topic,
+			ConfigNames:  []string{"max.message.bytes"},
+		}},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Client.DescribeConfigs() = %v", res)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/snappy v0.0.1
 	github.com/klauspost/compress v1.9.8
 	github.com/pierrec/lz4 v2.0.5+incompatible
+	github.com/stretchr/testify v1.6.1
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	github.com/xdg/stringprep v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
@@ -6,6 +8,10 @@ github.com/klauspost/compress v1.9.8 h1:VMAMUUOh+gaxKTMk+zqbjsSjsIcUcL/LF4o63i82
 github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
@@ -19,3 +25,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/protocol/alterconfigs/alterconfigs.go
+++ b/protocol/alterconfigs/alterconfigs.go
@@ -1,0 +1,48 @@
+package alterconfigs
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+// Detailed API definition: https://kafka.apache.org/protocol#The_Messages_AlterConfigs
+type Request struct {
+	Resources    []RequestResources `kafka:"min=v0,max=v1"`
+	ValidateOnly bool               `kafka:"min=v0,max=v1"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.AlterConfigs }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type RequestResources struct {
+	ResourceType int8            `kafka:"min=v0,max=v1"`
+	ResourceName string          `kafka:"min=v0,max=v1"`
+	Configs      []RequestConfig `kafka:"min=v0,max=v1"`
+}
+
+type RequestConfig struct {
+	Name  string `kafka:"min=v0,max=v1"`
+	Value string `kafka:"min=v0,max=v1,nullable"`
+}
+
+type Response struct {
+	ThrottleTimeMs int32               `kafka:"min=v0,max=v1"`
+	Responses      []ResponseResponses `kafka:"min=v0,max=v1"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.AlterConfigs }
+
+type ResponseResponses struct {
+	ErrorCode    int16  `kafka:"min=v0,max=v1"`
+	ErrorMessage string `kafka:"min=v0,max=v1,nullable"`
+	ResourceType int8   `kafka:"min=v0,max=v1"`
+	ResourceName string `kafka:"min=v0,max=v1"`
+}
+
+var (
+	_ protocol.BrokerMessage = (*Request)(nil)
+)

--- a/protocol/createpartitions/createpartitions.go
+++ b/protocol/createpartitions/createpartitions.go
@@ -7,7 +7,7 @@ func init() {
 }
 
 // Detailed API definition: https://kafka.apache.org/protocol#The_Messages_CreatePartitions.
-// here need to support version 2
+// TODO: Support version 2
 type Request struct {
 	Topics       []RequestTopic `kafka:"min=v0,max=v1"`
 	TimeoutMs    int32          `kafka:"min=v0,max=v1"`

--- a/protocol/createpartitions/createpartitions.go
+++ b/protocol/createpartitions/createpartitions.go
@@ -1,0 +1,48 @@
+package createpartitions
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+// Detailed API definition: https://kafka.apache.org/protocol#The_Messages_CreatePartitions.
+// here need to support version 2
+type Request struct {
+	Topics       []RequestTopic `kafka:"min=v0,max=v1"`
+	TimeoutMs    int32          `kafka:"min=v0,max=v1"`
+	ValidateOnly bool           `kafka:"min=v0,max=v1"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.CreatePartitions }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type RequestTopic struct {
+	Name        string              `kafka:"min=v0,max=v1"`
+	Count       int32               `kafka:"min=v0,max=v1"`
+	Assignments []RequestAssignment `kafka:"min=v0,max=v1"`
+}
+
+type RequestAssignment struct {
+	BrokerIDs []int32 `kafka:"min=v0,max=v1"`
+}
+
+type Response struct {
+	ThrottleTimeMs int32            `kafka:"min=v0,max=v1"`
+	Results        []ResponseResult `kafka:"min=v0,max=v1"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.CreatePartitions }
+
+type ResponseResult struct {
+	Name         string `kafka:"min=v0,max=v1"`
+	ErrorCode    int16  `kafka:"min=v0,max=v1"`
+	ErrorMessage string `kafka:"min=v0,max=v1,nullable"`
+}
+
+var (
+	_ protocol.BrokerMessage = (*Request)(nil)
+)

--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -1,0 +1,62 @@
+package describeconfigs
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+// Detailed API definition: https://kafka.apache.org/protocol#The_Messages_DescribeConfigs
+type Request struct {
+	Resources            []RequestResource `kafka:"min=v0,max=v3"`
+	IncludeSynonyms      bool              `kafka:"min=v1,max=v3"`
+	IncludeDocumentation bool              `kafka:"min=v3,max=v3"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.DescribeConfigs }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type RequestResource struct {
+	ResourceType int8     `kafka:"min=v0,max=v3"`
+	ResourceName string   `kafka:"min=v0,max=v3"`
+	ConfigNames  []string `kafka:"min=v0,max=v3"`
+}
+
+type Response struct {
+	ThrottleTimeMs int32              `kafka:"min=v0,max=v3"`
+	Resources      []ResponseResource `kafka:"min=v0,max=v3"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.DescribeConfigs }
+
+type ResponseResource struct {
+	ErrorCode     int16                 `kafka:"min=v0,max=v3"`
+	ErrorMessage  string                `kafka:"min=v0,max=v3,nullable"`
+	ResourceType  int8                  `kafka:"min=v0,max=v3"`
+	ResourceName  string                `kafka:"min=v0,max=v3"`
+	ConfigEntries []ResponseConfigEntry `kafka:"min=v0,max=v3"`
+}
+
+type ResponseConfigEntry struct {
+	ConfigName          string                  `kafka:"min=v0,max=v3"`
+	ConfigValue         string                  `kafka:"min=v0,max=v3,nullable"`
+	ReadOnly            bool                    `kafka:"min=v0,max=v3"`
+	IsDefault           bool                    `kafka:"min=v0,max=v3"`
+	IsSensitive         bool                    `kafka:"min=v0,max=v3"`
+	ConfigSynonyms      []ResponseConfigSynonym `kafka:"min=v1,max=v3"`
+	ConfigType          int8                    `kafka:"min=v3,max=v3"`
+	ConfigDocumentation string                  `kafka:"min=v3,max=v3,nullable"`
+}
+
+type ResponseConfigSynonym struct {
+	ConfigName   string `kafka:"min=v1,max=v3"`
+	ConfigValue  string `kafka:"min=v1,max=v3,nullable"`
+	ConfigSource int8   `kafka:"min=v1,max=v3"`
+}
+
+var (
+	_ protocol.BrokerMessage = (*Request)(nil)
+)

--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -44,7 +44,8 @@ type ResponseConfigEntry struct {
 	ConfigName          string                  `kafka:"min=v0,max=v3"`
 	ConfigValue         string                  `kafka:"min=v0,max=v3,nullable"`
 	ReadOnly            bool                    `kafka:"min=v0,max=v3"`
-	IsDefault           bool                    `kafka:"min=v0,max=v3"`
+	IsDefault           bool                    `kafka:"min=v0,max=v0"`
+	ConfigSource        int8                    `kafka:"min=v1,max=v3"`
 	IsSensitive         bool                    `kafka:"min=v0,max=v3"`
 	ConfigSynonyms      []ResponseConfigSynonym `kafka:"min=v1,max=v3"`
 	ConfigType          int8                    `kafka:"min=v3,max=v3"`


### PR DESCRIPTION
Implemented DescribeConfigs, AlterConfigs and CreatePartition functionalities for fixing [496](https://github.com/segmentio/kafka-go/issues/469) and [310](https://github.com/segmentio/kafka-go/issues/310).

Kafka Improvement Proposals :
https://cwiki.apache.org/confluence/display/KAFKA/KIP-195%3A+AdminClient.createPartitions .
https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs.

APIs:
[The_Messages_DescribeConfigs](https://kafka.apache.org/protocol#The_Messages_DescribeConfigs).
[The_Messages_AlterConfigs](https://kafka.apache.org/protocol#The_Messages_AlterConfigs)
[The_Messages_CreatePartitions](https://kafka.apache.org/protocol#The_Messages_CreatePartitions)

detailed information ,please looking at [470](https://github.com/segmentio/kafka-go/pull/470).