### PR TITLE
Kafka Client FindCoordinator implementation

### DIFF
--- a/error.go
+++ b/error.go
@@ -9,12 +9,6 @@ import (
 // https://kafka.apache.org/protocol#protocol_error_codes
 type Error int
 
-// ErrorWithCode retains Error code information while creating an error message
-type ErrorWithCode struct {
-	Error error
-	Code  int16
-}
-
 const (
 	Unknown                            Error = -1
 	OffsetOutOfRange                   Error = 1
@@ -560,13 +554,6 @@ func makeError(code int16, message string) error {
 		return Error(code)
 	}
 	return fmt.Errorf("%w: %s", Error(code), message)
-}
-
-func makeErrorWithCode(code int16, message string) *ErrorWithCode {
-	return &ErrorWithCode{
-		Error: makeError(code, message),
-		Code:  code,
-	}
 }
 
 // WriteError is returned by kafka.(*Writer).WriteMessages when the writer is

--- a/error.go
+++ b/error.go
@@ -9,6 +9,12 @@ import (
 // https://kafka.apache.org/protocol#protocol_error_codes
 type Error int
 
+// ErrorWithCode retains Error code information while creating an error message
+type ErrorWithCode struct {
+	Error error
+	Code  int16
+}
+
 const (
 	Unknown                            Error = -1
 	OffsetOutOfRange                   Error = 1
@@ -554,6 +560,13 @@ func makeError(code int16, message string) error {
 		return Error(code)
 	}
 	return fmt.Errorf("%w: %s", Error(code), message)
+}
+
+func makeErrorWithCode(code int16, message string) *ErrorWithCode {
+	return &ErrorWithCode{
+		Error: makeError(code, message),
+		Code:  code,
+	}
 }
 
 // WriteError is returned by kafka.(*Writer).WriteMessages when the writer is

--- a/findcoordinator.go
+++ b/findcoordinator.go
@@ -85,7 +85,7 @@ func (c *Client) FindCoordinator(ctx context.Context, req *FindCoordinatorReques
 		Coordinator: coordinator,
 	}
 
-	return ret, ret.Error
+	return ret, nil
 }
 
 // FindCoordinatorRequestV0 requests the coordinator for the specified group or transaction

--- a/findcoordinator.go
+++ b/findcoordinator.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/segmentio/kafka-go/protocol/findcoordinator"
@@ -87,29 +86,6 @@ func (c *Client) FindCoordinator(ctx context.Context, req *FindCoordinatorReques
 	}
 
 	return ret, ret.Error.Error
-}
-
-// WaitForCoordinatorIndefinitely is a blocking call till a coordinator is found
-func waitForCoordinatorIndefinitely(ctx context.Context, c *Client, req *FindCoordinatorRequest) (*FindCoordinatorResponse, error) {
-	fmt.Println("Trying to find Coordinator.")
-	resp, err := c.FindCoordinator(ctx, req)
-
-	for shouldRetryfindingCoordinator(resp, err) && ctx.Err() == nil {
-		time.Sleep(1 * time.Second)
-		resp, err = c.FindCoordinator(ctx, req)
-	}
-	return resp, err
-}
-
-func shouldRetryfindingCoordinator(resp *FindCoordinatorResponse, err error) bool {
-	brokerSetupIncomplete := err != nil &&
-		strings.Contains(
-			strings.ToLower(err.Error()),
-			strings.ToLower("unexpected EOF"))
-	coordinatorNotFound := err != nil &&
-		resp != nil &&
-		int(resp.Error.Code) == int(GroupCoordinatorNotAvailable)
-	return brokerSetupIncomplete || coordinatorNotFound
 }
 
 // FindCoordinatorRequestV0 requests the coordinator for the specified group or transaction

--- a/findcoordinator.go
+++ b/findcoordinator.go
@@ -57,7 +57,7 @@ type FindCoordinatorResponse struct {
 	//
 	// The error contains both the kafka error code, and an error message
 	// returned by the kafka broker.
-	Error *ErrorWithCode
+	Error error
 }
 
 // FindCoordinator sends a findCoordinator request to a kafka broker and returns the
@@ -81,11 +81,11 @@ func (c *Client) FindCoordinator(ctx context.Context, req *FindCoordinatorReques
 	}
 	ret := &FindCoordinatorResponse{
 		Throttle:    makeDuration(res.ThrottleTimeMs),
-		Error:       makeErrorWithCode(res.ErrorCode, res.ErrorMessage),
+		Error:       makeError(res.ErrorCode, res.ErrorMessage),
 		Coordinator: coordinator,
 	}
 
-	return ret, ret.Error.Error
+	return ret, ret.Error
 }
 
 // FindCoordinatorRequestV0 requests the coordinator for the specified group or transaction

--- a/findcoordinator.go
+++ b/findcoordinator.go
@@ -2,7 +2,91 @@ package kafka
 
 import (
 	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol/findcoordinator"
 )
