### PR TITLE
[WIP] Support additional APIs and flexible messages

### DIFF
--- a/alterpartitionreassignments.go
+++ b/alterpartitionreassignments.go
@@ -25,6 +25,14 @@ type AlterPartitionReassignmentsRequestAssignment struct {
 type AlterPartitionReassignmentsResponse struct {
 	ErrorCode    int16
 	ErrorMessage string
+
+	PartitionResults []AlterPartitionReassignmentsResponsePartitionResult
+}
+
+type AlterPartitionReassignmentsResponsePartitionResult struct {
+	PartitionID  int32
+	ErrorCode    int16
+	ErrorMessage string
 }
 
 func (c *Client) AlterPartitionReassignments(
@@ -63,8 +71,23 @@ func (c *Client) AlterPartitionReassignments(
 	}
 	apiResp := protoResp.(*alterpartitionreassignments.Response)
 
-	return &AlterPartitionReassignmentsResponse{
+	resp := &AlterPartitionReassignmentsResponse{
 		ErrorCode:    apiResp.ErrorCode,
 		ErrorMessage: apiResp.ErrorMessage,
-	}, nil
+	}
+
+	for _, topicResult := range apiResp.Results {
+		for _, partitionResult := range topicResult.Partitions {
+			resp.PartitionResults = append(
+				resp.PartitionResults,
+				AlterPartitionReassignmentsResponsePartitionResult{
+					PartitionID:  partitionResult.PartitionIndex,
+					ErrorCode:    partitionResult.ErrorCode,
+					ErrorMessage: partitionResult.ErrorMessage,
+				},
+			)
+		}
+	}
+
+	return resp, nil
 }

--- a/alterpartitionreassignments.go
+++ b/alterpartitionreassignments.go
@@ -1,0 +1,70 @@
+package kafka
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol/alterpartitionreassignments"
+)
+
+type AlterPartitionReassignmentsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	Topic       string
+	Assignments []AlterPartitionReassignmentsRequestAssignment
+	Timeout     time.Duration
+}
+
+type AlterPartitionReassignmentsRequestAssignment struct {
+	PartitionID int32
+	BrokerIDs   []int32
+}
+
+type AlterPartitionReassignmentsResponse struct {
+	ErrorCode    int16
+	ErrorMessage string
+}
+
+func (c *Client) AlterPartitionReassignments(
+	ctx context.Context,
+	req AlterPartitionReassignmentsRequest,
+) (*AlterPartitionReassignmentsResponse, error) {
+	apiPartitions := []alterpartitionreassignments.RequestPartition{}
+
+	for _, assignment := range req.Assignments {
+		apiPartitions = append(
+			apiPartitions,
+			alterpartitionreassignments.RequestPartition{
+				PartitionIndex: assignment.PartitionID,
+				Replicas:       assignment.BrokerIDs,
+			},
+		)
+	}
+
+	apiReq := &alterpartitionreassignments.Request{
+		TimeoutMs: int32(req.Timeout.Milliseconds()),
+		Topics: []alterpartitionreassignments.RequestTopic{
+			{
+				Name:       req.Topic,
+				Partitions: apiPartitions,
+			},
+		},
+	}
+
+	protoResp, err := c.roundTrip(
+		ctx,
+		req.Addr,
+		apiReq,
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiResp := protoResp.(*alterpartitionreassignments.Response)
+
+	return &AlterPartitionReassignmentsResponse{
+		ErrorCode:    apiResp.ErrorCode,
+		ErrorMessage: apiResp.ErrorMessage,
+	}, nil
+}

--- a/apiversions.go
+++ b/apiversions.go
@@ -1,0 +1,56 @@
+package kafka
+
+import (
+	"context"
+	"net"
+
+	"github.com/segmentio/kafka-go/protocol"
+	"github.com/segmentio/kafka-go/protocol/apiversions"
+)
+
+type ApiVersionsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+}
+
+type ApiVersionsResponse struct {
+	ErrorCode int16
+	ApiKeys   []ApiVersionsResponseApiKey
+}
+
+type ApiVersionsResponseApiKey struct {
+	ApiKey     int16
+	ApiName    string
+	MinVersion int16
+	MaxVersion int16
+}
+
+func (c *Client) ApiVersions(
+	ctx context.Context,
+	req ApiVersionsRequest,
+) (*ApiVersionsResponse, error) {
+	apiReq := &apiversions.Request{}
+	protoResp, err := c.roundTrip(
+		ctx,
+		req.Addr,
+		apiReq,
+	)
+	apiResp := protoResp.(*apiversions.Response)
+
+	resp := &ApiVersionsResponse{
+		ErrorCode: apiResp.ErrorCode,
+	}
+	for _, apiKey := range apiResp.ApiKeys {
+		resp.ApiKeys = append(
+			resp.ApiKeys,
+			ApiVersionsResponseApiKey{
+				ApiKey:     apiKey.ApiKey,
+				ApiName:    protocol.ApiKey(apiKey.ApiKey).String(),
+				MinVersion: apiKey.MinVersion,
+				MaxVersion: apiKey.MaxVersion,
+			},
+		)
+	}
+
+	return resp, err
+}

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/segmentio/kafka-go/protocol/createpartitions"
 )
@@ -15,6 +16,7 @@ type CreatePartitionsRequest struct {
 	Topic         string
 	NewPartitions []CreatePartitionsRequestPartition
 	TotalCount    int32
+	Timeout       time.Duration
 }
 
 type CreatePartitionsRequestPartition struct {
@@ -45,10 +47,10 @@ func (c *Client) CreatePartitions(
 				Assignments: assignments,
 			},
 		},
-		TimeoutMs: 5000,
+		TimeoutMs: int32(req.Timeout.Milliseconds()),
 	}
 
