### PR TITLE
Ensure headerCount is positive before making headers slice

### DIFF
--- a/message.go
+++ b/message.go
@@ -549,8 +549,6 @@ func (r *messageSetReaderV2) readMessage(min int64,
 		return
 	}
 
-	headers = make([]Header, headerCount)
-
 	if headerCount >= 0 {
 		headers = make([]Header, headerCount)
 	}

--- a/message.go
+++ b/message.go
@@ -551,6 +551,10 @@ func (r *messageSetReaderV2) readMessage(min int64,
 
 	headers = make([]Header, headerCount)
 
+	if headerCount >= 0 {
+		headers = make([]Header, headerCount)
+	}
+
 	for i := 0; i < int(headerCount); i++ {
 		if err = r.readMessageHeader(&headers[i]); err != nil {
 			return


### PR DESCRIPTION
Other libraries seems to be doing:
https://github.com/Shopify/sarama/blob/8c3fe6939f5667b9390af8865f834995182b8b58/record.go#L104
https://github.com/apache/kafka/blob/927edfece3db8aab7d01850955f9a65e5c110da5/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java#L356
https://github.com/dpkp/kafka-python/blob/a27ab881726ed1a2d952867a1fa266573165d6aa/kafka/record/default_records.py#L241

Might fix #457, not sure if it was due to an actual corrupted record or a bug elsewhere in the decoder.