+
+// CoordinatorKeyType is used to specify the type of coordinator to look for
+type CoordinatorKeyType int8
+
+const (
+	// CoordinatorKeyTypeConsumer type is used when looking for a Group coordinator
+	CoordinatorKeyTypeConsumer CoordinatorKeyType = 0
+
+	// CoordinatorKeyTypeTransaction type is used when looking for a Transaction coordinator
+	CoordinatorKeyTypeTransaction CoordinatorKeyType = 1
+)
+
+// FindCoordinatorRequest is the request structure for the FindCoordinator function
+type FindCoordinatorRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	// The coordinator key.
+	Key string
+
+	// The coordinator key type. (Group, transaction, etc.)
+	KeyType CoordinatorKeyType
+}
+
+// FindCoordinatorResponseCoordinator contains details about the found coordinator
+type FindCoordinatorResponseCoordinator struct {
+	// NodeID holds the broker id.
+	NodeID int32
+
+	// Host of the broker
+	Host string
+
+	// Port on which broker accepts requests
+	Port int32
+}
+
+// FindCoordinatorResponse is the response structure for the FindCoordinator function
+type FindCoordinatorResponse struct {
+	// The Transaction/Group Coordinator details
+	Coordinator *FindCoordinatorResponseCoordinator
+
+	// The amount of time that the broker throttled the request.
+	Throttle time.Duration
+
+	// An error that may have occurred while attempting to retrieve Coordinator
+	//
+	// The error contains both the kafka error code, and an error message
+	// returned by the kafka broker.
+	Error error
+}
+
+// FindCoordinator sends a findCoordinator request to a kafka broker and returns the
+// response.
+func (c *Client) FindCoordinator(ctx context.Context, req *FindCoordinatorRequest) (*FindCoordinatorResponse, error) {
+
+	m, err := c.roundTrip(ctx, req.Addr, &findcoordinator.Request{
+		Key:     req.Key,
+		KeyType: int8(req.KeyType),
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("kafka.(*Client).FindCoordinator: %w", err)
+	}
+
+	res := m.(*findcoordinator.Response)
+	coordinator := &FindCoordinatorResponseCoordinator{
+		NodeID: res.NodeID,
+		Host:   res.Host,
+		Port:   res.Port,
+	}
+	ret := &FindCoordinatorResponse{
+		Throttle:    makeDuration(res.ThrottleTimeMs),
+		Error:       makeError(res.ErrorCode, res.ErrorMessage),
+		Coordinator: coordinator,
+	}
+
+	return ret, ret.Error
+}
 
 // FindCoordinatorRequestV0 requests the coordinator for the specified group or transaction
 //

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -75,6 +75,8 @@ func waitForCoordinatorIndefinitely(ctx context.Context, c *Client, req *FindCoo
 	return resp, err
 }
 
+// Should retry looking for coordinator
+// Returns true when the test Kafka broker is still setting up
 func shouldRetryfindingCoordinator(resp *FindCoordinatorResponse, err error) bool {
 	brokerSetupIncomplete := err != nil &&
 		strings.Contains(

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"reflect"
 	"testing"
 )
@@ -34,5 +35,23 @@ func TestFindCoordinatorResponseV0(t *testing.T) {
 	if !reflect.DeepEqual(item, found) {
 		t.Error("expected item and found to be the same")
 		t.FailNow()
+	}
+}
+
+func TestClientFindCoordinator(t *testing.T) {
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
+	resp, err := client.FindCoordinator(context.Background(), &FindCoordinatorRequest{
+		Addr:    client.Addr,
+		Key:     "TransactionalID-1",
+		KeyType: CoordinatorKeyTypeTransaction,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Coordinator.Host != "localhost" {
+		t.Fatal("Coordinator should be found @ localhost")
 	}
 }

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -82,8 +82,8 @@ func shouldRetryfindingCoordinator(resp *FindCoordinatorResponse, err error) boo
 		strings.Contains(
 			strings.ToLower(err.Error()),
 			strings.ToLower("unexpected EOF"))
-	coordinatorNotFound := err != nil &&
-		resp != nil &&
+	coordinatorNotFound := resp != nil &&
+		resp.Error != nil &&
 		errors.Is(resp.Error, GroupCoordinatorNotAvailable)
 	return brokerSetupIncomplete || coordinatorNotFound
 }

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -45,7 +45,7 @@ func TestClientFindCoordinator(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	resp, err := client.WaitForCoordinatorIndefinitely(ctx, &FindCoordinatorRequest{
+	resp, err := waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     "TransactionalID-1",
 		KeyType: CoordinatorKeyTypeTransaction,

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -43,7 +43,7 @@ func TestClientFindCoordinator(t *testing.T) {
 	client, shutdown := newLocalClient()
 	defer shutdown()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	resp, err := client.WaitForCoordinatorIndefinitely(ctx, &FindCoordinatorRequest{
 		Addr:    client.Addr,

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -81,6 +82,6 @@ func shouldRetryfindingCoordinator(resp *FindCoordinatorResponse, err error) boo
 			strings.ToLower("unexpected EOF"))
 	coordinatorNotFound := err != nil &&
 		resp != nil &&
-		int(resp.Error.Code) == int(GroupCoordinatorNotAvailable)
+		errors.Is(resp.Error, GroupCoordinatorNotAvailable)
 	return brokerSetupIncomplete || coordinatorNotFound
 }


### PR DESCRIPTION
### This pull request contains
- FIndCoordinator implementation that utilizes the `kafka.(*Client)` abstraction.
- A tiny unit test for the same.

---
According to [this design doc](https://docs.google.com/document/d/11Jqy_GjUGtdXJK94XGsEIK7CP1SnQGdp2eF0wSw9ra8/edit#heading=h.dz78fc8xlsd5), the first step in implementing a **Transactional Producer** is looking for a TransactionCoordinator for the specified transactionalId using `FindCoordinatorRequest`. 

---
This PR is a step towards solving #233

CC: @achille-roussel 