### PR TITLE
Add support for flexible messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,14 +177,14 @@ jobs:
       KAFKA_VERSION: "2.4.1"
 
       # Need to skip nettest to avoid these kinds of errors:
-      #     --- FAIL: TestConn/nettest (17.56s)
-      #  --- FAIL: TestConn/nettest/PingPong (7.40s)
+      #  --- FAIL: TestConn/nettest (17.56s)
+      #    --- FAIL: TestConn/nettest/PingPong (7.40s)
       #      conntest.go:112: unexpected Read error: [7] Request Timed Out: the request exceeded the user-specified time limit in the request
       #      conntest.go:118: mismatching value: got 77, want 78
       #      conntest.go:118: mismatching value: got 78, want 79
       # ...
       #
-      # TODO: Figure out why these are happening and fix them (don't appear to be new).
+      # TODO: Figure out why these are happening and fix them (they don't appear to be new).
       KAFKA_SKIP_NETTEST: "1"
     docker:
     - image: circleci/golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
     working_directory: *working_directory
     environment:
       KAFKA_VERSION: "2.4.1"
+      KAFKA_SKIP_CONNTEST: "1"
     docker:
     - image: circleci/golang
     - image: wurstmeister/zookeeper

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,22 @@ jobs:
       environment: *environment
     steps: *steps
 
+  kafka-241:
+    working_directory: *working_directory
+    environment:
+      KAFKA_VERSION: "2.4.1"
+    docker:
+    - image: circleci/golang
+    - image: wurstmeister/zookeeper
+      ports:
+      - 2181:2181
+    - image: wurstmeister/kafka:2.12-2.4.1
+      ports:
+      - 9092:9092
+      - 9093:9093
+      environment: *environment
+    steps: *steps
+
 workflows:
   version: 2
   run:
@@ -183,3 +199,4 @@ workflows:
     - kafka-211
     - kafka-222
     - kafka-231
+    - kafka-241

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,16 @@ jobs:
     working_directory: *working_directory
     environment:
       KAFKA_VERSION: "2.4.1"
+
+      # Need to skip nettest to avoid these kinds of errors:
+      #     --- FAIL: TestConn/nettest (17.56s)
+      #  --- FAIL: TestConn/nettest/PingPong (7.40s)
+      #      conntest.go:112: unexpected Read error: [7] Request Timed Out: the request exceeded the user-specified time limit in the request
+      #      conntest.go:118: mismatching value: got 77, want 78
+      #      conntest.go:118: mismatching value: got 78, want 79
+      # ...
+      #
+      # TODO: Figure out why these are happening and fix them (don't appear to be new).
       KAFKA_SKIP_NETTEST: "1"
     docker:
     - image: circleci/golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
     working_directory: *working_directory
     environment:
       KAFKA_VERSION: "2.4.1"
-      KAFKA_SKIP_CONNTEST: "1"
+      KAFKA_SKIP_NETTEST: "1"
     docker:
     - image: circleci/golang
     - image: wurstmeister/zookeeper

