### PR TITLE
0.4: reduce memory footprint

### DIFF
--- a/protocol/error.go
+++ b/protocol/error.go
@@ -62,11 +62,11 @@ func (e *TopicError) Unwrap() error {
 
 type TopicPartitionError struct {
 	Topic     string
-	Partition int
+	Partition int32
 	Err       error
 }
 
-func NewTopicPartitionError(topic string, partition int, err error) *TopicPartitionError {
+func NewTopicPartitionError(topic string, partition int32, err error) *TopicPartitionError {
 	return &TopicPartitionError{
 		Topic:     topic,
 		Partition: partition,
@@ -74,11 +74,11 @@ func NewTopicPartitionError(topic string, partition int, err error) *TopicPartit
 	}
 }
 
-func NewErrNoPartition(topic string, partition int) *TopicPartitionError {
+func NewErrNoPartition(topic string, partition int32) *TopicPartitionError {
 	return NewTopicPartitionError(topic, partition, ErrNoPartition)
 }
 
-func NewErrNoLeader(topic string, partition int) *TopicPartitionError {
+func NewErrNoLeader(topic string, partition int32) *TopicPartitionError {
 	return NewTopicPartitionError(topic, partition, ErrNoLeader)
 }
 

--- a/protocol/fetch/fetch.go
+++ b/protocol/fetch/fetch.go
@@ -39,13 +39,13 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 		for j := range t.Partitions {
 			p := &t.Partitions[j]
 
-			partition, ok := topic.Partitions[int(p.Partition)]
+			partition, ok := topic.Partitions[p.Partition]
 			if !ok {
-				return broker, NewError(protocol.NewErrNoPartition(t.Topic, int(p.Partition)))
+				return broker, NewError(protocol.NewErrNoPartition(t.Topic, p.Partition))
 			}
 
 			if b, ok := cluster.Brokers[partition.Leader]; !ok {
-				return broker, NewError(protocol.NewErrNoLeader(t.Topic, int(p.Partition)))
+				return broker, NewError(protocol.NewErrNoLeader(t.Topic, p.Partition))
 			} else if broker.ID < 0 {
 				broker = b
 			} else if b.ID != broker.ID {

--- a/protocol/listoffsets/listoffsets.go
+++ b/protocol/listoffsets/listoffsets.go
@@ -41,7 +41,7 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 	topic := r.Topics[0].Topic
 
 	for _, p := range cluster.Topics[topic].Partitions {
-		if p.ID == int(partition) {
+		if p.ID == partition {
 			return cluster.Brokers[p.Leader], nil
 		}
 	}

--- a/protocol/produce/produce.go
+++ b/protocol/produce/produce.go
@@ -33,13 +33,13 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 		for j := range t.Partitions {
 			p := &t.Partitions[j]
 
-			partition, ok := topic.Partitions[int(p.Partition)]
+			partition, ok := topic.Partitions[p.Partition]
 			if !ok {
-				return broker, NewError(protocol.NewErrNoPartition(t.Topic, int(p.Partition)))
+				return broker, NewError(protocol.NewErrNoPartition(t.Topic, p.Partition))
 			}
 
 			if b, ok := cluster.Brokers[partition.Leader]; !ok {
-				return broker, NewError(protocol.NewErrNoLeader(t.Topic, int(p.Partition)))
+				return broker, NewError(protocol.NewErrNoLeader(t.Topic, p.Partition))
 			} else if broker.ID < 0 {
 				broker = b
 			} else if b.ID != broker.ID {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -353,22 +353,22 @@ func dontExpectEOF(err error) error {
 type Broker struct {
 	Rack string
 	Host string
-	Port int
-	ID   int
+	Port int32
+	ID   int32
 }
 
 func (b Broker) String() string {
-	return net.JoinHostPort(b.Host, strconv.Itoa(b.Port))
+	return net.JoinHostPort(b.Host, itoa(b.Port))
 }
 
 func (b Broker) Format(w fmt.State, v rune) {
 	switch v {
 	case 'd':
-		io.WriteString(w, strconv.Itoa(b.ID))
+		io.WriteString(w, itoa(b.ID))
 	case 's':
 		io.WriteString(w, b.String())
 	case 'v':
-		io.WriteString(w, strconv.Itoa(b.ID))
+		io.WriteString(w, itoa(b.ID))
 		io.WriteString(w, " ")
 		io.WriteString(w, b.String())
 		if b.Rack != "" {
@@ -378,19 +378,23 @@ func (b Broker) Format(w fmt.State, v rune) {
 	}
 }
 
+func itoa(i int32) string {
+	return strconv.Itoa(int(i))
+}
+
 type Topic struct {
 	Name       string
-	Error      int
-	Partitions map[int]Partition
+	Error      int16
+	Partitions map[int32]Partition
 }
 
 type Partition struct {
-	ID       int
-	Error    int
-	Leader   int
-	Replicas []int
-	ISR      []int
-	Offline  []int
+	ID       int32
+	Error    int16
+	Leader   int32
+	Replicas []int32
+	ISR      []int32
+	Offline  []int32
 }
 
 // BrokerMessage is an extension of the Message interface implemented by some


### PR DESCRIPTION
The goal of this PR is to reduce the memory footprint of internal data types by using `int16` or `int32` instead of `int` where possible.

The switch also brings extra type safety because we don't need to convert integers types to `int` anymore, allowing for stricter compiler checks.