-	protocolResp, err := c.roundTrip(
+	protoResp, err := c.roundTrip(
 		ctx,
 		req.Addr,
 		apiReq,
@@ -56,9 +58,8 @@ func (c *Client) CreatePartitions(
 	if err != nil {
 		return nil, err
 	}
-	apiResp := protocolResp.(*createpartitions.Response)
+	apiResp := protoResp.(*createpartitions.Response)
 
-	fmt.Printf("Response: %+v", *apiResp)
 	if len(apiResp.Results) == 0 {
 		return nil, fmt.Errorf("Empty results")
 	}

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -14,6 +14,7 @@ type CreatePartitionsRequest struct {
 
 	Topic         string
 	NewPartitions []CreatePartitionsRequestPartition
+	TotalCount    int32
 }
 
 type CreatePartitionsRequestPartition struct {
@@ -40,7 +41,7 @@ func (c *Client) CreatePartitions(
 		Topics: []createpartitions.RequestTopic{
 			{
 				Name:        req.Topic,
-				Count:       int32(len(req.NewPartitions)) + 3,
+				Count:       req.TotalCount,
 				Assignments: assignments,
 			},
 		},

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -40,10 +40,11 @@ func (c *Client) CreatePartitions(
 		Topics: []createpartitions.RequestTopic{
 			{
 				Name:        req.Topic,
-				Count:       int32(len(req.NewPartitions)),
+				Count:       int32(len(req.NewPartitions)) + 3,
 				Assignments: assignments,
 			},
 		},
+		TimeoutMs: 5000,
 	}
 
 	protocolResp, err := c.roundTrip(
@@ -56,6 +57,7 @@ func (c *Client) CreatePartitions(
 	}
 	apiResp := protocolResp.(*createpartitions.Response)
 
+	fmt.Printf("Response: %+v", *apiResp)
 	if len(apiResp.Results) == 0 {
 		return nil, fmt.Errorf("Empty results")
 	}

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -1,0 +1,67 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/segmentio/kafka-go/protocol/createpartitions"
+)
+
+type CreatePartitionsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	Topic         string
+	NewPartitions []CreatePartitionsRequestPartition
+}
+
+type CreatePartitionsRequestPartition struct {
+	BrokerIDs []int32
+}
+
+type CreatePartitionsResponse struct {
+	ErrorCode    int16
+	ErrorMessage string
+}
+
+func (c *Client) CreatePartitions(
+	ctx context.Context,
+	req CreatePartitionsRequest,
+) (*CreatePartitionsResponse, error) {
+	assignments := []createpartitions.RequestAssignment{}
+	for _, partition := range req.NewPartitions {
+		assignments = append(assignments, createpartitions.RequestAssignment{
+			BrokerIDs: partition.BrokerIDs,
+		})
+	}
+
+	apiReq := &createpartitions.Request{
+		Topics: []createpartitions.RequestTopic{
+			{
+				Name:        req.Topic,
+				Count:       int32(len(req.NewPartitions)),
+				Assignments: assignments,
+			},
+		},
+	}
+
+	protocolResp, err := c.roundTrip(
+		ctx,
+		req.Addr,
+		apiReq,
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiResp := protocolResp.(*createpartitions.Response)
+
+	if len(apiResp.Results) == 0 {
+		return nil, fmt.Errorf("Empty results")
+	}
+
+	return &CreatePartitionsResponse{
+		ErrorCode:    apiResp.Results[0].ErrorCode,
+		ErrorMessage: apiResp.Results[0].ErrorMessage,
+	}, nil
+}

--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -1,0 +1,103 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/segmentio/kafka-go/protocol/describeconfigs"
+)
+
+type DescribeConfigsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	Topics  []string
+	Brokers []int
+}
+
+type DescribeConfigsResponse struct {
+	Brokers []DescribeConfigsResponseBroker
+	Topics  []DescribeConfigsResponseTopic
+}
+
+type DescribeConfigsResponseBroker struct {
+	BrokerID int
+	Configs  map[string]string
+}
+
+type DescribeConfigsResponseTopic struct {
+	Topic   string
+	Configs map[string]string
+}
+
+func (c *Client) DescribeConfigs(
+	ctx context.Context,
+	req DescribeConfigsRequest,
+) (*DescribeConfigsResponse, error) {
+	resources := []describeconfigs.RequestResource{}
+
+	for _, broker := range req.Brokers {
+		resources = append(
+			resources,
+			describeconfigs.RequestResource{
+				ResourceType: describeconfigs.ResourceTypeBroker,
+				ResourceName: fmt.Sprintf("%d", broker),
+			},
+		)
+	}
+
+	for _, topic := range req.Topics {
+		resources = append(
+			resources,
+			describeconfigs.RequestResource{
+				ResourceType: describeconfigs.ResourceTypeTopic,
+				ResourceName: topic,
+			},
+		)
+	}
+
+	protocolResp, err := c.roundTrip(
+		ctx,
+		req.Addr,
+		&describeconfigs.Request{
+			Resources: resources,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiResp := protocolResp.(*describeconfigs.Response)
+
+	resp := &DescribeConfigsResponse{}
+
+	for _, resource := range apiResp.Resources {
+		configs := map[string]string{}
+		for _, entry := range resource.ConfigEntries {
+			configs[entry.ConfigName] = entry.ConfigValue
+		}
+
+		switch resource.ResourceType {
+		case describeconfigs.ResourceTypeBroker:
+			brokerID, err := strconv.Atoi(resource.ResourceName)
+			if err != nil {
+				return nil, err
+			}
+
+			resp.Brokers = append(resp.Brokers, DescribeConfigsResponseBroker{
+				BrokerID: brokerID,
+				Configs:  configs,
+			})
+		case describeconfigs.ResourceTypeTopic:
+			resp.Topics = append(resp.Topics, DescribeConfigsResponseTopic{
+				Topic:   resource.ResourceName,
+				Configs: configs,
+			})
+		default:
+			return nil, fmt.Errorf("Unrecognized resource type: %d", resource.ResourceType)
+		}
+	}
+
+	return resp, nil
+}

--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 
 	"github.com/segmentio/kafka-go/protocol/describeconfigs"
 )
@@ -60,7 +59,7 @@ func (c *Client) DescribeConfigs(
 		)
 	}
 
-	protocolResp, err := c.roundTrip(
+	protoResp, err := c.roundTrip(
 		ctx,
 		req.Addr,
 		&describeconfigs.Request{
@@ -70,7 +69,7 @@ func (c *Client) DescribeConfigs(
 	if err != nil {
 		return nil, err
 	}
-	apiResp := protocolResp.(*describeconfigs.Response)
+	apiResp := protoResp.(*describeconfigs.Response)
 
 	resp := &DescribeConfigsResponse{}
 
@@ -79,10 +78,6 @@ func (c *Client) DescribeConfigs(
 		case describeconfigs.ResourceTypeBroker:
 			configs := map[string]string{}
 			for _, entry := range resource.ConfigEntries {
-				if resource.ResourceName == "2" && strings.Contains(entry.ConfigName, "throttled") {
-					fmt.Printf("Entry: %+v\n", entry)
-				}
-
 				if !req.IncludeDefaults && (entry.IsDefault ||
 					entry.ConfigSource == describeconfigs.ConfigSourceDefaultConfig ||
 					entry.ConfigSource == describeconfigs.ConfigSourceStaticBrokerConfig ||

--- a/describegroups.go
+++ b/describegroups.go
@@ -52,8 +52,8 @@ type GroupMemberTopic struct {
 }
 
 func (c *Client) DescribeGroup(
-	req DescribeGroupRequest,
 	ctx context.Context,
+	req DescribeGroupRequest,
 ) (*DescribeGroupResponse, error) {
 	protocolResp, err := c.roundTrip(
 		ctx,

--- a/describegroups.go
+++ b/describegroups.go
@@ -60,7 +60,7 @@ func (c *Client) DescribeGroup(
 	ctx context.Context,
 	req DescribeGroupsRequest,
 ) (*DescribeGroupsResponse, error) {
-	protocolResp, err := c.roundTrip(
+	protoResp, err := c.roundTrip(
 		ctx,
 		req.Addr,
 		&describegroups.Request{
@@ -70,7 +70,7 @@ func (c *Client) DescribeGroup(
 	if err != nil {
 		return nil, err
 	}
-	apiResp := protocolResp.(*describegroups.Response)
+	apiResp := protoResp.(*describegroups.Response)
 	resp := &DescribeGroupsResponse{
 		Groups: []DescribeGroupsResponseGroup{},
 	}

--- a/describegroups.go
+++ b/describegroups.go
@@ -107,6 +107,8 @@ func (c *Client) DescribeGroup(
 }
 
 // See http://kafka.apache.org/protocol.html#The_Messages_DescribeGroups
+//
+// TODO: Remove everything below and use protocol-based version above everywhere.
 type describeGroupsRequestV0 struct {
 	// List of groupIds to request metadata for (an empty groupId array
 	// will return empty group metadata).

--- a/electleaders.go
+++ b/electleaders.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/segmentio/kafka-go/protocol/electleaders"
 )
@@ -13,7 +14,8 @@ type ElectLeadersRequest struct {
 
 	Topic      string
 	Partitions []int32
-	TimeoutMs  int32
+
+	Timeout time.Duration
 }
 
 type ElectLeadersResponse struct {
@@ -36,18 +38,18 @@ func (c *Client) ElectLeaders(
 		)
 	}
 
-	protocolResp, err := c.roundTrip(
+	protoResp, err := c.roundTrip(
 		ctx,
 		req.Addr,
 		&electleaders.Request{
 			TopicPartitions: topicPartitions,
-			TimeoutMs:       req.TimeoutMs,
+			TimeoutMs:       int32(req.Timeout.Milliseconds()),
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
-	apiResp := protocolResp.(*electleaders.Response)
+	apiResp := protoResp.(*electleaders.Response)
 
 	return &ElectLeadersResponse{
 		ErrorCode: apiResp.ErrorCode,

--- a/electleaders.go
+++ b/electleaders.go
@@ -1,0 +1,55 @@
+package kafka
+
+import (
+	"context"
+	"net"
+
+	"github.com/segmentio/kafka-go/protocol/electleaders"
+)
+
+type ElectLeadersRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	Topic      string
+	Partitions []int32
+	TimeoutMs  int32
+}
+
+type ElectLeadersResponse struct {
+	ErrorCode int16
+}
+
+func (c *Client) ElectLeaders(
+	ctx context.Context,
+	req ElectLeadersRequest,
+) (*ElectLeadersResponse, error) {
+	topicPartitions := []electleaders.RequestTopicPartition{}
+
+	for _, partition := range req.Partitions {
+		topicPartitions = append(
+			topicPartitions,
+			electleaders.RequestTopicPartition{
+				Topic:       req.Topic,
+				PartitionID: partition,
+			},
+		)
+	}
+
+	protocolResp, err := c.roundTrip(
+		ctx,
+		req.Addr,
+		&electleaders.Request{
+			TopicPartitions: topicPartitions,
+			TimeoutMs:       req.TimeoutMs,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiResp := protocolResp.(*electleaders.Response)
+
+	return &ElectLeadersResponse{
+		ErrorCode: apiResp.ErrorCode,
+	}, nil
+}

--- a/electleaders.go
+++ b/electleaders.go
@@ -19,31 +19,31 @@ type ElectLeadersRequest struct {
 }
 
 type ElectLeadersResponse struct {
-	ErrorCode int16
+	ErrorCode        int16
+	PartitionResults []ElectLeadersResponsePartitionResult
+}
+
+type ElectLeadersResponsePartitionResult struct {
+	Partition    int32
+	ErrorCode    int16
+	ErrorMessage string
 }
 
 func (c *Client) ElectLeaders(
 	ctx context.Context,
 	req ElectLeadersRequest,
 ) (*ElectLeadersResponse, error) {
-	topicPartitions := []electleaders.RequestTopicPartition{}
-
-	for _, partition := range req.Partitions {
-		topicPartitions = append(
-			topicPartitions,
-			electleaders.RequestTopicPartition{
-				Topic:       req.Topic,
-				PartitionID: partition,
-			},
-		)
-	}
-
 	protoResp, err := c.roundTrip(
 		ctx,
 		req.Addr,
 		&electleaders.Request{
-			TopicPartitions: topicPartitions,
-			TimeoutMs:       int32(req.Timeout.Milliseconds()),
+			TopicPartitions: []electleaders.RequestTopicPartitions{
+				{
+					Topic:        req.Topic,
+					PartitionIDs: req.Partitions,
+				},
+			},
+			TimeoutMs: int32(req.Timeout.Milliseconds()),
 		},
 	)
 	if err != nil {
@@ -51,7 +51,22 @@ func (c *Client) ElectLeaders(
 	}
 	apiResp := protoResp.(*electleaders.Response)
 
-	return &ElectLeadersResponse{
+	resp := &ElectLeadersResponse{
 		ErrorCode: apiResp.ErrorCode,
-	}, nil
+	}
+
+	for _, topicResult := range apiResp.ReplicaElectionResults {
+		for _, partitionResult := range topicResult.PartitionResults {
+			resp.PartitionResults = append(
+				resp.PartitionResults,
+				ElectLeadersResponsePartitionResult{
+					Partition:    partitionResult.PartitionID,
+					ErrorCode:    partitionResult.ErrorCode,
+					ErrorMessage: partitionResult.ErrorMessage,
+				},
+			)
+		}
+	}
+
+	return resp, nil
 }

--- a/incrementalalterconfigs.go
+++ b/incrementalalterconfigs.go
@@ -58,7 +58,6 @@ func (c *Client) AlterBrokerConfigs(
 		return nil, err
 	}
 	apiResp := protocolResp.(*incrementalalterconfigs.Response)
-
 	if len(apiResp.Responses) == 0 {
 		return nil, fmt.Errorf("Empty response")
 	}
@@ -77,7 +76,7 @@ func (c *Client) AlterTopicConfigs(
 	apiReq := &incrementalalterconfigs.Request{
 		Resources: []incrementalalterconfigs.RequestResource{
 			{
-				ResourceType: incrementalalterconfigs.ResourceTypeBroker,
+				ResourceType: incrementalalterconfigs.ResourceTypeTopic,
 				ResourceName: req.Topic,
 				Configs:      configs,
 			},

--- a/incrementalalterconfigs.go
+++ b/incrementalalterconfigs.go
@@ -49,7 +49,7 @@ func (c *Client) AlterBrokerConfigs(
 		},
 	}
 
-	protocolResp, err := c.roundTrip(
+	protoResp, err := c.roundTrip(
 		ctx,
 		req.Addr,
 		apiReq,
@@ -57,7 +57,7 @@ func (c *Client) AlterBrokerConfigs(
 	if err != nil {
 		return nil, err
 	}
-	apiResp := protocolResp.(*incrementalalterconfigs.Response)
+	apiResp := protoResp.(*incrementalalterconfigs.Response)
 	if len(apiResp.Responses) == 0 {
 		return nil, fmt.Errorf("Empty response")
 	}
@@ -83,7 +83,7 @@ func (c *Client) AlterTopicConfigs(
 		},
 	}
 
-	protocolResp, err := c.roundTrip(
+	protoResp, err := c.roundTrip(
 		ctx,
 		req.Addr,
 		apiReq,
@@ -91,7 +91,7 @@ func (c *Client) AlterTopicConfigs(
 	if err != nil {
 		return nil, err
 	}
-	apiResp := protocolResp.(*incrementalalterconfigs.Response)
+	apiResp := protoResp.(*incrementalalterconfigs.Response)
 
 	if len(apiResp.Responses) == 0 {
 		return nil, fmt.Errorf("Empty response")

--- a/incrementalalterconfigs.go
+++ b/incrementalalterconfigs.go
@@ -1,0 +1,131 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/segmentio/kafka-go/protocol/incrementalalterconfigs"
+)
+
+type AlterBrokerConfigsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	BrokerID      int
+	ConfigEntries []ConfigEntry
+}
+
+type AlterBrokerConfigsResponse struct {
+	ErrorCode    int16
+	ErrorMessage string
+}
+
+type AlterTopicConfigsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	Topic         string
+	ConfigEntries []ConfigEntry
+}
+
+type AlterTopicConfigsResponse struct {
+	ErrorCode    int16
+	ErrorMessage string
+}
+
+func (c *Client) AlterBrokerConfigs(
+	ctx context.Context,
+	req AlterBrokerConfigsRequest,
+) (*AlterBrokerConfigsResponse, error) {
+	configs := configEntriesToConfigs(req.ConfigEntries)
+	apiReq := &incrementalalterconfigs.Request{
+		Resources: []incrementalalterconfigs.RequestResource{
+			{
+				ResourceType: incrementalalterconfigs.ResourceTypeBroker,
+				ResourceName: fmt.Sprintf("%d", req.BrokerID),
+				Configs:      configs,
+			},
+		},
+	}
+
+	protocolResp, err := c.roundTrip(
+		ctx,
+		req.Addr,
+		apiReq,
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiResp := protocolResp.(*incrementalalterconfigs.Response)
+
+	if len(apiResp.Responses) == 0 {
+		return nil, fmt.Errorf("Empty response")
+	}
+
+	return &AlterBrokerConfigsResponse{
+		ErrorCode:    apiResp.Responses[0].ErrorCode,
+		ErrorMessage: apiResp.Responses[0].ErrorMessage,
+	}, nil
+}
+
+func (c *Client) AlterTopicConfigs(
+	ctx context.Context,
+	req AlterTopicConfigsRequest,
+) (*AlterTopicConfigsResponse, error) {
+	configs := configEntriesToConfigs(req.ConfigEntries)
+	apiReq := &incrementalalterconfigs.Request{
+		Resources: []incrementalalterconfigs.RequestResource{
+			{
+				ResourceType: incrementalalterconfigs.ResourceTypeBroker,
+				ResourceName: req.Topic,
+				Configs:      configs,
+			},
+		},
+	}
+
+	protocolResp, err := c.roundTrip(
+		ctx,
+		req.Addr,
+		apiReq,
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiResp := protocolResp.(*incrementalalterconfigs.Response)
+
+	if len(apiResp.Responses) == 0 {
+		return nil, fmt.Errorf("Empty response")
+	}
+
+	return &AlterTopicConfigsResponse{
+		ErrorCode:    apiResp.Responses[0].ErrorCode,
+		ErrorMessage: apiResp.Responses[0].ErrorMessage,
+	}, nil
+}
+
+func configEntriesToConfigs(entries []ConfigEntry) []incrementalalterconfigs.RequestConfig {
+	configs := []incrementalalterconfigs.RequestConfig{}
+	for _, entry := range entries {
+		if entry.ConfigValue != "" {
+			configs = append(
+				configs,
+				incrementalalterconfigs.RequestConfig{
+					Name:            entry.ConfigName,
+					Value:           entry.ConfigValue,
+					ConfigOperation: incrementalalterconfigs.OpTypeSet,
+				},
+			)
+		} else {
+			configs = append(
+				configs,
+				incrementalalterconfigs.RequestConfig{
+					Name:            entry.ConfigName,
+					ConfigOperation: incrementalalterconfigs.OpTypeDelete,
+				},
+			)
+		}
+	}
+
+	return configs
+}

--- a/listgroups.go
+++ b/listgroups.go
@@ -43,6 +43,7 @@ func (c *Client) ListGroups(
 	return resp, nil
 }
 
+// TODO: Remove everything below and use protocol-based version above everywhere.
 type listGroupsRequestV1 struct {
 }
 

--- a/listgroups.go
+++ b/listgroups.go
@@ -24,8 +24,8 @@ type ConsumerGroupInfo struct {
 }
 
 func (c *Client) ListGroups(
-	req ListGroupsRequest,
 	ctx context.Context,
+	req ListGroupsRequest,
 ) (*ListGroupsResponse, error) {
 	protocolResp, err := c.roundTrip(ctx, req.Addr, &listgroups.Request{})
 	if err != nil {

--- a/listgroups.go
+++ b/listgroups.go
@@ -26,11 +26,11 @@ func (c *Client) ListGroups(
 	ctx context.Context,
 	req ListGroupsRequest,
 ) (*ListGroupsResponse, error) {
-	protocolResp, err := c.roundTrip(ctx, req.Addr, &listgroups.Request{})
+	protoResp, err := c.roundTrip(ctx, req.Addr, &listgroups.Request{})
 	if err != nil {
 		return nil, err
 	}
-	apiResp := protocolResp.(*listgroups.Response)
+	apiResp := protoResp.(*listgroups.Response)
 	resp := &ListGroupsResponse{}
 
 	for _, apiGroupInfo := range apiResp.Groups {

--- a/listgroups.go
+++ b/listgroups.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"bufio"
 	"context"
-	"errors"
 	"net"
 
 	"github.com/segmentio/kafka-go/protocol/listgroups"
@@ -15,10 +14,10 @@ type ListGroupsRequest struct {
 }
 
 type ListGroupsResponse struct {
-	Groups []ConsumerGroupInfo
+	Groups []ListGroupsResponseGroup
 }
 
-type ConsumerGroupInfo struct {
+type ListGroupsResponseGroup struct {
 	GroupID     string
 	Coordinator int32
 }
@@ -31,15 +30,11 @@ func (c *Client) ListGroups(
 	if err != nil {
 		return nil, err
 	}
-	apiResp, ok := protocolResp.(*listgroups.Response)
-	if !ok {
-		return nil, errors.New("Unexpected response type")
-	}
-
+	apiResp := protocolResp.(*listgroups.Response)
 	resp := &ListGroupsResponse{}
 
 	for _, apiGroupInfo := range apiResp.Groups {
-		resp.Groups = append(resp.Groups, ConsumerGroupInfo{
+		resp.Groups = append(resp.Groups, ListGroupsResponseGroup{
 			GroupID:     apiGroupInfo.GroupID,
 			Coordinator: apiGroupInfo.BrokerID,
 		})

--- a/protocol/alterpartitionreassignments/alterpartitionreassignments.go
+++ b/protocol/alterpartitionreassignments/alterpartitionreassignments.go
@@ -9,6 +9,10 @@ func init() {
 type Request struct {
 	TimeoutMs int32          `kafka:"min=v0,max=v0"`
 	Topics    []RequestTopic `kafka:"min=v0,max=v0"`
+
+	// We need at least one tagged field to indicate that this is a "flexible" message
+	// type.
+	_ struct{} `kafka:"min=v0,max=v0,tagId=-1"`
 }
 
 type RequestTopic struct {
@@ -30,6 +34,24 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 }
 
 type Response struct {
+	ThrottleTimeMs int32  `kafka:"min=v0,max=v0"`
+	ErrorCode      int16  `kafka:"min=v0,max=v0"`
+	ErrorMessage   string `kafka:"min=v0,max=v0,compact,nullable"`
+
+	// We need at least one tagged field to indicate that this is a "flexible" message
+	// type.
+	_ struct{} `kafka:"min=v0,max=v0,tagId=-1"`
+}
+
+type ResponseResult struct {
+	Name       string              `kafka:"min=v0,max=v0,compact"`
+	Partitions []ResponsePartition `kafka:"min=v0,max=v0"`
+}
+
+type ResponsePartition struct {
+	PartitionIndex int32
+	ErrorCode      int16
+	ErrorMessage   string `kafka:"min=v0,max=v0,compact,nullable"`
 }
 
 func (r *Response) ApiKey() protocol.ApiKey {

--- a/protocol/alterpartitionreassignments/alterpartitionreassignments.go
+++ b/protocol/alterpartitionreassignments/alterpartitionreassignments.go
@@ -16,13 +16,13 @@ type Request struct {
 }
 
 type RequestTopic struct {
-	Name       string              `kafka:"min=v0,max=v0,compact"`
-	Partitions []RequestPartitions `kafka:"min=v0,max=v0"`
+	Name       string             `kafka:"min=v0,max=v0"`
+	Partitions []RequestPartition `kafka:"min=v0,max=v0"`
 }
 
-type RequestPartitions struct {
-	PartitionIndex int32 `kafka:"min=v0,max=v0"`
-	Replicas       int32 `kafka:"min=v0,max=v0"`
+type RequestPartition struct {
+	PartitionIndex int32   `kafka:"min=v0,max=v0"`
+	Replicas       []int32 `kafka:"min=v0,max=v0"`
 }
 
 func (r *Request) ApiKey() protocol.ApiKey {
@@ -34,9 +34,10 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 }
 
 type Response struct {
-	ThrottleTimeMs int32  `kafka:"min=v0,max=v0"`
-	ErrorCode      int16  `kafka:"min=v0,max=v0"`
-	ErrorMessage   string `kafka:"min=v0,max=v0,compact,nullable"`
+	ThrottleTimeMs int32            `kafka:"min=v0,max=v0"`
+	ErrorCode      int16            `kafka:"min=v0,max=v0"`
+	ErrorMessage   string           `kafka:"min=v0,max=v0,nullable"`
+	Results        []ResponseResult `kafka:"min=v0,max=v0"`
 
 	// We need at least one tagged field to indicate that this is a "flexible" message
 	// type.
@@ -44,14 +45,14 @@ type Response struct {
 }
 
 type ResponseResult struct {
-	Name       string              `kafka:"min=v0,max=v0,compact"`
+	Name       string              `kafka:"min=v0,max=v0"`
 	Partitions []ResponsePartition `kafka:"min=v0,max=v0"`
 }
 
 type ResponsePartition struct {
-	PartitionIndex int32
-	ErrorCode      int16
-	ErrorMessage   string `kafka:"min=v0,max=v0,compact,nullable"`
+	PartitionIndex int32  `kafka:"min=v0,max=v0"`
+	ErrorCode      int16  `kafka:"min=v0,max=v0"`
+	ErrorMessage   string `kafka:"min=v0,max=v0,nullable"`
 }
 
 func (r *Response) ApiKey() protocol.ApiKey {

--- a/protocol/alterpartitionreassignments/alterpartitionreassignments.go
+++ b/protocol/alterpartitionreassignments/alterpartitionreassignments.go
@@ -1,0 +1,37 @@
+package alterpartitionreassignments
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	TimeoutMs int32          `kafka:"min=v0,max=v0"`
+	Topics    []RequestTopic `kafka:"min=v0,max=v0"`
+}
+
+type RequestTopic struct {
+	Name       string              `kafka:"min=v0,max=v0,compact"`
+	Partitions []RequestPartitions `kafka:"min=v0,max=v0"`
+}
+
+type RequestPartitions struct {
+	PartitionIndex int32 `kafka:"min=v0,max=v0"`
+	Replicas       int32 `kafka:"min=v0,max=v0"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey {
+	return protocol.AlterPartitionReassignments
+}
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type Response struct {
+}
+
+func (r *Response) ApiKey() protocol.ApiKey {
+	return protocol.AlterPartitionReassignments
+}

--- a/protocol/conn.go
+++ b/protocol/conn.go
@@ -81,6 +81,7 @@ func (c *Conn) SetVersions(versions map[ApiKey]int16) {
 func (c *Conn) RoundTrip(msg Message) (Message, error) {
 	correlationID := atomic.AddInt32(&c.idgen, +1)
 	versions, _ := c.versions.Load().(map[ApiKey]int16)
+
 	apiVersion := versions[msg.ApiKey()]
 
 	if p, _ := msg.(PreparedMessage); p != nil {

--- a/protocol/createpartitions/createpartitions.go
+++ b/protocol/createpartitions/createpartitions.go
@@ -1,0 +1,41 @@
+package incrementalalterconfigs
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	Topics       []RequestTopic `kafka:"min=v0,max=v1"`
+	TimeoutMs    int32          `kafka:"min=v0,max=v1"`
+	ValidateOnly bool           `kafka:"min=v0,max=v1"`
+}
+
+type RequestTopic struct {
+	Name        string              `kafka:"min=v0,max=v1"`
+	Count       int32               `kafka:"min=v0,max=v1"`
+	Assignments []RequestAssignment `kafka:"min=v0,max=v1"`
+}
+
+type RequestAssignment struct {
+	BrokerIDs []int32 `kafka:"min=v0,max=v1"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.CreatePartitions }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type Response struct {
+	Results []ResponseResult `kafka:"min=v0,max=v1"`
+}
+
+type ResponseResult struct {
+	Name         string `kafka:"min=v0,max=v1"`
+	ErrorCode    int16  `kafka:"min=v0,max=v1"`
+	ErrorMessage string `kafka:"min=v0,max=v1,nullable"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.CreatePartitions }

--- a/protocol/createpartitions/createpartitions.go
+++ b/protocol/createpartitions/createpartitions.go
@@ -1,4 +1,4 @@
-package incrementalalterconfigs
+package createpartitions
 
 import "github.com/segmentio/kafka-go/protocol"
 

--- a/protocol/createpartitions/createpartitions.go
+++ b/protocol/createpartitions/createpartitions.go
@@ -1,6 +1,8 @@
 package createpartitions
 
-import "github.com/segmentio/kafka-go/protocol"
+import (
+	"github.com/segmentio/kafka-go/protocol"
+)
 
 func init() {
 	protocol.Register(&Request{}, &Response{})
@@ -29,7 +31,8 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 }
 
 type Response struct {
-	Results []ResponseResult `kafka:"min=v0,max=v1"`
+	ThrottleTimeMs int32            `kafka:"min=v0,max=v1"`
+	Results        []ResponseResult `kafka:"min=v0,max=v1"`
 }
 
 type ResponseResult struct {

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -318,7 +318,7 @@ func (d *decoder) readUnsignedVarInt() uint64 {
 		n--
 	}
 
-	d.setError(fmt.Errorf("cannot decode varint from input stream"))
+	d.setError(fmt.Errorf("cannot decode unsigned varint from input stream"))
 	return 0
 }
 

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -225,6 +225,14 @@ func (d *decoder) readString() string {
 	}
 }
 
+func (d *decoder) readVarString() string {
+	if n := d.readVarInt(); n < 0 {
+		return ""
+	} else {
+		return bytesToString(d.read(int(n)))
+	}
+}
+
 func (d *decoder) readCompactString() string {
 	if n := d.readUnsignedVarInt(); n < 1 {
 		// TODO: Distinguish between empty and null?
@@ -244,6 +252,23 @@ func (d *decoder) readBytes() []byte {
 
 func (d *decoder) readBytesTo(w io.Writer) bool {
 	if n := d.readInt32(); n < 0 {
+		return false
+	} else {
+		d.writeTo(w, int(n))
+		return d.err == nil
+	}
+}
+
+func (d *decoder) readVarBytes() []byte {
+	if n := d.readVarInt(); n < 0 {
+		return nil
+	} else {
+		return d.read(int(n))
+	}
+}
+
+func (d *decoder) readVarBytesTo(w io.Writer) bool {
+	if n := d.readVarInt(); n < 0 {
 		return false
 	} else {
 		d.writeTo(w, int(n))

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -89,8 +89,16 @@ func (d *decoder) decodeString(v value) {
 	v.setString(d.readString())
 }
 
+func (d *decoder) decodeCompactString(v value) {
+	v.setString(d.readCompactString())
+}
+
 func (d *decoder) decodeBytes(v value) {
 	v.setBytes(d.readBytes())
+}
+
+func (d *decoder) decodeCompactBytes(v value) {
+	v.setBytes(d.readCompactBytes())
 }
 
 func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeFunc) {
@@ -99,6 +107,19 @@ func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeF
 	} else {
 		a := makeArray(elemType, int(n))
 		for i := 0; i < int(n) && d.remain > 0; i++ {
+			decodeElem(d, a.index(i))
+		}
+		v.setArray(a)
+	}
+}
+
+func (d *decoder) decodeCompactArray(v value, elemType reflect.Type, decodeElem decodeFunc) {
+	if n := d.readUnsignedVarInt(); n < 1 {
+		// TODO: Distinguish between empty and null?
+		v.setArray(array{})
+	} else {
+		a := makeArray(elemType, int(n-1))
+		for i := 0; i < int(n-1) && d.remain > 0; i++ {
 			decodeElem(d, a.index(i))
 		}
 		v.setArray(a)
@@ -205,10 +226,11 @@ func (d *decoder) readString() string {
 }
 
 func (d *decoder) readCompactString() string {
-	if n := d.readVarInt(); n < 0 {
+	if n := d.readUnsignedVarInt(); n < 1 {
+		// TODO: Distinguish between empty and null?
 		return ""
 	} else {
-		return bytesToString(d.read(int(n)))
+		return bytesToString(d.read(int(n - 1)))
 	}
 }
 
@@ -230,18 +252,18 @@ func (d *decoder) readBytesTo(w io.Writer) bool {
 }
 
 func (d *decoder) readCompactBytes() []byte {
-	if n := d.readVarInt(); n < 0 {
+	if n := d.readUnsignedVarInt(); n < 1 {
 		return nil
 	} else {
-		return d.read(int(n))
+		return d.read(int(n - 1))
 	}
 }
 
 func (d *decoder) readCompactBytesTo(w io.Writer) bool {
-	if n := d.readVarInt(); n < 0 {
+	if n := d.readUnsignedVarInt(); n < 1 {
 		return false
 	} else {
-		d.writeTo(w, int(n))
+		d.writeTo(w, int(n-1))
 		return d.err == nil
 	}
 }
@@ -262,6 +284,33 @@ func (d *decoder) readVarInt() int64 {
 		if (b & 0x80) == 0 {
 			x |= uint64(b) << s
 			return int64(x>>1) ^ -(int64(x) & 1)
+		}
+
+		x |= uint64(b&0x7f) << s
+		s += 7
+		n--
+	}
+
+	d.setError(fmt.Errorf("cannot decode varint from input stream"))
+	return 0
+}
+
+func (d *decoder) readUnsignedVarInt() uint64 {
+	n := 11 // varints are at most 11 bytes
+
+	if n > d.remain {
+		n = d.remain
+	}
+
+	x := uint64(0)
+	s := uint(0)
+
+	for n > 0 {
+		b := d.readByte()
+
+		if (b & 0x80) == 0 {
+			x |= uint64(b) << s
+			return x
 		}
 
 		x |= uint64(b&0x7f) << s
@@ -298,12 +347,12 @@ func decodeFuncOf(typ reflect.Type, version int16, flexible bool, tag structTag)
 	case reflect.Int64:
 		return (*decoder).decodeInt64
 	case reflect.String:
-		return stringDecodeFuncOf(tag)
+		return stringDecodeFuncOf(flexible, tag)
 	case reflect.Struct:
 		return structDecodeFuncOf(typ, version, flexible)
 	case reflect.Slice:
 		if typ.Elem().Kind() == reflect.Uint8 { // []byte
-			return bytesDecodeFuncOf(tag)
+			return bytesDecodeFuncOf(flexible, tag)
 		}
 		return arrayDecodeFuncOf(typ, version, flexible, tag)
 	default:
@@ -311,12 +360,22 @@ func decodeFuncOf(typ reflect.Type, version int16, flexible bool, tag structTag)
 	}
 }
 
-func stringDecodeFuncOf(tag structTag) decodeFunc {
-	return (*decoder).decodeString
+func stringDecodeFuncOf(flexible bool, tag structTag) decodeFunc {
+	if flexible {
+		// In flexible messages, all strings are compact
+		return (*decoder).decodeCompactString
+	} else {
+		return (*decoder).decodeString
+	}
 }
 
-func bytesDecodeFuncOf(tag structTag) decodeFunc {
-	return (*decoder).decodeBytes
+func bytesDecodeFuncOf(flexible bool, tag structTag) decodeFunc {
+	if flexible {
+		// In flexible messages, all arrays are compact
+		return (*decoder).decodeCompactBytes
+	} else {
+		return (*decoder).decodeBytes
+	}
 }
 
 func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFunc {
@@ -327,7 +386,7 @@ func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFu
 	}
 
 	var fields []field
-	var taggedFields map[int]*field
+	taggedFields := map[int]*field{}
 
 	forEachStructField(typ, func(typ reflect.Type, index index, tag string) {
 		forEachStructTag(tag, func(tag structTag) bool {
@@ -356,15 +415,13 @@ func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFu
 		}
 
 		if flexible {
-			fmt.Println("Decoding flexible fields")
-
 			// See https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields
 			// for details of tag buffers in "flexible" messages.
-			numFields := int(d.readVarInt())
+			numFields := int(d.readUnsignedVarInt())
 
 			for i := 0; i < numFields; i++ {
-				tagID := int(d.readVarInt())
-				size := int(d.readVarInt())
+				tagID := int(d.readUnsignedVarInt())
+				size := int(d.readUnsignedVarInt())
 
 				f, ok := taggedFields[tagID]
 				if ok {
@@ -380,6 +437,11 @@ func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFu
 func arrayDecodeFuncOf(typ reflect.Type, version int16, flexible bool, tag structTag) decodeFunc {
 	elemType := typ.Elem()
 	elemFunc := decodeFuncOf(elemType, version, flexible, tag)
+	if flexible {
+		// In flexible messages, all arrays are compact
+		return func(d *decoder, v value) { d.decodeCompactArray(v, elemType, elemFunc) }
+	}
+
 	return func(d *decoder, v value) { d.decodeArray(v, elemType, elemFunc) }
 }
 

--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -9,6 +9,14 @@ import (
 const (
 	ResourceTypeBroker int8 = 4
 	ResourceTypeTopic  int8 = 2
+
+	ConfigSourceUnknown                    int8 = 0
+	ConfigSourceTopicConfig                int8 = 1
+	ConfigSourceDynamicBrokerConfig        int8 = 2
+	ConfigSourceDynamicDefaultBrokerConfig int8 = 3
+	ConfigSourceStaticBrokerConfig         int8 = 4
+	ConfigSourceDefaultConfig              int8 = 5
+	ConfigSourceDynamicBrokerLoggerConfig  int8 = 6
 )
 
 func init() {
@@ -56,7 +64,7 @@ func (r *Request) Split(cluster protocol.Cluster) (
 	}
 
 	for _, resource := range r.Resources {
-		// Split out broker requests into separate brokers
+		// Split out broker requests to separate brokers
 		if resource.ResourceType == ResourceTypeBroker {
 			messages = append(messages, &Request{
 				Resources: []RequestResource{resource},
@@ -93,7 +101,8 @@ type ResponseConfigEntry struct {
 	ConfigName   string `kafka:"min=v0,max=v3"`
 	ConfigValue  string `kafka:"min=v0,max=v3,nullable"`
 	ReadOnly     bool   `kafka:"min=v0,max=v3"`
-	ConfigSource int8   `kafka:"min=v0,max=v3"`
+	IsDefault    bool   `kafka:"min=v0,max=v0"`
+	ConfigSource int8   `kafka:"min=v1,max=v3"`
 	IsSensitive  bool   `kafka:"min=v0,max=v3"`
 
 	ConfigSynonyms []ResponseConfigSynonym `kafka:"min=v1,max=v3"`

--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -2,6 +2,11 @@ package describeconfigs
 
 import "github.com/segmentio/kafka-go/protocol"
 
+const (
+	ResourceTypeBroker int8 = 4
+	ResourceTypeTopic  int8 = 2
+)
+
 func init() {
 	protocol.Register(&Request{}, &Response{})
 }
@@ -14,7 +19,7 @@ type Request struct {
 
 type RequestResource struct {
 	ResourceType int8     `kafka:"min=v0,max=v3"`
-	ResourceName int16    `kafka:"min=v0,max=v3"`
+	ResourceName string   `kafka:"min=v0,max=v3"`
 	ConfigNames  []string `kafka:"min=v0,max=v3"`
 }
 
@@ -25,7 +30,8 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 }
 
 type Response struct {
-	ThrottleTimeMs int32 `kafka:"min=v0,max=v3"`
+	ThrottleTimeMs int32              `kafka:"min=v0,max=v3"`
+	Resources      []ResponseResource `kafka:"min=v0,max=v3"`
 }
 
 type ResponseResource struct {
@@ -51,9 +57,9 @@ type ResponseConfigEntry struct {
 }
 
 type ResponseConfigSynonym struct {
-	ConfigName   string `kafka:"min=v0,max=v3"`
-	ConfigValue  string `kafka:"min=v0,max=v3,nullable"`
-	ConfigSource int8   `kafka:"min=v0,max=v3"`
+	ConfigName   string `kafka:"min=v1,max=v3"`
+	ConfigValue  string `kafka:"min=v1,max=v3,nullable"`
+	ConfigSource int8   `kafka:"min=v1,max=v3"`
 }
 
 func (r *Response) ApiKey() protocol.ApiKey { return protocol.DescribeConfigs }

--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -1,0 +1,59 @@
+package describeconfigs
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	Resources            []RequestResource `kafka:"min=v0,max=v3"`
+	IncludeSynonyms      bool              `kafka:"min=v1,max=v3"`
+	IncludeDocumentation bool              `kafka:"min=v3,max=v3"`
+}
+
+type RequestResource struct {
+	ResourceType int8     `kafka:"min=v0,max=v3"`
+	ResourceName int16    `kafka:"min=v0,max=v3"`
+	ConfigNames  []string `kafka:"min=v0,max=v3"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.DescribeConfigs }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type Response struct {
+	ThrottleTimeMs int32 `kafka:"min=v0,max=v3"`
+}
+
+type ResponseResource struct {
+	ErrorCode    int16  `kafka:"min=v0,max=v3"`
+	ErrorMessage string `kafka:"min=v0,max=v3,nullable"`
+	ResourceType int8   `kafka:"min=v0,max=v3"`
+	ResourceName string `kafka:"min=v0,max=v3"`
+
+	ConfigEntries []ResponseConfigEntry `kafka:"min=v0,max=v3"`
+}
+
+type ResponseConfigEntry struct {
+	ConfigName   string `kafka:"min=v0,max=v3"`
+	ConfigValue  string `kafka:"min=v0,max=v3,nullable"`
+	ReadOnly     bool   `kafka:"min=v0,max=v3"`
+	ConfigSource int8   `kafka:"min=v0,max=v3"`
+	IsSensitive  bool   `kafka:"min=v0,max=v3"`
+
+	ConfigSynonyms []ResponseConfigSynonym `kafka:"min=v1,max=v3"`
+
+	ConfigType          int8   `kafka:"min=v3,max=v3"`
+	ConfigDocumentation string `kafka:"min=v3,max=v3,nullable"`
+}
+
+type ResponseConfigSynonym struct {
+	ConfigName   string `kafka:"min=v0,max=v3"`
+	ConfigValue  string `kafka:"min=v0,max=v3,nullable"`
+	ConfigSource int8   `kafka:"min=v0,max=v3"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.DescribeConfigs }

--- a/protocol/describegroups/describegroups.go
+++ b/protocol/describegroups/describegroups.go
@@ -1,0 +1,47 @@
+package describegroups
+
+import (
+	"github.com/segmentio/kafka-go/protocol"
+)
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	Groups                      []string `kafka:"min=v0,max=v4"`
+	IncludeAuthorizedOperations bool     `kafka:"min=v3,max=v4"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.DescribeGroups }
+
+func (r *Request) Group() string {
+	// TODO: Handle other groups too (via splitter).
+	return r.Groups[0]
+}
+
+type Response struct {
+	ThrottleTimeMs int32           `kafka:"min=v1,max=v4"`
+	Groups         []ResponseGroup `kafka:"min=v0,max=v4"`
+}
+
+type ResponseGroup struct {
+	ErrorCode            int16                 `kafka:"min=v0,max=v4"`
+	GroupID              string                `kafka:"min=v0,max=v4"`
+	GroupState           string                `kafka:"min=v0,max=v4"`
+	ProtocolType         string                `kafka:"min=v0,max=v4"`
+	ProtocolData         string                `kafka:"min=v0,max=v4"`
+	Members              []ResponseGroupMember `kafka:"min=v0,max=v4"`
+	AuthorizedOperations int32                 `kafka:"min=v3,max=v4"`
+}
+
+type ResponseGroupMember struct {
+	MemberID         string `kafka:"min=v0,max=v4"`
+	GroupInstanceID  string `kafka:"min=v4,max=v4,nullable"`
+	ClientID         string `kafka:"min=v0,max=v4"`
+	ClientHost       string `kafka:"min=v0,max=v4"`
+	MemberMetadata   []byte `kafka:"min=v0,max=v4"`
+	MemberAssignment []byte `kafka:"min=v0,max=v4"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.DescribeGroups }

--- a/protocol/electleaders/electleaders.go
+++ b/protocol/electleaders/electleaders.go
@@ -1,0 +1,43 @@
+package electleaders
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	ElectionType    int8                    `kafka:"min=v1,max=v1"`
+	TopicPartitions []RequestTopicPartition `kafka:"min=v0,max=v1"`
+	TimeoutMs       int32                   `kafka:"min=v0,max=v1"`
+}
+
+type RequestTopicPartition struct {
+	Topic       string
+	PartitionID int32
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.ElectLeaders }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type Response struct {
+	ThrottleTime           int32                           `kafka:"min=v0,max=v1"`
+	ErrorCode              int16                           `kafka:"min=v1,max=v1"`
+	ReplicaElectionResults []ResponseReplicaElectionResult `kafka:"min=v0,max=v1"`
+}
+
+type ResponseReplicaElectionResult struct {
+	Topic            string                    `kafka:"min=v0,max=v1"`
+	PartitionResults []ResponsePartitionResult `kafka:"min=v0,max=v1"`
+}
+
+type ResponsePartitionResult struct {
+	PartitionID  int32  `kafka:"min=v0,max=v1"`
+	ErrorCode    int16  `kafka:"min=v0,max=v1"`
+	ErrorMessage string `kafka:"min=v0,max=v1,nullable"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.ElectLeaders }

--- a/protocol/electleaders/electleaders.go
+++ b/protocol/electleaders/electleaders.go
@@ -7,14 +7,14 @@ func init() {
 }
 
 type Request struct {
-	ElectionType    int8                    `kafka:"min=v1,max=v1"`
-	TopicPartitions []RequestTopicPartition `kafka:"min=v0,max=v1"`
-	TimeoutMs       int32                   `kafka:"min=v0,max=v1"`
+	ElectionType    int8                     `kafka:"min=v1,max=v1"`
+	TopicPartitions []RequestTopicPartitions `kafka:"min=v0,max=v1"`
+	TimeoutMs       int32                    `kafka:"min=v0,max=v1"`
 }
 
-type RequestTopicPartition struct {
-	Topic       string
-	PartitionID int32
+type RequestTopicPartitions struct {
+	Topic        string  `kafka:"min=v0,max=v1"`
+	PartitionIDs []int32 `kafka:"min=v0,max=v1"`
 }
 
 func (r *Request) ApiKey() protocol.ApiKey { return protocol.ElectLeaders }

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -413,7 +413,8 @@ func stringEncodeFuncOf(flexible bool, tag structTag) encodeFunc {
 func bytesEncodeFuncOf(flexible bool, tag structTag) encodeFunc {
 	switch {
 	case flexible:
-		// In flexible messages, all arrays are compact
+		// In flexible messages, all arrays are compact and there is no encoding
+		// distinction between nullable and non-nullable arrays.
 		return (*encoder).encodeCompactBytes
 	case tag.Nullable:
 		return (*encoder).encodeNullBytes
@@ -484,7 +485,8 @@ func arrayEncodeFuncOf(typ reflect.Type, version int16, flexible bool, tag struc
 	elemFunc := encodeFuncOf(elemType, version, flexible, tag)
 	switch {
 	case flexible:
-		// In flexible messages, all arrays are compact
+		// In flexible messages, all arrays are compact and there is no encoding
+		// distinction between nullable and non-nullable arrays.
 		return func(e *encoder, v value) { e.encodeCompactArray(v, elemType, elemFunc) }
 	case tag.Nullable:
 		return func(e *encoder, v value) { e.encodeNullArray(v, elemType, elemFunc) }
@@ -531,7 +533,6 @@ func Marshal(version int16, value interface{}) ([]byte, error) {
 	encode := cache[typ]
 
 	if encode == nil {
-		// TODO:
 		encode = encodeFuncOf(reflect.TypeOf(value), version, false, structTag{
 			MinVersion: -1,
 			MaxVersion: -1,

--- a/protocol/incrementalalterconfigs/incrementalalterconfigs.go
+++ b/protocol/incrementalalterconfigs/incrementalalterconfigs.go
@@ -1,0 +1,44 @@
+package incrementalalterconfigs
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	Resources    []RequestResource `kafka:"min=v0,max=v0"`
+	ValidateOnly bool              `kafka:"min=v0,max=v0"`
+}
+
+type RequestResource struct {
+	ResourceType int8            `kafka:"min=v0,max=v0"`
+	ResourceName string          `kafka:"min=v0,max=v0"`
+	Configs      []RequestConfig `kafka:"min=v0,max=v0"`
+}
+
+type RequestConfig struct {
+	Name            string `kafka:"min=v0,max=v0"`
+	ConfigOperation int8   `kafka:"min=v0,max=v0"`
+	Value           string `kafka:"min=v0,max=v0,nullable"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.IncrementalAlterConfigs }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type Response struct {
+	ThrottleTimeMs int32                   `kafka:"min=v0,max=v0"`
+	Responses      []ResponseAlterResponse `kafka:"min=v0,max=v0"`
+}
+
+type ResponseAlterResponse struct {
+	ErrorCode    int16  `kafka:"min=v0,max=v0"`
+	ErrorMessage string `kafka:"min=v0,max=v0,nullable"`
+	ResourceType int8   `kafka:"min=v0,max=v0"`
+	ResourceName string `kafka:"min=v0,max=v0"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.IncrementalAlterConfigs }

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -1,8 +1,6 @@
 package listgroups
 
 import (
-	"log"
-
 	"github.com/segmentio/kafka-go/protocol"
 )
 
@@ -18,7 +16,6 @@ type Request struct {
 func (r *Request) ApiKey() protocol.ApiKey { return protocol.ListGroups }
 
 func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
-	log.Printf("Getting id for broker %d\n", r.brokerID)
 	return cluster.Brokers[r.brokerID], nil
 }
 

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -2,6 +2,7 @@ package listgroups
 
 import (
 	"errors"
+	"log"
 
 	"github.com/segmentio/kafka-go/protocol"
 )
@@ -17,6 +18,7 @@ type Request struct {
 func (r *Request) ApiKey() protocol.ApiKey { return protocol.ListGroups }
 
 func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	log.Printf("Getting id for broker %d\n", r.brokerID)
 	return cluster.Brokers[r.brokerID], nil
 }
 
@@ -30,6 +32,8 @@ func (r *Request) Split(cluster protocol.Cluster) (
 	for _, broker := range cluster.Brokers {
 		messages = append(messages, &Request{broker.ID})
 	}
+
+	log.Printf("Spliting request into %d subrequests\n", len(messages))
 
 	return nil, new(Response), nil
 }

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -1,0 +1,82 @@
+package listgroups
+
+import (
+	"errors"
+
+	"github.com/segmentio/kafka-go/protocol"
+)
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	brokerID int32
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.ListGroups }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[r.brokerID], nil
+}
+
+func (r *Request) Split(cluster protocol.Cluster) (
+	[]protocol.Message,
+	protocol.Merger,
+	error,
+) {
+	messages := []protocol.Message{}
+
+	for _, broker := range cluster.Brokers {
+		messages = append(messages, &Request{broker.ID})
+	}
+
+	return nil, new(Response), nil
+}
+
+type Response struct {
+	ThrottleTimeMs int32           `kafka:"min=v1,max=v2"`
+	ErrorCode      int16           `kafka:"min=v0,max=v2"`
+	Groups         []ResponseGroup `kafka:"min=v0,max=v2"`
+}
+
+type ResponseGroup struct {
+	GroupID      string `kafka:"min=v0,max=v2"`
+	ProtocolType string `kafka:"min=v0,max=v2"`
+
+	// Use this to store which broker returned the response
+	BrokerID int32 `kafka:"-"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.ListGroups }
+
+func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
+	protocol.Message,
+	error,
+) {
+	response := &Response{}
+
+	for r, result := range results {
+		brokerResp, ok := result.(*Response)
+		if !ok {
+			return nil, errors.New("Unexpected response type")
+		}
+
+		respGroups := []ResponseGroup{}
+
+		for _, brokerResp := range brokerResp.Groups {
+			respGroups = append(
+				respGroups,
+				ResponseGroup{
+					GroupID:      brokerResp.GroupID,
+					ProtocolType: brokerResp.ProtocolType,
+					BrokerID:     requests[r].(*Request).brokerID,
+				},
+			)
+		}
+
+		response.Groups = append(response.Groups, brokerResp.Groups...)
+	}
+
+	return response, nil
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -100,8 +100,10 @@ const (
 	AlterPartitionReassignments ApiKey = 45
 	ListPartitionReassignments  ApiKey = 46
 	OffsetDelete                ApiKey = 47
+	DescribeClientQuotas        ApiKey = 48
+	AlterClientQuotas           ApiKey = 49
 
-	numApis = 48
+	numApis = 50
 )
 
 var apiNames = [numApis]string{
@@ -149,10 +151,12 @@ var apiNames = [numApis]string{
 	DescribeDelegationToken:     "DescribeDelegationToken",
 	DeleteGroups:                "DeleteGroups",
 	ElectLeaders:                "ElectLeaders",
-	IncrementalAlterConfigs:     "IncrementalAlfterConfigs",
+	IncrementalAlterConfigs:     "IncrementalAlterConfigs",
 	AlterPartitionReassignments: "AlterPartitionReassignments",
 	ListPartitionReassignments:  "ListPartitionReassignments",
 	OffsetDelete:                "OffsetDelete",
+	DescribeClientQuotas:        "DescribeClientQuotas",
+	AlterClientQuotas:           "AlterClientQuotas",
 }
 
 type messageType struct {

--- a/protocol/record.go
+++ b/protocol/record.go
@@ -264,8 +264,10 @@ func (rs *RecordSet) WriteTo(w io.Writer) (int64, error) {
 	var err error
 	switch rs.Version {
 	case 0, 1:
+		fmt.Println("Writing to record set version 1")
 		err = rs.writeToVersion1(buffer, bufferOffset+4)
 	case 2:
+		fmt.Println("Writing to record set version 2")
 		err = rs.writeToVersion2(buffer, bufferOffset+4)
 	default:
 		err = fmt.Errorf("unsupported record set version %d", rs.Version)

--- a/protocol/record.go
+++ b/protocol/record.go
@@ -264,10 +264,8 @@ func (rs *RecordSet) WriteTo(w io.Writer) (int64, error) {
 	var err error
 	switch rs.Version {
 	case 0, 1:
-		fmt.Println("Writing to record set version 1")
 		err = rs.writeToVersion1(buffer, bufferOffset+4)
 	case 2:
-		fmt.Println("Writing to record set version 2")
 		err = rs.writeToVersion2(buffer, bufferOffset+4)
 	default:
 		err = fmt.Errorf("unsupported record set version %d", rs.Version)

--- a/protocol/record_v2.go
+++ b/protocol/record_v2.go
@@ -123,8 +123,8 @@ func (rs *RecordSet) readFromVersion2(d *decoder) error {
 
 			for i := range h {
 				h[i] = Header{
-					Key:   dec.readCompactString(),
-					Value: dec.readCompactBytes(),
+					Key:   dec.readVarString(),
+					Value: dec.readVarBytes(),
 				}
 			}
 
@@ -239,12 +239,12 @@ func (rs *RecordSet) writeToVersion2(buffer *pageBuffer, bufferOffset int64) err
 		length := 1 + // attributes
 			sizeOfVarInt(timestampDelta) +
 			sizeOfVarInt(offsetDelta) +
-			sizeOfVarBytes(r.Key) +
-			sizeOfVarBytes(r.Value) +
+			sizeOfVarNullBytesIface(r.Key) +
+			sizeOfVarNullBytesIface(r.Value) +
 			sizeOfVarInt(int64(len(r.Headers)))
 
 		for _, h := range r.Headers {
-			length += sizeOfCompactString(h.Key) + sizeOfCompactNullBytes(h.Value)
+			length += sizeOfVarString(h.Key) + sizeOfVarNullBytes(h.Value)
 		}
 
 		e.writeVarInt(int64(length))
@@ -252,19 +252,19 @@ func (rs *RecordSet) writeToVersion2(buffer *pageBuffer, bufferOffset int64) err
 		e.writeVarInt(timestampDelta)
 		e.writeVarInt(offsetDelta)
 
-		if err := e.writeCompactNullBytesFrom(r.Key); err != nil {
+		if err := e.writeVarNullBytesFrom(r.Key); err != nil {
 			return err
 		}
 
-		if err := e.writeCompactNullBytesFrom(r.Value); err != nil {
+		if err := e.writeVarNullBytesFrom(r.Value); err != nil {
 			return err
 		}
 
 		e.writeVarInt(int64(len(r.Headers)))
 
 		for _, h := range r.Headers {
-			e.writeCompactString(h.Key)
-			e.writeCompactNullBytes(h.Value)
+			e.writeVarString(h.Key)
+			e.writeVarNullBytes(h.Value)
 		}
 
 		numRecords++

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -6,7 +6,13 @@ import (
 	"log"
 )
 
-func ReadRequest(r io.Reader) (apiVersion int16, correlationID int32, clientID string, msg Message, err error) {
+func ReadRequest(r io.Reader) (
+	apiVersion int16,
+	correlationID int32,
+	clientID string,
+	msg Message,
+	err error,
+) {
 	d := &decoder{reader: r, remain: 4}
 	size := d.readInt32()
 
@@ -41,7 +47,13 @@ func ReadRequest(r io.Reader) (apiVersion int16, correlationID int32, clientID s
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		err = fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
+		err = fmt.Errorf(
+			"unsupported %s version: v%d not in range v%d-v%d",
+			apiKey,
+			apiVersion,
+			minVersion,
+			maxVersion,
+		)
 		return
 	}
 
@@ -57,7 +69,13 @@ func ReadRequest(r io.Reader) (apiVersion int16, correlationID int32, clientID s
 	return
 }
 
-func WriteRequest(w io.Writer, apiVersion int16, correlationID int32, clientID string, msg Message) error {
+func WriteRequest(
+	w io.Writer,
+	apiVersion int16,
+	correlationID int32,
+	clientID string,
+	msg Message,
+) error {
 	apiKey := msg.ApiKey()
 
 	if i := int(apiKey); i < 0 || i >= len(apiTypes) {
@@ -73,7 +91,13 @@ func WriteRequest(w io.Writer, apiVersion int16, correlationID int32, clientID s
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		return fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
+		return fmt.Errorf(
+			"unsupported %s version: v%d not in range v%d-v%d",
+			apiKey,
+			apiVersion,
+			minVersion,
+			maxVersion,
+		)
 	}
 
 	log.Printf(

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -118,10 +118,24 @@ func WriteRequest(
 	e.writeInt16(int16(apiKey))
 	e.writeInt16(apiVersion)
 	e.writeInt32(correlationID)
-	// Technically, recent versions of kafka interpret this field as a nullable
-	// string, however kafka 0.10 expected a non-nullable string and fails with
-	// a NullPointerException when it receives a null client id.
-	e.writeString(clientID)
+
+	if r.flexible {
+		fmt.Println(">>>>>> Flexible request")
+		// Flexible uses a compact string for the client ID, then extra space for a
+		// tag buffer, which begins with a size value. Since we're not writing any fields into the
+		// latter, we can just write zero for now.
+		//
+		// See
+		// https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields
+		// for details.
+		e.writeCompactString(clientID)
+		e.writeVarInt(0)
+	} else {
+		// Technically, recent versions of kafka interpret this field as a nullable
+		// string, however kafka 0.10 expected a non-nullable string and fails with
+		// a NullPointerException when it receives a null client id.
+		e.writeString(clientID)
+	}
 	r.encode(e, v)
 	err := e.err
 

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"fmt"
 	"io"
+	"log"
 )
 
 func ReadRequest(r io.Reader) (apiVersion int16, correlationID int32, clientID string, msg Message, err error) {
@@ -74,6 +75,14 @@ func WriteRequest(w io.Writer, apiVersion int16, correlationID int32, clientID s
 	if apiVersion < minVersion || apiVersion > maxVersion {
 		return fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
 	}
+
+	log.Printf(
+		"Making request with apiKey %+v, apiVersion %d, minVersion %d, msg %+v\n",
+		apiKey,
+		apiVersion,
+		minVersion,
+		msg,
+	)
 
 	r := &t.requests[apiVersion-minVersion]
 	v := valueOf(msg)

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -49,11 +49,10 @@ func ReadResponse(
 	res := &t.responses[apiVersion-minVersion]
 
 	if res.flexible {
-		fmt.Println(">>>>>> Flexible response")
 		// In the flexible case, there's room for tagged fields at the end
 		// of the response header. However, we don't currently implement
 		// anything to decode them.
-		tagBufferSize := int(d.readVarInt())
+		tagBufferSize := int(d.readUnsignedVarInt())
 		if tagBufferSize > 0 {
 			d.read(tagBufferSize)
 		}

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -5,7 +5,11 @@ import (
 	"io"
 )
 
-func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID int32, msg Message, err error) {
+func ReadResponse(
+	r io.Reader,
+	apiKey ApiKey,
+	apiVersion int16,
+) (correlationID int32, msg Message, err error) {
 	if i := int(apiKey); i < 0 || i >= len(apiTypes) {
 		err = fmt.Errorf("unsupported api key: %d", i)
 		return
@@ -21,7 +25,13 @@ func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID i
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		err = fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
+		err = fmt.Errorf(
+			"unsupported %s version: v%d not in range v%d-v%d",
+			apiKey,
+			apiVersion,
+			minVersion,
+			maxVersion,
+		)
 		return
 	}
 
@@ -48,7 +58,12 @@ func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID i
 	return
 }
 
-func WriteResponse(w io.Writer, apiVersion int16, correlationID int32, msg Message) error {
+func WriteResponse(
+	w io.Writer,
+	apiVersion int16,
+	correlationID int32,
+	msg Message,
+) error {
 	apiKey := msg.ApiKey()
 
 	if i := int(apiKey); i < 0 || i >= len(apiTypes) {
@@ -64,7 +79,13 @@ func WriteResponse(w io.Writer, apiVersion int16, correlationID int32, msg Messa
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		return fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
+		return fmt.Errorf(
+			"unsupported %s version: v%d not in range v%d-v%d",
+			apiKey,
+			apiVersion,
+			minVersion,
+			maxVersion,
+		)
 	}
 
 	r := &t.responses[apiVersion-minVersion]

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -47,6 +47,18 @@ func ReadResponse(
 	correlationID = d.readInt32()
 
 	res := &t.responses[apiVersion-minVersion]
+
+	if res.flexible {
+		fmt.Println(">>>>>> Flexible response")
+		// In the flexible case, there's room for tagged fields at the end
+		// of the response header. However, we don't currently implement
+		// anything to decode them.
+		tagBufferSize := int(d.readVarInt())
+		if tagBufferSize > 0 {
+			d.read(tagBufferSize)
+		}
+	}
+
 	msg = res.new()
 	res.decode(d, valueOf(msg))
 	d.discardAll()

--- a/protocol/size.go
+++ b/protocol/size.go
@@ -27,28 +27,61 @@ func sizeOfBytes(b []byte) int {
 	return 4 + len(b)
 }
 
-func sizeOfCompactString(s string) int {
+func sizeOfVarString(s string) int {
 	return sizeOfVarInt(int64(len(s))) + len(s)
 }
 
-func sizeOfCompactBytes(b []byte) int {
+func sizeOfCompactString(s string) int {
+	return sizeOfUnsignedVarInt(int64(len(s)+1)) + len(s)
+}
+
+func sizeOfVarBytes(b []byte) int {
 	return sizeOfVarInt(int64(len(b))) + len(b)
+}
+
+func sizeOfCompactBytes(b []byte) int {
+	return sizeOfUnsignedVarInt(int64(len(b)+1)) + len(b)
+}
+
+func sizeOfVarNullString(s string) int {
+	n := len(s)
+	if n == 0 {
+		return sizeOfVarInt(-1)
+	}
+	return sizeOfVarInt(int64(n)) + n
 }
 
 func sizeOfCompactNullString(s string) int {
 	n := len(s)
 	if n == 0 {
-		n = -1
+		return sizeOfUnsignedVarInt(0)
 	}
-	return sizeOfVarInt(int64(n)) + len(s)
+	return sizeOfUnsignedVarInt(int64(n)+1) + n
+}
+
+func sizeOfVarNullBytes(b []byte) int {
+	if b == nil {
+		return sizeOfVarInt(-1)
+	}
+	n := len(b)
+	return sizeOfVarInt(int64(n)) + n
+}
+
+func sizeOfVarNullBytesIface(b Bytes) int {
+	if b == nil {
+		return sizeOfVarInt(-1)
+	} else {
+		n := b.Len()
+		return sizeOfVarInt(int64(n)) + n
+	}
 }
 
 func sizeOfCompactNullBytes(b []byte) int {
 	n := len(b)
 	if b == nil {
-		n = -1
+		return sizeOfUnsignedVarInt(0)
 	}
-	return sizeOfVarInt(int64(n)) + len(b)
+	return sizeOfUnsignedVarInt(int64(n)+1) + n
 }
 
 func sizeOfVarInt(i int64) int {
@@ -63,11 +96,13 @@ func sizeOfVarInt(i int64) int {
 	return n + 1
 }
 
-func sizeOfVarBytes(b Bytes) int {
-	if b == nil {
-		return sizeOfVarInt(-1)
-	} else {
-		n := b.Len()
-		return sizeOfVarInt(int64(n)) + n
+func sizeOfUnsignedVarInt(i int64) int {
+	n := 0
+
+	for i >= 0x80 {
+		i >>= 7
+		n++
 	}
+
+	return n + 1
 }

--- a/transport.go
+++ b/transport.go
@@ -1137,6 +1137,7 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 		return nil, err
 	}
 	res := r.(*apiversions.Response)
+
 	ver := make(map[protocol.ApiKey]int16, len(res.ApiKeys))
 
 	if res.ErrorCode != 0 {

--- a/transport.go
+++ b/transport.go
@@ -628,7 +628,6 @@ func (p *connPool) sendRequest(ctx context.Context, req Request, state connPoolS
 			return reject(err)
 		}
 		brokerID = broker.ID
-
 	case protocol.GroupMessage:
 		// Some requests are supposed to be sent to a group coordinator,
 		// look up which broker is currently the coordinator for the group

--- a/transport.go
+++ b/transport.go
@@ -628,6 +628,7 @@ func (p *connPool) sendRequest(ctx context.Context, req Request, state connPoolS
 			return reject(err)
 		}
 		brokerID = broker.ID
+
 	case protocol.GroupMessage:
 		// Some requests are supposed to be sent to a group coordinator,
 		// look up which broker is currently the coordinator for the group
@@ -1137,7 +1138,6 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 		return nil, err
 	}
 	res := r.(*apiversions.Response)
-
 	ver := make(map[protocol.ApiKey]int16, len(res.ApiKeys))
 
 	if res.ErrorCode != 0 {


### PR DESCRIPTION
## Description
This change extends kafka-go to support some additional APIs and newer protocols.

The new APIs (added into the existing client) are:

1. `AlterPartitionReassignments`
2. `CreatePartitions`
3. `DescribeConfigs`
4. `ElectLeaders`
5. `IncrementalAlterConfigs`

It also adds some existing APIs into the client more directly so they can be more easily used by `topicctl` and other apps:

1. `ApiVersions`
2. `DescribeGroups`
3. `ListGroups`

The `AlterPartitionReassignments` API only supports the new, "flexible" message format described in https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields. Since this isn't supported in kafka-go currently, this change also adds basic support for this new protocol.

The proposed interface for this is via extra tags on struct fields, e.g.:

```
type Request struct {
    [non-optional fields]

    TaggedField0 `kafka:"min=v0,max=v0,tagId=0"`
    TaggedField1 `kafka:"min=v0,max=v0,tagId=1"`
   ...
}
```

If a version has any `tagId` fields set, then it's considered "flexible" and the new protocol is used. Otherwise, we continue to use the old, non-flexible protocol.

For now, it looks like tags are not actively used in the API, so I've just put placeholders into the `AlterPartitionReassignments` structs so that the encoder and decoder know to use the "flexible" format.

I've tested these changes on a v2.4.1 cluster via `topicctl`, but if the initial approach looks good I can add more unit tests into this change.

Some other, miscellaneous notes:
1. KIP-482 defines new, "compact" encodings that are different from the ones currently defined in the kafka-go procotol. I've renamed the latter from "compact" to "var", e.g. `VarString`, `VarBytes`, etc. to distinguish them.
2. In "flexible" messages, it seems that all strings and arrays are compact by default. So, there is no need to add extra tags to indicate these things.