--- a/conn_test.go
+++ b/conn_test.go
@@ -294,7 +294,15 @@ func TestConn(t *testing.T) {
 	}
 
 	t.Run("nettest", func(t *testing.T) {
-		// TODO: Remove this once we figure out why these tests are failing with v2.4.1.
+		// Need ability to skip nettest on newer Kafka versions to avoid these kinds of errors:
+		//  --- FAIL: TestConn/nettest (17.56s)
+		//    --- FAIL: TestConn/nettest/PingPong (7.40s)
+		//      conntest.go:112: unexpected Read error: [7] Request Timed Out: the request exceeded the user-specified time limit in the request
+		//      conntest.go:118: mismatching value: got 77, want 78
+		//      conntest.go:118: mismatching value: got 78, want 79
+		// ...
+		//
+		// TODO: Figure out why these are happening and fix them (they don't appear to be new).
 		if _, ok := os.LookupEnv("KAFKA_SKIP_NETTEST"); ok {
 			t.Log("skipping nettest because KAFKA_SKIP_NETTEST is set")
 			t.Skip()

--- a/conn_test.go
+++ b/conn_test.go
@@ -273,12 +273,6 @@ func TestConn(t *testing.T) {
 			continue
 		}
 
-		// TODO: Remove this once we figure out why these tests are failing with v2.4.1.
-		if _, ok := os.LookupEnv("KAFKA_SKIP_CONNTEST"); ok {
-			t.Log("skipping " + test.scenario + " because KAFKA_SKIP_CONNTEST is set")
-			continue
-		}
-
 		testFunc := test.function
 		t.Run(test.scenario, func(t *testing.T) {
 			t.Parallel()
@@ -300,6 +294,12 @@ func TestConn(t *testing.T) {
 	}
 
 	t.Run("nettest", func(t *testing.T) {
+		// TODO: Remove this once we figure out why these tests are failing with v2.4.1.
+		if _, ok := os.LookupEnv("KAFKA_SKIP_NETTEST"); ok {
+			t.Log("skipping nettest because KAFKA_SKIP_NETTEST is set")
+			t.Skip()
+		}
+
 		t.Parallel()
 
 		nettest.TestConn(t, func() (c1 net.Conn, c2 net.Conn, stop func(), err error) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -269,6 +270,12 @@ func TestConn(t *testing.T) {
 	for _, test := range tests {
 		if !ktesting.KafkaIsAtLeast(test.minVersion) {
 			t.Log("skipping " + test.scenario + " because broker is not at least version " + test.minVersion)
+			continue
+		}
+
+		// TODO: Remove this once we figure out why these tests are failing with v2.4.1.
+		if _, ok := os.LookupEnv("KAFKA_SKIP_CONNTEST"); ok {
+			t.Log("skipping " + test.scenario + " because KAFKA_SKIP_CONNTEST is set")
 			continue
 		}
 

--- a/createtopics_test.go
+++ b/createtopics_test.go
@@ -27,13 +27,27 @@ func TestClientCreateTopics(t *testing.T) {
 		Topics: []TopicConfig{
 			{
 				Topic:             topic1,
-				NumPartitions:     1,
-				ReplicationFactor: 1,
-				ConfigEntries:     config,
+				NumPartitions:     -1,
+				ReplicationFactor: -1,
+				ReplicaAssignments: []ReplicaAssignment{
+					{
+						Partition: 0,
+						Replicas:  []int{1},
+					},
+					{
+						Partition: 1,
+						Replicas:  []int{1},
+					},
+					{
+						Partition: 2,
+						Replicas:  []int{1},
+					},
+				},
+				ConfigEntries: config,
 			},
 			{
 				Topic:             topic2,
-				NumPartitions:     1,
+				NumPartitions:     2,
 				ReplicationFactor: 1,
 				ConfigEntries:     config,
 			},

--- a/docker-compose-241.yml
+++ b/docker-compose-241.yml
@@ -1,0 +1,32 @@
+version: "3"
+services:
+  kafka:
+    image: wurstmeister/kafka:2.12-2.4.1
+    restart: on-failure:3
+    links:
+    - zookeeper
+    ports:
+    - 9092:9092
+    - 9093:9093
+    environment:
+      KAFKA_VERSION: '2.4.1'
+      KAFKA_BROKER_ID: '1'
+      KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
+      KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+      KAFKA_ADVERTISED_PORT: '9092'
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_MESSAGE_MAX_BYTES: '200000000'
+      KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+      CUSTOM_INIT_SCRIPT: |-
+        echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+        /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+    - 2181:2181

--- a/protocol/createtopics/createtopics.go
+++ b/protocol/createtopics/createtopics.go
@@ -7,9 +7,13 @@ func init() {
 }
 
 type Request struct {
-	Topics       []RequestTopic `kafka:"min=v0,max=v4"`
-	TimeoutMs    int32          `kafka:"min=v0,max=v4"`
-	ValidateOnly bool           `kafka:"min=v1,max=v4"`
+	Topics       []RequestTopic `kafka:"min=v0,max=v5"`
+	TimeoutMs    int32          `kafka:"min=v0,max=v5"`
+	ValidateOnly bool           `kafka:"min=v1,max=v5"`
+
+	// We need at least one tagged field to indicate that v5+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v5,max=v5,tag=-1"`
 }
 
 func (r *Request) ApiKey() protocol.ApiKey { return protocol.CreateTopics }
@@ -19,34 +23,50 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 }
 
 type RequestTopic struct {
-	Name              string              `kafka:"min=v0,max=v4"`
-	NumPartitions     int32               `kafka:"min=v0,max=v4"`
-	ReplicationFactor int16               `kafka:"min=v0,max=v4"`
-	Assignments       []RequestAssignment `kafka:"min=v0,max=v4"`
-	Configs           []RequestConfig     `kafka:"min=v0,max=v4"`
+	Name              string              `kafka:"min=v0,max=v5"`
+	NumPartitions     int32               `kafka:"min=v0,max=v5"`
+	ReplicationFactor int16               `kafka:"min=v0,max=v5"`
+	Assignments       []RequestAssignment `kafka:"min=v0,max=v5"`
+	Configs           []RequestConfig     `kafka:"min=v0,max=v5"`
 }
 
 type RequestAssignment struct {
-	PartitionIndex int32   `kafka:"min=v0,max=v4"`
-	BrokerIDs      []int32 `kafka:"min=v0,max=v4"`
+	PartitionIndex int32   `kafka:"min=v0,max=v5"`
+	BrokerIDs      []int32 `kafka:"min=v0,max=v5"`
 }
 
 type RequestConfig struct {
-	Name  string `kafka:"min=v0,max=v4"`
-	Value string `kafka:"min=v0,max=v4,nullable"`
+	Name  string `kafka:"min=v0,max=v5"`
+	Value string `kafka:"min=v0,max=v5,nullable"`
 }
 
 type Response struct {
-	ThrottleTimeMs int32           `kafka:"min=v2,max=v4"`
-	Topics         []ResponseTopic `kafka:"min=v0,max=v4"`
+	ThrottleTimeMs int32           `kafka:"min=v2,max=v5"`
+	Topics         []ResponseTopic `kafka:"min=v0,max=v5"`
+
+	// We need at least one tagged field to indicate that v5+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v5,max=v5,tag=-1"`
 }
 
 func (r *Response) ApiKey() protocol.ApiKey { return protocol.CreateTopics }
 
 type ResponseTopic struct {
-	Name         string `kafka:"min=v0,max=v4"`
-	ErrorCode    int16  `kafka:"min=v0,max=v4"`
-	ErrorMessage string `kafka:"min=v1,max=v4,nullable"`
+	Name              string `kafka:"min=v0,max=v5"`
+	ErrorCode         int16  `kafka:"min=v0,max=v5"`
+	ErrorMessage      string `kafka:"min=v1,max=v5,nullable"`
+	NumPartitions     int32  `kafka:"min=v5,max=v5"`
+	ReplicationFactor int16  `kafka:"min=v5,max=v5"`
+
+	Configs []ResponseTopicConfig `kafka:"min=v5,max=v5"`
+}
+
+type ResponseTopicConfig struct {
+	Name         string `kafka:"min=v5,max=v5"`
+	Value        string `kafka:"min=v5,max=v5,nullable"`
+	ReadOnly     bool   `kafka:"min=v5,max=v5"`
+	ConfigSource int8   `kafka:"min=v5,max=v5"`
+	IsSensitive  bool   `kafka:"min=v5,max=v5"`
 }
 
 var (

--- a/protocol/createtopics/createtopics.go
+++ b/protocol/createtopics/createtopics.go
@@ -7,13 +7,13 @@ func init() {
 }
 
 type Request struct {
+	// We need at least one tagged field to indicate that v5+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v5,max=v5,tag"`
+
 	Topics       []RequestTopic `kafka:"min=v0,max=v5"`
 	TimeoutMs    int32          `kafka:"min=v0,max=v5"`
 	ValidateOnly bool           `kafka:"min=v1,max=v5"`
-
-	// We need at least one tagged field to indicate that v5+ uses "flexible"
-	// messages.
-	_ struct{} `kafka:"min=v5,max=v5,tag=-1"`
 }
 
 func (r *Request) ApiKey() protocol.ApiKey { return protocol.CreateTopics }
@@ -41,12 +41,12 @@ type RequestConfig struct {
 }
 
 type Response struct {
-	ThrottleTimeMs int32           `kafka:"min=v2,max=v5"`
-	Topics         []ResponseTopic `kafka:"min=v0,max=v5"`
-
 	// We need at least one tagged field to indicate that v5+ uses "flexible"
 	// messages.
-	_ struct{} `kafka:"min=v5,max=v5,tag=-1"`
+	_ struct{} `kafka:"min=v5,max=v5,tag"`
+
+	ThrottleTimeMs int32           `kafka:"min=v2,max=v5"`
+	Topics         []ResponseTopic `kafka:"min=v0,max=v5"`
 }
 
 func (r *Response) ApiKey() protocol.ApiKey { return protocol.CreateTopics }

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -419,8 +419,10 @@ func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFu
 				}
 
 				if tag.TagID < -1 {
+					// Normal required field
 					fields = append(fields, f)
 				} else {
+					// Optional tagged field (flexible messages only)
 					taggedFields[tag.TagID] = &f
 				}
 				return false

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -441,9 +441,9 @@ func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFu
 		if flexible {
 			// See https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields
 			// for details of tag buffers in "flexible" messages.
-			numFields := int(d.readUnsignedVarInt())
+			n := int(d.readUnsignedVarInt())
 
-			for i := 0; i < numFields; i++ {
+			for i := 0; i < n; i++ {
 				tagID := int(d.readUnsignedVarInt())
 				size := int(d.readUnsignedVarInt())
 

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -387,18 +387,16 @@ func stringDecodeFuncOf(flexible bool, tag structTag) decodeFunc {
 	if flexible {
 		// In flexible messages, all strings are compact
 		return (*decoder).decodeCompactString
-	} else {
-		return (*decoder).decodeString
 	}
+	return (*decoder).decodeString
 }
 
 func bytesDecodeFuncOf(flexible bool, tag structTag) decodeFunc {
 	if flexible {
 		// In flexible messages, all arrays are compact
 		return (*decoder).decodeCompactBytes
-	} else {
-		return (*decoder).decodeBytes
 	}
+	return (*decoder).decodeBytes
 }
 
 func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFunc {

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -234,7 +234,6 @@ func (d *decoder) readVarString() string {
 
 func (d *decoder) readCompactString() string {
 	if n := d.readUnsignedVarInt(); n < 1 {
-		// TODO: Distinguish between empty and null?
 		return ""
 	} else {
 		return bytesToString(d.read(int(n - 1)))

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -115,7 +115,6 @@ func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeF
 
 func (d *decoder) decodeCompactArray(v value, elemType reflect.Type, decodeElem decodeFunc) {
 	if n := d.readUnsignedVarInt(); n < 1 {
-		// TODO: Distinguish between empty and null?
 		v.setArray(array{})
 	} else {
 		a := makeArray(elemType, int(n-1))

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -89,8 +89,16 @@ func (d *decoder) decodeString(v value) {
 	v.setString(d.readString())
 }
 
+func (d *decoder) decodeCompactString(v value) {
+	v.setString(d.readCompactString())
+}
+
 func (d *decoder) decodeBytes(v value) {
 	v.setBytes(d.readBytes())
+}
+
+func (d *decoder) decodeCompactBytes(v value) {
+	v.setBytes(d.readCompactBytes())
 }
 
 func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeFunc) {
@@ -99,6 +107,19 @@ func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeF
 	} else {
 		a := makeArray(elemType, int(n))
 		for i := 0; i < int(n) && d.remain > 0; i++ {
+			decodeElem(d, a.index(i))
+		}
+		v.setArray(a)
+	}
+}
+
+func (d *decoder) decodeCompactArray(v value, elemType reflect.Type, decodeElem decodeFunc) {
+	if n := d.readUnsignedVarInt(); n < 1 {
+		// TODO: Distinguish between empty and null?
+		v.setArray(array{})
+	} else {
+		a := makeArray(elemType, int(n-1))
+		for i := 0; i < int(n-1) && d.remain > 0; i++ {
 			decodeElem(d, a.index(i))
 		}
 		v.setArray(a)
@@ -204,11 +225,20 @@ func (d *decoder) readString() string {
 	}
 }
 
-func (d *decoder) readCompactString() string {
+func (d *decoder) readVarString() string {
 	if n := d.readVarInt(); n < 0 {
 		return ""
 	} else {
 		return bytesToString(d.read(int(n)))
+	}
+}
+
+func (d *decoder) readCompactString() string {
+	if n := d.readUnsignedVarInt(); n < 1 {
+		// TODO: Distinguish between empty and null?
+		return ""
+	} else {
+		return bytesToString(d.read(int(n - 1)))
 	}
 }
 
@@ -229,7 +259,7 @@ func (d *decoder) readBytesTo(w io.Writer) bool {
 	}
 }
 
-func (d *decoder) readCompactBytes() []byte {
+func (d *decoder) readVarBytes() []byte {
 	if n := d.readVarInt(); n < 0 {
 		return nil
 	} else {
@@ -237,11 +267,28 @@ func (d *decoder) readCompactBytes() []byte {
 	}
 }
 
-func (d *decoder) readCompactBytesTo(w io.Writer) bool {
+func (d *decoder) readVarBytesTo(w io.Writer) bool {
 	if n := d.readVarInt(); n < 0 {
 		return false
 	} else {
 		d.writeTo(w, int(n))
+		return d.err == nil
+	}
+}
+
+func (d *decoder) readCompactBytes() []byte {
+	if n := d.readUnsignedVarInt(); n < 1 {
+		return nil
+	} else {
+		return d.read(int(n - 1))
+	}
+}
+
+func (d *decoder) readCompactBytesTo(w io.Writer) bool {
+	if n := d.readUnsignedVarInt(); n < 1 {
+		return false
+	} else {
+		d.writeTo(w, int(n-1))
 		return d.err == nil
 	}
 }
@@ -273,6 +320,33 @@ func (d *decoder) readVarInt() int64 {
 	return 0
 }
 
+func (d *decoder) readUnsignedVarInt() uint64 {
+	n := 11 // varints are at most 11 bytes
+
+	if n > d.remain {
+		n = d.remain
+	}
+
+	x := uint64(0)
+	s := uint(0)
+
+	for n > 0 {
+		b := d.readByte()
+
+		if (b & 0x80) == 0 {
+			x |= uint64(b) << s
+			return x
+		}
+
+		x |= uint64(b&0x7f) << s
+		s += 7
+		n--
+	}
+
+	d.setError(fmt.Errorf("cannot decode unsigned varint from input stream"))
+	return 0
+}
+
 type decodeFunc func(*decoder, value)
 
 var (
@@ -282,7 +356,7 @@ var (
 	readerFrom = reflect.TypeOf((*io.ReaderFrom)(nil)).Elem()
 )
 
-func decodeFuncOf(typ reflect.Type, version int16, tag structTag) decodeFunc {
+func decodeFuncOf(typ reflect.Type, version int16, flexible bool, tag structTag) decodeFunc {
 	if reflect.PtrTo(typ).Implements(readerFrom) {
 		return readerDecodeFuncOf(typ)
 	}
@@ -298,41 +372,61 @@ func decodeFuncOf(typ reflect.Type, version int16, tag structTag) decodeFunc {
 	case reflect.Int64:
 		return (*decoder).decodeInt64
 	case reflect.String:
-		return stringDecodeFuncOf(tag)
+		return stringDecodeFuncOf(flexible, tag)
 	case reflect.Struct:
-		return structDecodeFuncOf(typ, version)
+		return structDecodeFuncOf(typ, version, flexible)
 	case reflect.Slice:
 		if typ.Elem().Kind() == reflect.Uint8 { // []byte
-			return bytesDecodeFuncOf(tag)
+			return bytesDecodeFuncOf(flexible, tag)
 		}
-		return arrayDecodeFuncOf(typ, version, tag)
+		return arrayDecodeFuncOf(typ, version, flexible, tag)
 	default:
 		panic("unsupported type: " + typ.String())
 	}
 }
 
-func stringDecodeFuncOf(tag structTag) decodeFunc {
-	return (*decoder).decodeString
+func stringDecodeFuncOf(flexible bool, tag structTag) decodeFunc {
+	if flexible {
+		// In flexible messages, all strings are compact
+		return (*decoder).decodeCompactString
+	} else {
+		return (*decoder).decodeString
+	}
 }
 
-func bytesDecodeFuncOf(tag structTag) decodeFunc {
-	return (*decoder).decodeBytes
+func bytesDecodeFuncOf(flexible bool, tag structTag) decodeFunc {
+	if flexible {
+		// In flexible messages, all arrays are compact
+		return (*decoder).decodeCompactBytes
+	} else {
+		return (*decoder).decodeBytes
+	}
 }
 
-func structDecodeFuncOf(typ reflect.Type, version int16) decodeFunc {
+func structDecodeFuncOf(typ reflect.Type, version int16, flexible bool) decodeFunc {
 	type field struct {
 		decode decodeFunc
 		index  index
+		tagID  int
 	}
 
 	var fields []field
+	taggedFields := map[int]*field{}
+
 	forEachStructField(typ, func(typ reflect.Type, index index, tag string) {
 		forEachStructTag(tag, func(tag structTag) bool {
 			if tag.MinVersion <= version && version <= tag.MaxVersion {
-				fields = append(fields, field{
-					decode: decodeFuncOf(typ, version, tag),
+				f := field{
+					decode: decodeFuncOf(typ, version, flexible, tag),
 					index:  index,
-				})
+					tagID:  tag.TagID,
+				}
+
+				if tag.TagID < -1 {
+					fields = append(fields, f)
+				} else {
+					taggedFields[tag.TagID] = &f
+				}
 				return false
 			}
 			return true
@@ -344,12 +438,35 @@ func structDecodeFuncOf(typ reflect.Type, version int16) decodeFunc {
 			f := &fields[i]
 			f.decode(d, v.fieldByIndex(f.index))
 		}
+
+		if flexible {
+			// See https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields
+			// for details of tag buffers in "flexible" messages.
+			numFields := int(d.readUnsignedVarInt())
+
+			for i := 0; i < numFields; i++ {
+				tagID := int(d.readUnsignedVarInt())
+				size := int(d.readUnsignedVarInt())
+
+				f, ok := taggedFields[tagID]
+				if ok {
+					f.decode(d, v.fieldByIndex(f.index))
+				} else {
+					d.read(size)
+				}
+			}
+		}
 	}
 }
 
-func arrayDecodeFuncOf(typ reflect.Type, version int16, tag structTag) decodeFunc {
+func arrayDecodeFuncOf(typ reflect.Type, version int16, flexible bool, tag structTag) decodeFunc {
 	elemType := typ.Elem()
-	elemFunc := decodeFuncOf(elemType, version, tag)
+	elemFunc := decodeFuncOf(elemType, version, flexible, tag)
+	if flexible {
+		// In flexible messages, all arrays are compact
+		return func(d *decoder, v value) { d.decodeCompactArray(v, elemType, elemFunc) }
+	}
+
 	return func(d *decoder, v value) { d.decodeArray(v, elemType, elemFunc) }
 }
 
@@ -387,9 +504,10 @@ func Unmarshal(data []byte, version int16, value interface{}) error {
 	decode := cache[typ]
 
 	if decode == nil {
-		decode = decodeFuncOf(reflect.TypeOf(value).Elem(), version, structTag{
+		decode = decodeFuncOf(reflect.TypeOf(value).Elem(), version, false, structTag{
 			MinVersion: -1,
 			MaxVersion: -1,
+			TagID:      -2,
 			Compact:    true,
 			Nullable:   true,
 		})

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -513,8 +513,10 @@ func structEncodeFuncOf(typ reflect.Type, version int16, flexible bool) encodeFu
 					}
 
 					if tag.TagID < -1 {
+						// Normal required field
 						fields = append(fields, f)
 					} else {
+						// Optional tagged field (flexible messages only)
 						taggedFields = append(taggedFields, f)
 					}
 					return false

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -386,22 +386,7 @@ func (e *encoder) writeCompactNullBytesFrom(b Bytes) error {
 }
 
 func (e *encoder) writeVarInt(i int64) {
-	b := e.buffer[:]
-	u := uint64((i << 1) ^ (i >> 63))
-	n := 0
-
-	for u >= 0x80 && n < len(b) {
-		b[n] = byte(u) | 0x80
-		u >>= 7
-		n++
-	}
-
-	if n < len(b) {
-		b[n] = byte(u)
-		n++
-	}
-
-	e.Write(b[:n])
+	e.writeUnsignedVarInt(uint64((i << 1) ^ (i >> 63)))
 }
 
 func (e *encoder) writeUnsignedVarInt(i uint64) {

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -536,7 +536,7 @@ func structEncodeFuncOf(typ reflect.Type, version int16, flexible bool) encodeFu
 			e.writeUnsignedVarInt(uint64(len(taggedFields)))
 
 			for i := range taggedFields {
-				f := &fields[i]
+				f := &taggedFields[i]
 				e.writeUnsignedVarInt(uint64(f.tagID))
 
 				buf := &bytes.Buffer{}

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -386,30 +386,15 @@ func (e *encoder) writeCompactNullBytesFrom(b Bytes) error {
 }
 
 func (e *encoder) writeVarInt(i int64) {
-	b := e.buffer[:]
-	u := uint64((i << 1) ^ (i >> 63))
-	n := 0
-
-	for u >= 0x80 && n < len(b) {
-		b[n] = byte(u) | 0x80
-		u >>= 7
-		n++
-	}
-
-	if n < len(b) {
-		b[n] = byte(u)
-		n++
-	}
-
-	e.Write(b[:n])
+	e.writeUnsignedVarInt(uint64((i << 1) ^ (i >> 63)))
 }
 
 func (e *encoder) writeUnsignedVarInt(i uint64) {
 	b := e.buffer[:]
 	n := 0
 
-	for i > 0x80 && n < len(b) {
-		b[n] = byte(i)&0x7f | 0x80
+	for i >= 0x80 && n < len(b) {
+		b[n] = byte(i) | 0x80
 		i >>= 7
 		n++
 	}

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -133,16 +133,48 @@ func (e *encoder) encodeString(v value) {
 	e.writeString(v.string())
 }
 
+func (e *encoder) encodeVarString(v value) {
+	e.writeVarString(v.string())
+}
+
+func (e *encoder) encodeCompactString(v value) {
+	e.writeCompactString(v.string())
+}
+
 func (e *encoder) encodeNullString(v value) {
 	e.writeNullString(v.string())
+}
+
+func (e *encoder) encodeVarNullString(v value) {
+	e.writeVarNullString(v.string())
+}
+
+func (e *encoder) encodeCompactNullString(v value) {
+	e.writeCompactNullString(v.string())
 }
 
 func (e *encoder) encodeBytes(v value) {
 	e.writeBytes(v.bytes())
 }
 
+func (e *encoder) encodeVarBytes(v value) {
+	e.writeVarBytes(v.bytes())
+}
+
+func (e *encoder) encodeCompactBytes(v value) {
+	e.writeCompactBytes(v.bytes())
+}
+
 func (e *encoder) encodeNullBytes(v value) {
 	e.writeNullBytes(v.bytes())
+}
+
+func (e *encoder) encodeVarNullBytes(v value) {
+	e.writeVarNullBytes(v.bytes())
+}
+
+func (e *encoder) encodeCompactNullBytes(v value) {
+	e.writeCompactNullBytes(v.bytes())
 }
 
 func (e *encoder) encodeArray(v value, elemType reflect.Type, encodeElem encodeFunc) {
@@ -150,6 +182,22 @@ func (e *encoder) encodeArray(v value, elemType reflect.Type, encodeElem encodeF
 	n := a.length()
 	e.writeInt32(int32(n))
 
+	for i := 0; i < n; i++ {
+		encodeElem(e, a.index(i))
+	}
+}
+
+func (e *encoder) encodeCompactArray(v value, elemType reflect.Type, encodeElem encodeFunc) {
+	a := v.array(elemType)
+	if a.isNil() {
+		e.writeUnsignedVarInt(0)
+		return
+	}
+
+	n := a.length()
+
+	// In compact scheme, size 0=null, size 1=0 len array, etc.
+	e.writeUnsignedVarInt(uint64(n + 1))
 	for i := 0; i < n; i++ {
 		encodeElem(e, a.index(i))
 	}
@@ -195,6 +243,16 @@ func (e *encoder) writeString(s string) {
 	e.WriteString(s)
 }
 
+func (e *encoder) writeVarString(s string) {
+	e.writeVarInt(int64(len(s)))
+	e.WriteString(s)
+}
+
+func (e *encoder) writeCompactString(s string) {
+	e.writeUnsignedVarInt(uint64(len(s)) + 1)
+	e.WriteString(s)
+}
+
 func (e *encoder) writeNullString(s string) {
 	if s == "" {
 		e.writeInt16(-1)
@@ -204,12 +262,7 @@ func (e *encoder) writeNullString(s string) {
 	}
 }
 
-func (e *encoder) writeCompactString(s string) {
-	e.writeVarInt(int64(len(s)))
-	e.WriteString(s)
-}
-
-func (e *encoder) writeCompactNullString(s string) {
+func (e *encoder) writeVarNullString(s string) {
 	if s == "" {
 		e.writeVarInt(-1)
 	} else {
@@ -218,8 +271,27 @@ func (e *encoder) writeCompactNullString(s string) {
 	}
 }
 
+func (e *encoder) writeCompactNullString(s string) {
+	if s == "" {
+		e.writeUnsignedVarInt(0)
+	} else {
+		e.writeUnsignedVarInt(uint64(len(s)) + 1)
+		e.WriteString(s)
+	}
+}
+
 func (e *encoder) writeBytes(b []byte) {
 	e.writeInt32(int32(len(b)))
+	e.Write(b)
+}
+
+func (e *encoder) writeVarBytes(b []byte) {
+	e.writeVarInt(int64(len(b)))
+	e.Write(b)
+}
+
+func (e *encoder) writeCompactBytes(b []byte) {
+	e.writeUnsignedVarInt(uint64(len(b)) + 1)
 	e.Write(b)
 }
 
@@ -232,16 +304,20 @@ func (e *encoder) writeNullBytes(b []byte) {
 	}
 }
 
-func (e *encoder) writeCompactBytes(b []byte) {
-	e.writeVarInt(int64(len(b)))
-	e.Write(b)
-}
-
-func (e *encoder) writeCompactNullBytes(b []byte) {
+func (e *encoder) writeVarNullBytes(b []byte) {
 	if b == nil {
 		e.writeVarInt(-1)
 	} else {
 		e.writeVarInt(int64(len(b)))
+		e.Write(b)
+	}
+}
+
+func (e *encoder) writeCompactNullBytes(b []byte) {
+	if b == nil {
+		e.writeUnsignedVarInt(0)
+	} else {
+		e.writeUnsignedVarInt(uint64(len(b)) + 1)
 		e.Write(b)
 	}
 }
@@ -271,13 +347,28 @@ func (e *encoder) writeNullBytesFrom(b Bytes) error {
 	}
 }
 
-func (e *encoder) writeCompactNullBytesFrom(b Bytes) error {
+func (e *encoder) writeVarNullBytesFrom(b Bytes) error {
 	if b == nil {
 		e.writeVarInt(-1)
 		return nil
 	} else {
 		size := int64(b.Len())
 		e.writeVarInt(size)
+		n, err := io.Copy(e, b)
+		if err == nil && n != size {
+			err = fmt.Errorf("size of nullable bytes does not match the number of bytes that were written (size=%d, written=%d): %w", size, n, io.ErrUnexpectedEOF)
+		}
+		return err
+	}
+}
+
+func (e *encoder) writeCompactNullBytesFrom(b Bytes) error {
+	if b == nil {
+		e.writeUnsignedVarInt(0)
+		return nil
+	} else {
+		size := int64(b.Len())
+		e.writeUnsignedVarInt(uint64(size + 1))
 		n, err := io.Copy(e, b)
 		if err == nil && n != size {
 			err = fmt.Errorf("size of compact nullable bytes does not match the number of bytes that were written (size=%d, written=%d): %w", size, n, io.ErrUnexpectedEOF)
@@ -305,6 +396,24 @@ func (e *encoder) writeVarInt(i int64) {
 	e.Write(b[:n])
 }
 
+func (e *encoder) writeUnsignedVarInt(i uint64) {
+	b := e.buffer[:]
+	n := 0
+
+	for i > 0x80 && n < len(b) {
+		b[n] = byte(i)&0x7f | 0x80
+		i >>= 7
+		n++
+	}
+
+	if n < len(b) {
+		b[n] = byte(i)
+		n++
+	}
+
+	e.Write(b[:n])
+}
+
 type encodeFunc func(*encoder, value)
 
 var (
@@ -316,7 +425,7 @@ var (
 	writerTo = reflect.TypeOf((*io.WriterTo)(nil)).Elem()
 )
 
-func encodeFuncOf(typ reflect.Type, version int16, tag structTag) encodeFunc {
+func encodeFuncOf(typ reflect.Type, version int16, flexible bool, tag structTag) encodeFunc {
 	if reflect.PtrTo(typ).Implements(writerTo) {
 		return writerEncodeFuncOf(typ)
 	}
@@ -332,21 +441,27 @@ func encodeFuncOf(typ reflect.Type, version int16, tag structTag) encodeFunc {
 	case reflect.Int64:
 		return (*encoder).encodeInt64
 	case reflect.String:
-		return stringEncodeFuncOf(tag)
+		return stringEncodeFuncOf(flexible, tag)
 	case reflect.Struct:
-		return structEncodeFuncOf(typ, version)
+		return structEncodeFuncOf(typ, version, flexible)
 	case reflect.Slice:
 		if typ.Elem().Kind() == reflect.Uint8 { // []byte
-			return bytesEncodeFuncOf(tag)
+			return bytesEncodeFuncOf(flexible, tag)
 		}
-		return arrayEncodeFuncOf(typ, version, tag)
+		return arrayEncodeFuncOf(typ, version, flexible, tag)
 	default:
 		panic("unsupported type: " + typ.String())
 	}
 }
 
-func stringEncodeFuncOf(tag structTag) encodeFunc {
+func stringEncodeFuncOf(flexible bool, tag structTag) encodeFunc {
 	switch {
+	case flexible && tag.Nullable:
+		// In flexible messages, all strings are compact
+		return (*encoder).encodeCompactNullString
+	case flexible:
+		// In flexible messages, all strings are compact
+		return (*encoder).encodeCompactString
 	case tag.Nullable:
 		return (*encoder).encodeNullString
 	default:
@@ -354,8 +469,12 @@ func stringEncodeFuncOf(tag structTag) encodeFunc {
 	}
 }
 
-func bytesEncodeFuncOf(tag structTag) encodeFunc {
+func bytesEncodeFuncOf(flexible bool, tag structTag) encodeFunc {
 	switch {
+	case flexible:
+		// In flexible messages, all arrays are compact and there is no encoding
+		// distinction between nullable and non-nullable arrays.
+		return (*encoder).encodeCompactBytes
 	case tag.Nullable:
 		return (*encoder).encodeNullBytes
 	default:
@@ -363,21 +482,31 @@ func bytesEncodeFuncOf(tag structTag) encodeFunc {
 	}
 }
 
-func structEncodeFuncOf(typ reflect.Type, version int16) encodeFunc {
+func structEncodeFuncOf(typ reflect.Type, version int16, flexible bool) encodeFunc {
 	type field struct {
 		encode encodeFunc
 		index  index
+		tagID  int
 	}
 
 	var fields []field
+	var taggedFields []field
+
 	forEachStructField(typ, func(typ reflect.Type, index index, tag string) {
 		if typ.Size() != 0 { // skip struct{}
 			forEachStructTag(tag, func(tag structTag) bool {
 				if tag.MinVersion <= version && version <= tag.MaxVersion {
-					fields = append(fields, field{
-						encode: encodeFuncOf(typ, version, tag),
+					f := field{
+						encode: encodeFuncOf(typ, version, flexible, tag),
 						index:  index,
-					})
+						tagID:  tag.TagID,
+					}
+
+					if tag.TagID < -1 {
+						fields = append(fields, f)
+					} else {
+						taggedFields = append(taggedFields, f)
+					}
 					return false
 				}
 				return true
@@ -390,13 +519,34 @@ func structEncodeFuncOf(typ reflect.Type, version int16) encodeFunc {
 			f := &fields[i]
 			f.encode(e, v.fieldByIndex(f.index))
 		}
+
+		if flexible {
+			// See https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields
+			// for details of tag buffers in "flexible" messages.
+			e.writeUnsignedVarInt(uint64(len(taggedFields)))
+
+			for i := range taggedFields {
+				f := &fields[i]
+				e.writeUnsignedVarInt(uint64(f.tagID))
+
+				buf := &bytes.Buffer{}
+				se := &encoder{writer: buf}
+				f.encode(se, v.fieldByIndex(f.index))
+				e.writeUnsignedVarInt(uint64(buf.Len()))
+				e.Write(buf.Bytes())
+			}
+		}
 	}
 }
 
-func arrayEncodeFuncOf(typ reflect.Type, version int16, tag structTag) encodeFunc {
+func arrayEncodeFuncOf(typ reflect.Type, version int16, flexible bool, tag structTag) encodeFunc {
 	elemType := typ.Elem()
-	elemFunc := encodeFuncOf(elemType, version, tag)
+	elemFunc := encodeFuncOf(elemType, version, flexible, tag)
 	switch {
+	case flexible:
+		// In flexible messages, all arrays are compact and there is no encoding
+		// distinction between nullable and non-nullable arrays.
+		return func(e *encoder, v value) { e.encodeCompactArray(v, elemType, elemFunc) }
 	case tag.Nullable:
 		return func(e *encoder, v value) { e.encodeNullArray(v, elemType, elemFunc) }
 	default:
@@ -442,9 +592,10 @@ func Marshal(version int16, value interface{}) ([]byte, error) {
 	encode := cache[typ]
 
 	if encode == nil {
-		encode = encodeFuncOf(reflect.TypeOf(value), version, structTag{
+		encode = encodeFuncOf(reflect.TypeOf(value), version, false, structTag{
 			MinVersion: -1,
 			MaxVersion: -1,
+			TagID:      -2,
 			Compact:    true,
 			Nullable:   true,
 		})

--- a/protocol/encode.go
+++ b/protocol/encode.go
@@ -386,7 +386,22 @@ func (e *encoder) writeCompactNullBytesFrom(b Bytes) error {
 }
 
 func (e *encoder) writeVarInt(i int64) {
-	e.writeUnsignedVarInt(uint64((i << 1) ^ (i >> 63)))
+	b := e.buffer[:]
+	u := uint64((i << 1) ^ (i >> 63))
+	n := 0
+
+	for u >= 0x80 && n < len(b) {
+		b[n] = byte(u) | 0x80
+		u >>= 7
+		n++
+	}
+
+	if n < len(b) {
+		b[n] = byte(u)
+		n++
+	}
+
+	e.Write(b[:n])
 }
 
 func (e *encoder) writeUnsignedVarInt(i uint64) {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -279,7 +279,7 @@ func forEachStructTag(tag string, do func(structTag) bool) {
 				tag.MinVersion, err = parseVersion(s[4:])
 			case strings.HasPrefix(s, "max="):
 				tag.MaxVersion, err = parseVersion(s[4:])
-			case strings.HasPrefix(s, "tagId="):
+			case strings.HasPrefix(s, "tag="):
 				tag.TagID, err = strconv.Atoi(s[6:])
 			case s == "compact":
 				tag.Compact = true

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -228,7 +228,7 @@ func makeTypes(t reflect.Type) []messageType {
 			if maxVersion < 0 || tag.MaxVersion > maxVersion {
 				maxVersion = tag.MaxVersion
 			}
-			if tag.TagID > -2 && tag.MinVersion > minFlexibleVersion {
+			if tag.TagID > -2 && (minFlexibleVersion < 0 || tag.MinVersion < minFlexibleVersion) {
 				minFlexibleVersion = tag.MinVersion
 			}
 			return true

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -280,7 +280,7 @@ func forEachStructTag(tag string, do func(structTag) bool) {
 			case strings.HasPrefix(s, "max="):
 				tag.MaxVersion, err = parseVersion(s[4:])
 			case strings.HasPrefix(s, "tag="):
-				tag.TagID, err = strconv.Atoi(s[6:])
+				tag.TagID, err = strconv.Atoi(s[4:])
 			case s == "compact":
 				tag.Compact = true
 			case s == "nullable":

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -269,7 +269,11 @@ func forEachStructTag(tag string, do func(structTag) bool) {
 		tag := structTag{
 			MinVersion: -1,
 			MaxVersion: -1,
-			TagID:      -2,
+
+			// Legitimate tag IDs can start at 0. We use -1 as a placeholder to indicate
+			// that the message type is flexible, so that leaves -2 as the default for
+			// indicating that there is no tag ID and the message is not flexible.
+			TagID: -2,
 		}
 
 		var err error
@@ -279,6 +283,8 @@ func forEachStructTag(tag string, do func(structTag) bool) {
 				tag.MinVersion, err = parseVersion(s[4:])
 			case strings.HasPrefix(s, "max="):
 				tag.MaxVersion, err = parseVersion(s[4:])
+			case s == "tag":
+				tag.TagID = -1
 			case strings.HasPrefix(s, "tag="):
 				tag.TagID, err = strconv.Atoi(s[4:])
 			case s == "compact":

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -100,8 +100,10 @@ const (
 	AlterPartitionReassignments ApiKey = 45
 	ListPartitionReassignments  ApiKey = 46
 	OffsetDelete                ApiKey = 47
+	DescribeClientQuotas        ApiKey = 48
+	AlterClientQuotas           ApiKey = 49
 
-	numApis = 48
+	numApis = 50
 )
 
 var apiNames = [numApis]string{
@@ -149,17 +151,20 @@ var apiNames = [numApis]string{
 	DescribeDelegationToken:     "DescribeDelegationToken",
 	DeleteGroups:                "DeleteGroups",
 	ElectLeaders:                "ElectLeaders",
-	IncrementalAlterConfigs:     "IncrementalAlfterConfigs",
+	IncrementalAlterConfigs:     "IncrementalAlterConfigs",
 	AlterPartitionReassignments: "AlterPartitionReassignments",
 	ListPartitionReassignments:  "ListPartitionReassignments",
 	OffsetDelete:                "OffsetDelete",
+	DescribeClientQuotas:        "DescribeClientQuotas",
+	AlterClientQuotas:           "AlterClientQuotas",
 }
 
 type messageType struct {
-	version int16
-	gotype  reflect.Type
-	decode  decodeFunc
-	encode  encodeFunc
+	version  int16
+	flexible bool
+	gotype   reflect.Type
+	decode   decodeFunc
+	encode   encodeFunc
 }
 
 func (t *messageType) new() Message {
@@ -211,6 +216,10 @@ func makeTypes(t reflect.Type) []messageType {
 	minVersion := int16(-1)
 	maxVersion := int16(-1)
 
+	// All future versions will be flexible (according to spec), so don't need to
+	// worry about maxes here.
+	minFlexibleVersion := int16(-1)
+
 	forEachStructField(t, func(_ reflect.Type, _ index, tag string) {
 		forEachStructTag(tag, func(tag structTag) bool {
 			if minVersion < 0 || tag.MinVersion < minVersion {
@@ -219,6 +228,9 @@ func makeTypes(t reflect.Type) []messageType {
 			if maxVersion < 0 || tag.MaxVersion > maxVersion {
 				maxVersion = tag.MaxVersion
 			}
+			if tag.TagID > -2 && tag.MinVersion > minFlexibleVersion {
+				minFlexibleVersion = tag.MinVersion
+			}
 			return true
 		})
 	})
@@ -226,11 +238,14 @@ func makeTypes(t reflect.Type) []messageType {
 	types := make([]messageType, 0, (maxVersion-minVersion)+1)
 
 	for v := minVersion; v <= maxVersion; v++ {
+		flexible := minFlexibleVersion >= 0 && v >= minFlexibleVersion
+
 		types = append(types, messageType{
-			version: v,
-			gotype:  t,
-			decode:  decodeFuncOf(t, v, structTag{}),
-			encode:  encodeFuncOf(t, v, structTag{}),
+			version:  v,
+			gotype:   t,
+			flexible: flexible,
+			decode:   decodeFuncOf(t, v, flexible, structTag{}),
+			encode:   encodeFuncOf(t, v, flexible, structTag{}),
 		})
 	}
 
@@ -242,6 +257,7 @@ type structTag struct {
 	MaxVersion int16
 	Compact    bool
 	Nullable   bool
+	TagID      int
 }
 
 func forEachStructTag(tag string, do func(structTag) bool) {
@@ -253,6 +269,7 @@ func forEachStructTag(tag string, do func(structTag) bool) {
 		tag := structTag{
 			MinVersion: -1,
 			MaxVersion: -1,
+			TagID:      -2,
 		}
 
 		var err error
@@ -262,6 +279,8 @@ func forEachStructTag(tag string, do func(structTag) bool) {
 				tag.MinVersion, err = parseVersion(s[4:])
 			case strings.HasPrefix(s, "max="):
 				tag.MaxVersion, err = parseVersion(s[4:])
+			case strings.HasPrefix(s, "tagId="):
+				tag.TagID, err = strconv.Atoi(s[6:])
 			case s == "compact":
 				tag.Compact = true
 			case s == "nullable":

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -197,6 +197,11 @@ func TestVarInts(t *testing.T) {
 			expVarInt:  []byte{242, 192, 1},
 			expUVarInt: []byte{185, 96},
 		},
+		{
+			input:      123456789101112,
+			expVarInt:  []byte{240, 232, 249, 224, 144, 146, 56},
+			expUVarInt: []byte{184, 244, 188, 176, 136, 137, 28},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -217,6 +222,15 @@ func TestVarInts(t *testing.T) {
 				"got", b.Bytes(),
 			)
 		}
+		expLen := sizeOfVarInt(tc.input)
+		if expLen != len(b.Bytes()) {
+			t.Error(
+				"Wrong sizeOf for", tc.input, "as varInt",
+				"expected", expLen,
+				"got", len(b.Bytes()),
+			)
+		}
+
 		d := &decoder{reader: b, remain: len(b.Bytes())}
 		v := d.readVarInt()
 		if v != tc.input {
@@ -244,6 +258,15 @@ func TestVarInts(t *testing.T) {
 				"got", b.Bytes(),
 			)
 		}
+		expLen = sizeOfUnsignedVarInt(uint64(tc.input))
+		if expLen != len(b.Bytes()) {
+			t.Error(
+				"Wrong sizeOf for", tc.input, "as unsignedVarInt",
+				"expected", expLen,
+				"got", len(b.Bytes()),
+			)
+		}
+
 		d = &decoder{reader: b, remain: len(b.Bytes())}
 		v = int64(d.readUnsignedVarInt())
 		if v != tc.input {

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -163,6 +163,36 @@ func TestVarInts(t *testing.T) {
 			expUVarInt: []byte{12},
 		},
 		{
+			input:      63,
+			expVarInt:  []byte{126},
+			expUVarInt: []byte{63},
+		},
+		{
+			input:      -64,
+			expVarInt:  []byte{127},
+			expUVarInt: []byte{192, 255, 255, 255, 255, 255, 255, 255, 255, 1},
+		},
+		{
+			input:      64,
+			expVarInt:  []byte{128, 1},
+			expUVarInt: []byte{64},
+		},
+		{
+			input:      127,
+			expVarInt:  []byte{254, 1},
+			expUVarInt: []byte{127},
+		},
+		{
+			input:      128,
+			expVarInt:  []byte{128, 2},
+			expUVarInt: []byte{128, 1},
+		},
+		{
+			input:      129,
+			expVarInt:  []byte{130, 2},
+			expUVarInt: []byte{129, 1},
+		},
+		{
 			input:      12345,
 			expVarInt:  []byte{242, 192, 1},
 			expUVarInt: []byte{185, 96},

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,0 +1,228 @@
+package protocol
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+type testType struct {
+	Field1   string        `kafka:"min=v0,max=v4,nullable"`
+	Field2   int16         `kafka:"min=v2,max=v4"`
+	Field3   []byte        `kafka:"min=v2,max=v4,nullable"`
+	SubTypes []testSubType `kafka:"min=v1,max=v4"`
+
+	TaggedField1 int8   `kafka:"min=v3,max=v4,tag=0"`
+	TaggedField2 string `kafka:"min=v4,max=v4,tag=1"`
+}
+
+type testSubType struct {
+	SubField1 int8 `kafka:"min=v1,max=v4"`
+}
+
+func TestMakeFlexibleTypes(t *testing.T) {
+	types := makeTypes(reflect.TypeOf(&testType{}).Elem())
+	if len(types) != 5 {
+		t.Error(
+			"Wrong number of types",
+			"expected", 5,
+			"got", len(types),
+		)
+	}
+
+	fv := []int16{}
+
+	for _, to := range types {
+		if to.flexible {
+			fv = append(fv, to.version)
+		}
+	}
+
+	if !reflect.DeepEqual([]int16{3, 4}, fv) {
+		t.Error(
+			"Unexpected flexible versions",
+			"expected", []int16{3, 4},
+			"got", fv,
+		)
+	}
+}
+
+func TestEncodeDecodeFlexibleType(t *testing.T) {
+	f := &testType{
+		Field1: "value1",
+		Field2: 15,
+		Field3: []byte("hello"),
+		SubTypes: []testSubType{
+			{
+				SubField1: 2,
+			},
+			{
+				SubField1: 3,
+			},
+		},
+
+		TaggedField1: 34,
+		TaggedField2: "taggedValue2",
+	}
+
+	b := &bytes.Buffer{}
+	e := &encoder{writer: b}
+
+	types := makeTypes(reflect.TypeOf(&testType{}).Elem())
+	ft := types[4]
+	ft.encode(e, valueOf(f))
+	if e.err != nil {
+		t.Error(
+			"Error during encoding",
+			"expected", nil,
+			"got", e.err,
+		)
+	}
+
+	exp := []byte{
+		// size of "value1" + 1
+		7,
+		// "value1"
+		118, 97, 108, 117, 101, 49,
+		// 15 as 16-bit int
+		0, 15,
+		// size of []byte("hello") + 1
+		6,
+		// []byte("hello")
+		104, 101, 108, 108, 111,
+		// size of []SubTypes + 1
+		3,
+		// 2 as 8-bit int
+		2,
+		// tag buffer for first SubType struct
+		0,
+		// 3 as 8-bit int
+		3,
+		// tag buffer for second SubType struct
+		0,
+		// number of tagged fields
+		2,
+		// id of first tagged field
+		0,
+		// size of first tagged field
+		1,
+		// 34 as 8-bit int
+		34,
+		// id of second tagged field
+		1,
+		// size of second tagged field
+		13,
+		// size of "taggedValue2" + 1
+		13,
+		// "taggedValue2"
+		116, 97, 103, 103, 101, 100, 86, 97, 108, 117, 101, 50,
+	}
+
+	if !reflect.DeepEqual(exp, b.Bytes()) {
+		t.Error(
+			"Wrong encoded output",
+			"expected", exp,
+			"got", b.Bytes(),
+		)
+	}
+
+	b = &bytes.Buffer{}
+	b.Write(exp)
+	d := &decoder{reader: b, remain: len(exp)}
+
+	f2 := &testType{}
+	ft.decode(d, valueOf(f2))
+	if d.err != nil {
+		t.Error(
+			"Error during decoding",
+			"expected", nil,
+			"got", e.err,
+		)
+	}
+
+	if !reflect.DeepEqual(f, f2) {
+		t.Error(
+			"Decoded value does not equal encoded one",
+			"expected", *f,
+			"got", *f2,
+		)
+	}
+}
+
+func TestVarInts(t *testing.T) {
+	type tc struct {
+		input      int64
+		expVarInt  []byte
+		expUVarInt []byte
+	}
+
+	tcs := []tc{
+		{
+			input:      12,
+			expVarInt:  []byte{24},
+			expUVarInt: []byte{12},
+		},
+		{
+			input:      12345,
+			expVarInt:  []byte{242, 192, 1},
+			expUVarInt: []byte{185, 96},
+		},
+	}
+
+	for _, tc := range tcs {
+		b := &bytes.Buffer{}
+		e := &encoder{writer: b}
+		e.writeVarInt(tc.input)
+		if e.err != nil {
+			t.Errorf(
+				"Unexpected error encoding %d as varInt: %+v",
+				tc.input,
+				e.err,
+			)
+		}
+		if !reflect.DeepEqual(b.Bytes(), tc.expVarInt) {
+			t.Error(
+				"Wrong output encoding value", tc.input, "as varInt",
+				"expected", tc.expVarInt,
+				"got", b.Bytes(),
+			)
+		}
+		d := &decoder{reader: b, remain: len(b.Bytes())}
+		v := d.readVarInt()
+		if v != tc.input {
+			t.Error(
+				"Decoded varInt value does not equal encoded one",
+				"expected", tc.input,
+				"got", v,
+			)
+		}
+
+		b = &bytes.Buffer{}
+		e = &encoder{writer: b}
+		e.writeUnsignedVarInt(uint64(tc.input))
+		if e.err != nil {
+			t.Errorf(
+				"Unexpected error encoding %d as unsignedVarInt: %+v",
+				tc.input,
+				e.err,
+			)
+		}
+		if !reflect.DeepEqual(b.Bytes(), tc.expUVarInt) {
+			t.Error(
+				"Wrong output encoding value", tc.input, "as unsignedVarInt",
+				"expected", tc.expUVarInt,
+				"got", b.Bytes(),
+			)
+		}
+		d = &decoder{reader: b, remain: len(b.Bytes())}
+		v = int64(d.readUnsignedVarInt())
+		if v != tc.input {
+			t.Error(
+				"Decoded unsignedVarInt value does not equal encoded one",
+				"expected", tc.input,
+				"got", v,
+			)
+		}
+
+	}
+}

--- a/protocol/record_v2.go
+++ b/protocol/record_v2.go
@@ -123,8 +123,8 @@ func (rs *RecordSet) readFromVersion2(d *decoder) error {
 
 			for i := range h {
 				h[i] = Header{
-					Key:   dec.readCompactString(),
-					Value: dec.readCompactBytes(),
+					Key:   dec.readVarString(),
+					Value: dec.readVarBytes(),
 				}
 			}
 
@@ -239,12 +239,12 @@ func (rs *RecordSet) writeToVersion2(buffer *pageBuffer, bufferOffset int64) err
 		length := 1 + // attributes
 			sizeOfVarInt(timestampDelta) +
 			sizeOfVarInt(offsetDelta) +
-			sizeOfVarBytes(r.Key) +
-			sizeOfVarBytes(r.Value) +
+			sizeOfVarNullBytesIface(r.Key) +
+			sizeOfVarNullBytesIface(r.Value) +
 			sizeOfVarInt(int64(len(r.Headers)))
 
 		for _, h := range r.Headers {
-			length += sizeOfCompactString(h.Key) + sizeOfCompactNullBytes(h.Value)
+			length += sizeOfVarString(h.Key) + sizeOfVarNullBytes(h.Value)
 		}
 
 		e.writeVarInt(int64(length))
@@ -252,19 +252,19 @@ func (rs *RecordSet) writeToVersion2(buffer *pageBuffer, bufferOffset int64) err
 		e.writeVarInt(timestampDelta)
 		e.writeVarInt(offsetDelta)
 
-		if err := e.writeCompactNullBytesFrom(r.Key); err != nil {
+		if err := e.writeVarNullBytesFrom(r.Key); err != nil {
 			return err
 		}
 
-		if err := e.writeCompactNullBytesFrom(r.Value); err != nil {
+		if err := e.writeVarNullBytesFrom(r.Value); err != nil {
 			return err
 		}
 
 		e.writeVarInt(int64(len(r.Headers)))
 
 		for _, h := range r.Headers {
-			e.writeCompactString(h.Key)
-			e.writeCompactNullBytes(h.Value)
+			e.writeVarString(h.Key)
+			e.writeVarNullBytes(h.Value)
 		}
 
 		numRecords++

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -57,6 +57,17 @@ func ReadRequest(r io.Reader) (
 	}
 
 	req := &t.requests[apiVersion-minVersion]
+
+	if req.flexible {
+		// In the flexible case, there's room for tagged fields at the end
+		// of the response header. However, we don't currently implement
+		// anything to decode them.
+		tagBufferSize := int(d.readUnsignedVarInt())
+		if tagBufferSize > 0 {
+			d.read(tagBufferSize)
+		}
+	}
+
 	msg = req.new()
 	req.decode(d, valueOf(msg))
 	d.discardAll()

--- a/protocol/request.go
+++ b/protocol/request.go
@@ -40,13 +40,7 @@ func ReadRequest(r io.Reader) (apiVersion int16, correlationID int32, clientID s
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		err = fmt.Errorf(
-			"unsupported %s version: v%d not in range v%d-v%d",
-			apiKey,
-			apiVersion,
-			minVersion,
-			maxVersion,
-		)
+		err = fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
 		return
 	}
 
@@ -91,13 +85,7 @@ func WriteRequest(w io.Writer, apiVersion int16, correlationID int32, clientID s
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		return fmt.Errorf(
-			"unsupported %s version: v%d not in range v%d-v%d",
-			apiKey,
-			apiVersion,
-			minVersion,
-			maxVersion,
-		)
+		return fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
 	}
 
 	r := &t.requests[apiVersion-minVersion]

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -5,7 +5,11 @@ import (
 	"io"
 )
 
-func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID int32, msg Message, err error) {
+func ReadResponse(
+	r io.Reader,
+	apiKey ApiKey,
+	apiVersion int16,
+) (correlationID int32, msg Message, err error) {
 	if i := int(apiKey); i < 0 || i >= len(apiTypes) {
 		err = fmt.Errorf("unsupported api key: %d", i)
 		return
@@ -21,7 +25,13 @@ func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID i
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		err = fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
+		err = fmt.Errorf(
+			"unsupported %s version: v%d not in range v%d-v%d",
+			apiKey,
+			apiVersion,
+			minVersion,
+			maxVersion,
+		)
 		return
 	}
 
@@ -37,6 +47,17 @@ func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID i
 	correlationID = d.readInt32()
 
 	res := &t.responses[apiVersion-minVersion]
+
+	if res.flexible {
+		// In the flexible case, there's room for tagged fields at the end
+		// of the response header. However, we don't currently implement
+		// anything to decode them.
+		tagBufferSize := int(d.readUnsignedVarInt())
+		if tagBufferSize > 0 {
+			d.read(tagBufferSize)
+		}
+	}
+
 	msg = res.new()
 	res.decode(d, valueOf(msg))
 	d.discardAll()
@@ -48,7 +69,12 @@ func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID i
 	return
 }
 
-func WriteResponse(w io.Writer, apiVersion int16, correlationID int32, msg Message) error {
+func WriteResponse(
+	w io.Writer,
+	apiVersion int16,
+	correlationID int32,
+	msg Message,
+) error {
 	apiKey := msg.ApiKey()
 
 	if i := int(apiKey); i < 0 || i >= len(apiTypes) {
@@ -64,7 +90,13 @@ func WriteResponse(w io.Writer, apiVersion int16, correlationID int32, msg Messa
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		return fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
+		return fmt.Errorf(
+			"unsupported %s version: v%d not in range v%d-v%d",
+			apiKey,
+			apiVersion,
+			minVersion,
+			maxVersion,
+		)
 	}
 
 	r := &t.responses[apiVersion-minVersion]

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -49,13 +49,14 @@ func ReadResponse(
 	res := &t.responses[apiVersion-minVersion]
 
 	if res.flexible {
-		// In the flexible case, there's room for tagged fields at the end
-		// of the response header. However, we don't currently implement
-		// anything to decode them.
-		tagBufferSize := int(d.readUnsignedVarInt())
+		// In the flexible case, there's a tag buffer at the end of the request header
+		taggedCount := int(d.readUnsignedVarInt())
+		for i := 0; i < taggedCount; i++ {
+			d.readUnsignedVarInt() // tagID
+			size := d.readUnsignedVarInt()
 
-		if tagBufferSize > 0 {
-			d.read(tagBufferSize)
+			// Just throw away the values for now
+			d.read(int(size))
 		}
 	}
 

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -53,6 +53,7 @@ func ReadResponse(
 		// of the response header. However, we don't currently implement
 		// anything to decode them.
 		tagBufferSize := int(d.readUnsignedVarInt())
+
 		if tagBufferSize > 0 {
 			d.read(tagBufferSize)
 		}

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -39,7 +39,7 @@ func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID i
 	res := &t.responses[apiVersion-minVersion]
 
 	if res.flexible {
-		// In the flexible case, there's a tag buffer at the end of the request header
+		// In the flexible case, there's a tag buffer at the end of the response header
 		taggedCount := int(d.readUnsignedVarInt())
 		for i := 0; i < taggedCount; i++ {
 			d.readUnsignedVarInt() // tagID

--- a/protocol/response.go
+++ b/protocol/response.go
@@ -5,11 +5,7 @@ import (
 	"io"
 )
 
-func ReadResponse(
-	r io.Reader,
-	apiKey ApiKey,
-	apiVersion int16,
-) (correlationID int32, msg Message, err error) {
+func ReadResponse(r io.Reader, apiKey ApiKey, apiVersion int16) (correlationID int32, msg Message, err error) {
 	if i := int(apiKey); i < 0 || i >= len(apiTypes) {
 		err = fmt.Errorf("unsupported api key: %d", i)
 		return
@@ -25,13 +21,7 @@ func ReadResponse(
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		err = fmt.Errorf(
-			"unsupported %s version: v%d not in range v%d-v%d",
-			apiKey,
-			apiVersion,
-			minVersion,
-			maxVersion,
-		)
+		err = fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
 		return
 	}
 
@@ -71,12 +61,7 @@ func ReadResponse(
 	return
 }
 
-func WriteResponse(
-	w io.Writer,
-	apiVersion int16,
-	correlationID int32,
-	msg Message,
-) error {
+func WriteResponse(w io.Writer, apiVersion int16, correlationID int32, msg Message) error {
 	apiKey := msg.ApiKey()
 
 	if i := int(apiKey); i < 0 || i >= len(apiTypes) {
@@ -92,13 +77,7 @@ func WriteResponse(
 	maxVersion := t.maxVersion()
 
 	if apiVersion < minVersion || apiVersion > maxVersion {
-		return fmt.Errorf(
-			"unsupported %s version: v%d not in range v%d-v%d",
-			apiKey,
-			apiVersion,
-			minVersion,
-			maxVersion,
-		)
+		return fmt.Errorf("unsupported %s version: v%d not in range v%d-v%d", apiKey, apiVersion, minVersion, maxVersion)
 	}
 
 	r := &t.responses[apiVersion-minVersion]

--- a/protocol/size.go
+++ b/protocol/size.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"math/bits"
 	"reflect"
 )
 
@@ -32,7 +33,7 @@ func sizeOfVarString(s string) int {
 }
 
 func sizeOfCompactString(s string) int {
-	return sizeOfUnsignedVarInt(int64(len(s)+1)) + len(s)
+	return sizeOfUnsignedVarInt(uint64(len(s)+1)) + len(s)
 }
 
 func sizeOfVarBytes(b []byte) int {
@@ -40,7 +41,7 @@ func sizeOfVarBytes(b []byte) int {
 }
 
 func sizeOfCompactBytes(b []byte) int {
-	return sizeOfUnsignedVarInt(int64(len(b)+1)) + len(b)
+	return sizeOfUnsignedVarInt(uint64(len(b)+1)) + len(b)
 }
 
 func sizeOfVarNullString(s string) int {
@@ -56,7 +57,7 @@ func sizeOfCompactNullString(s string) int {
 	if n == 0 {
 		return sizeOfUnsignedVarInt(0)
 	}
-	return sizeOfUnsignedVarInt(int64(n)+1) + n
+	return sizeOfUnsignedVarInt(uint64(n)+1) + n
 }
 
 func sizeOfVarNullBytes(b []byte) int {
@@ -80,28 +81,13 @@ func sizeOfCompactNullBytes(b []byte) int {
 		return sizeOfUnsignedVarInt(0)
 	}
 	n := len(b)
-	return sizeOfUnsignedVarInt(int64(n)+1) + n
+	return sizeOfUnsignedVarInt(uint64(n)+1) + n
 }
 
 func sizeOfVarInt(i int64) int {
-	u := uint64((i << 1) ^ (i >> 63)) // zig-zag encoding
-	n := 0
-
-	for u >= 0x80 {
-		u >>= 7
-		n++
-	}
-
-	return n + 1
+	return sizeOfUnsignedVarInt(uint64((i << 1) ^ (i >> 63))) // zig-zag encoding
 }
 
-func sizeOfUnsignedVarInt(i int64) int {
-	n := 0
-
-	for i >= 0x80 {
-		i >>= 7
-		n++
-	}
-
-	return n + 1
+func sizeOfUnsignedVarInt(i uint64) int {
+	return (bits.Len64(i|1) + 6) / 7
 }

--- a/protocol/size.go
+++ b/protocol/size.go
@@ -70,17 +70,16 @@ func sizeOfVarNullBytes(b []byte) int {
 func sizeOfVarNullBytesIface(b Bytes) int {
 	if b == nil {
 		return sizeOfVarInt(-1)
-	} else {
-		n := b.Len()
-		return sizeOfVarInt(int64(n)) + n
 	}
+	n := b.Len()
+	return sizeOfVarInt(int64(n)) + n
 }
 
 func sizeOfCompactNullBytes(b []byte) int {
-	n := len(b)
 	if b == nil {
 		return sizeOfUnsignedVarInt(0)
 	}
+	n := len(b)
 	return sizeOfUnsignedVarInt(int64(n)+1) + n
 }
 

--- a/protocol/size.go
+++ b/protocol/size.go
@@ -27,28 +27,61 @@ func sizeOfBytes(b []byte) int {
 	return 4 + len(b)
 }
 
-func sizeOfCompactString(s string) int {
+func sizeOfVarString(s string) int {
 	return sizeOfVarInt(int64(len(s))) + len(s)
 }
 
-func sizeOfCompactBytes(b []byte) int {
+func sizeOfCompactString(s string) int {
+	return sizeOfUnsignedVarInt(int64(len(s)+1)) + len(s)
+}
+
+func sizeOfVarBytes(b []byte) int {
 	return sizeOfVarInt(int64(len(b))) + len(b)
+}
+
+func sizeOfCompactBytes(b []byte) int {
+	return sizeOfUnsignedVarInt(int64(len(b)+1)) + len(b)
+}
+
+func sizeOfVarNullString(s string) int {
+	n := len(s)
+	if n == 0 {
+		return sizeOfVarInt(-1)
+	}
+	return sizeOfVarInt(int64(n)) + n
 }
 
 func sizeOfCompactNullString(s string) int {
 	n := len(s)
 	if n == 0 {
-		n = -1
+		return sizeOfUnsignedVarInt(0)
 	}
-	return sizeOfVarInt(int64(n)) + len(s)
+	return sizeOfUnsignedVarInt(int64(n)+1) + n
+}
+
+func sizeOfVarNullBytes(b []byte) int {
+	if b == nil {
+		return sizeOfVarInt(-1)
+	}
+	n := len(b)
+	return sizeOfVarInt(int64(n)) + n
+}
+
+func sizeOfVarNullBytesIface(b Bytes) int {
+	if b == nil {
+		return sizeOfVarInt(-1)
+	} else {
+		n := b.Len()
+		return sizeOfVarInt(int64(n)) + n
+	}
 }
 
 func sizeOfCompactNullBytes(b []byte) int {
 	n := len(b)
 	if b == nil {
-		n = -1
+		return sizeOfUnsignedVarInt(0)
 	}
-	return sizeOfVarInt(int64(n)) + len(b)
+	return sizeOfUnsignedVarInt(int64(n)+1) + n
 }
 
 func sizeOfVarInt(i int64) int {
@@ -63,11 +96,13 @@ func sizeOfVarInt(i int64) int {
 	return n + 1
 }
 
-func sizeOfVarBytes(b Bytes) int {
-	if b == nil {
-		return sizeOfVarInt(-1)
-	} else {
-		n := b.Len()
-		return sizeOfVarInt(int64(n)) + n
+func sizeOfUnsignedVarInt(i int64) int {
+	n := 0
+
+	for i >= 0x80 {
+		i >>= 7
+		n++
 	}
+
+	return n + 1
 }


### PR DESCRIPTION
## Description
This change updates kafka-go to support the "flexible" message format described in [KIP-482](https://cwiki.apache.org/confluence/display/KAFKA/KIP-482%3A+The+Kafka+Protocol+should+Support+Optional+Tagged+Fields). Among other changes, the new format adds optional "tagged fields" into API messages and also makes the encodings of strings and arrays more compact.

The values of the tagged fields aren't used for much yet (I think), but we need to support the new, "flexible" format to get the latest API versions described in the [Kafka protocol guide](https://kafka.apache.org/protocol).

The proposed interface is to support tagged fields via a new, `tag=` property in the existing protocol struct tags, e.g.:

```
type Request struct {
    [required fields]

    TaggedField0 `kafka:"min=v1,max=v3,tag=0"`
    TaggedField1 `kafka:"min=v2,max=v3,tag=1"`
   ...
}
```

As an example and to provide something to test with, this change updates the max version of the `CreateTopics` API to v5, which uses the new format.

#### Misc. notes and TODOs
1. I've added Kafka 2.4.1 into the CI since something >= 2.4 is needed to exercise the new message formats. However, the `nettest` suite fails for this version, so I'm temporarily adding an option to skip this. I get the same failures when running from the base `0.4` branch, so I don't think these errors are related to the changes here.
2. KIP-482 defines new, "compact" encodings that are different from the ones currently defined in the kafka-go procotol. I've renamed the latter from "compact" to "var", e.g. `VarString`, `VarBytes`, etc. to distinguish them.
3. Non-empty tag buffers aren't included yet in any real APIs (as far as I can tell), so it's hard to be sure that the implementation here is 100% aligned with what Kafka will expect in the future. We may need to make fixes in the future once tagged fields are actively set.