### PR TITLE
Propagate Preferred read replica to FetchResponse

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,6 +40,9 @@ type Client struct {
 	//
 	// If nil, DefaultTransport is used.
 	Transport RoundTripper
+
+	// Rack ID define where the client is running in a rack aware deployment.
+	RackID string
 }
 
 // A ConsumerGroup and Topic as these are both strings we define a type for


### PR DESCRIPTION
This PR propagates the PreferredReadReplica to the FetchResponse. This is a first step toward implementing https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica.