### PR TITLE
GSSAPI SASL mechanism based on gokrb5/v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,46 @@ if err != nil {
 }
 ```
 
+#### [GSSAPI](https://godoc.org/github.com/segmentio/kafka-go/sasl/gssapi)
+
+The GSSAPI mechanism wraps a Kerberos client from version 8 of
+[`gokrb5`](https://github.com/jcmturner/gokrb5). You have to
+initialize and manage the client yourself. Typical usage might
+look something like this:
+```go
+// In your imports, include both of these:
+//     github.com/jcmturner/gokrb5/v8/client
+//     github.com/jcmturner/gokrb5/v8/config
+
+cfg, err := config.Load("/etc/krb5.conf")
+if err != nil {
+	panic(err)
+}
+
+const realm = "EXAMPLE.COM" // This will be specific to your Kerberos
+clnt := client.NewWithPassword(username, realm, password, cfg)
+
+err = clnt.Login()
+if err != nil {
+	panic(err)
+}
+
+const serviceName = "kafka" // Might be different in your Kerberos
+mechanism, err := gssapi.Gokrb5v8(clnt, serviceName)
+if err != nil {
+	panic(err)
+}
+
+// After connecting to the Kafka brokers you need, you may want to call
+// `clnt.Destroy()` if you are not reusing the client for other
+// Kerberos functionality, like automatic ticket renewal.
+```
+
+You can see more examples of how to initialize the Kerberos client,
+for example with a keytab instead of a password, in the gokrb5/v8
+[usage notes](https://github.com/jcmturner/gokrb5/blob/master/v8/USAGE.md).
+
+
 ### Connection
 
 ```go

--- a/dialer.go
+++ b/dialer.go
@@ -279,7 +279,8 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 	conn := NewConnWith(c, connCfg)
 
 	if d.SASLMechanism != nil {
-		if err := d.authenticateSASL(ctx, conn); err != nil {
+		host, _ := splitHostPort(address)
+		if err := d.authenticateSASL(ctx, conn, host); err != nil {
 			_ = conn.Close()
 			return nil, err
 		}
@@ -294,12 +295,18 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 //
 // In case of error, this function *does not* close the connection.  That is the
 // responsibility of the caller.
-func (d *Dialer) authenticateSASL(ctx context.Context, conn *Conn) error {
-	if err := conn.saslHandshake(d.SASLMechanism.Name()); err != nil {
+func (d *Dialer) authenticateSASL(ctx context.Context, conn *Conn, host string) error {
+	mechanism := d.SASLMechanism
+
+	if err := conn.saslHandshake(mechanism.Name()); err != nil {
 		return err
 	}
 
-	sess, state, err := d.SASLMechanism.Start(ctx)
+	if m, ok := mechanism.(sasl.NeedsHost); ok {
+		mechanism = m.WithHost(host)
+	}
+
+	sess, state, err := mechanism.Start(ctx)
 	if err != nil {
 		return err
 	}

--- a/sasl/gssapi/gssapi.go
+++ b/sasl/gssapi/gssapi.go
@@ -1,0 +1,215 @@
+package gssapi
+
+import (
+	"context"
+	"encoding/asn1"
+	"encoding/binary"
+
+	"github.com/segmentio/kafka-go/sasl"
+
+	"github.com/jcmturner/gokrb5/v8/client"
+	"github.com/jcmturner/gokrb5/v8/crypto"
+	"github.com/jcmturner/gokrb5/v8/gssapi"
+	"github.com/jcmturner/gokrb5/v8/iana/chksumtype"
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+const (
+	// https://tools.ietf.org/html/rfc4121#section-4.1
+	TOK_ID_KRB_AP_REQ = "\x01\x00"
+)
+
+type mechanism struct {
+	client      *client.Client
+	serviceName string
+	host        string
+}
+
+func (m mechanism) Name() string {
+	return "GSSAPI"
+}
+
+// Gokrb5v8 uses gokrb5/v8 to implement the GSSAPI mechanism.
+//
+// client is a github.com/gokrb5/v8/client *Client instance.
+// kafkaServiceName is the name of the Kafka service in your Kerberos.
+func Gokrb5v8(client *client.Client, kafkaServiceName string) sasl.Mechanism {
+	return mechanism{client, kafkaServiceName, ""}
+}
+
+// WithHost fulfills the optional sasl.NeedsHost interface
+// needed for this sasl.Mechanism implementation.
+//
+// Unless you are implementing a SASL handshake yourself,
+// you do not need to call this.
+func (m mechanism) WithHost(host string) sasl.Mechanism {
+	m.host = host
+	return m
+}
+
+// StartWithoutHostError is the error type for when Start is called on
+// the GSSAPI mechanism without the host having been set by WithHost.
+//
+// Unless you are calling the GSSAPI SASL mechanim's Start method
+// yourself for some reason, this error will never be returned.
+type StartWithoutHostError struct{}
+
+func (e StartWithoutHostError) Error() string {
+	return "GSSAPI SASL handshake needs a host"
+}
+
+func (m mechanism) Start(ctx context.Context) (sasl.StateMachine, []byte, error) {
+	if m.host == "" {
+		return nil, nil, StartWithoutHostError{}
+	}
+
+	servicePrincipalName := m.serviceName + "/" + m.host
+	ticket, key, err := m.client.GetServiceTicket(
+		servicePrincipalName,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	authenticator, err := types.NewAuthenticator(
+		m.client.Credentials.Realm(),
+		m.client.Credentials.CName(),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	encryptionType, err := crypto.GetEtype(key.KeyType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keySize := encryptionType.GetKeyByteSize()
+	err = authenticator.GenerateSeqNumberAndSubKey(key.KeyType, keySize)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	authenticator.Cksum = types.Checksum{
+		CksumType: chksumtype.GSSAPI,
+		Checksum:  authenticatorPseudoChecksum(),
+	}
+	apReq, err := messages.NewAPReq(ticket, key, authenticator)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bytes, err := apReq.Marshal()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bytesWithPrefix := make([]byte, 0, len(TOK_ID_KRB_AP_REQ)+len(bytes))
+	bytesWithPrefix = append(bytesWithPrefix, TOK_ID_KRB_AP_REQ...)
+	bytesWithPrefix = append(bytesWithPrefix, bytes...)
+
+	gssapiToken, err := prependGSSAPITokenTag(bytesWithPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &gokrb5v8Session{authenticator.SubKey, false}, gssapiToken, nil
+}
+
+func authenticatorPseudoChecksum() []byte {
+	// Not actually a checksum, but it goes in the checksum field.
+	// https://tools.ietf.org/html/rfc4121#section-4.1.1
+	checksum := make([]byte, 24)
+
+	flags := gssapi.ContextFlagInteg
+	// Reasons for each flag being on or off:
+	//     Delegation: Off. We are not using delegated credentials.
+	//     Mutual: Off. Mutual authentication is already provided
+	//         as a result of how Kerberos works.
+	//     Replay: Off. We don’t need replay protection because each
+	//         packet is secured by a per-session key and is unique
+	//         within its session.
+	//     Sequence: Off. Out-of-order messages cannot happen in our
+	//         case, and if it somehow happened anyway it would
+	//         necessarily trigger other appropriate errors.
+	//     Confidentiality: Off. Our authentication itself does not
+	//         seem to be requesting or using any “security layers”
+	//         in the GSSAPI sense, and this is just one of the
+	//         security layer features. Also, if we were requesting
+	//         a GSSAPI security layer, we would be required to
+	//         set the mutual flag to on.
+	//         https://tools.ietf.org/html/rfc4752#section-3.1
+	//     Integrity: On. Must be on when calling the standard API,
+	//         so it probably must be set in the raw packet itself.
+	//         https://tools.ietf.org/html/rfc4752#section-3.1
+	//         https://tools.ietf.org/html/rfc4752#section-7
+	//     Anonymous: Off. We are not using an anonymous ticket.
+	//         https://tools.ietf.org/html/rfc6112#section-3
+
+	binary.LittleEndian.PutUint32(checksum[0:4], 16)
+	// checksum[4:20] is unused/blank channel binding settings.
+	binary.LittleEndian.PutUint32(checksum[20:24], uint32(flags))
+	return checksum
+}
+
+type gssapiToken struct {
+	OID    asn1.ObjectIdentifier
+	Object asn1.RawValue
+}
+
+func prependGSSAPITokenTag(payload []byte) ([]byte, error) {
+	// The GSSAPI "token" is almost an ASN.1 encoded object, except
+	// that the "token object" is raw bytes, not necessarily ASN.1.
+	// https://tools.ietf.org/html/rfc2743#page-81 (section 3.1)
+	token := gssapiToken{
+		OID:    asn1.ObjectIdentifier(gssapi.OIDKRB5.OID()),
+		Object: asn1.RawValue{FullBytes: payload},
+	}
+	return asn1.MarshalWithParams(token, "application")
+}
+
+type gokrb5v8Session struct {
+	key  types.EncryptionKey
+	done bool
+}
+
+func (s *gokrb5v8Session) Next(ctx context.Context, challenge []byte) (bool, []byte, error) {
+	if s.done {
+		return true, nil, nil
+	}
+	const tokenIsFromGSSAcceptor = true
+	challengeToken := gssapi.WrapToken{}
+	err := challengeToken.Unmarshal(challenge, tokenIsFromGSSAcceptor)
+	if err != nil {
+		return false, nil, err
+	}
+
+	valid, err := challengeToken.Verify(
+		s.key,
+		keyusage.GSSAPI_ACCEPTOR_SEAL,
+	)
+	if !valid {
+		return false, nil, err
+	}
+
+	responseToken, err := gssapi.NewInitiatorWrapToken(
+		challengeToken.Payload,
+		s.key,
+	)
+	if err != nil {
+		return false, nil, err
+	}
+
+	response, err := responseToken.Marshal()
+	if err != nil {
+		return false, nil, err
+	}
+
+	// We are are done, but we can't return `true` yet because
+	// the SASL loop calling this needs the first return to be
+	// `false` any time there are response bytes to send.
+	s.done = true
+	return false, response, nil
+}

--- a/sasl/sasl.go
+++ b/sasl/sasl.go
@@ -26,6 +26,19 @@ type Mechanism interface {
 	Start(ctx context.Context) (sess StateMachine, ir []byte, err error)
 }
 
+// NeedsHost is an optional interface for a SASL Mechanism that
+// needs to know the host it is doing the SASL handshake with.
+type NeedsHost interface {
+	// WithHost will be called before calling Start with the
+	// address of the Kafka broker being connected to. This
+	// will be the same address that was used to connect to
+	// the broker, without any port number.
+	//
+	// WithHost must return a Mechanism instance that will
+	// use the host address once Start is called on it.
+	WithHost(address string) Mechanism
+}
+
 // StateMachine implements the SASL challenge/response flow for a single SASL
 // handshake.  A StateMachine will be created by the Mechanism per connection,
 // so it does not need to be safe for concurrent access by multiple goroutines.


### PR DESCRIPTION
This PR implements GSSAPI/Kerberos support.

I previously commented in PR #563 from my personal account (@mentalisttraceur) about how we also implemented GSSAPI/Kerberos support at Viasat and just hadn't yet had time to create the PR yet - this is that PR.

---

Key differences from PR #563:

1. Supports Kafka clusters with multiple brokers.

2. The Kerberos client is dependency-injected and managed externally.

3. Some of the GSSAPI internals are explained more thoroughly in the code comments.

4. Supports authenticating with either username+password or keytab file.

---

I won't take anything personally, so:

* If you disagree with something I did or have criticisms/critique/concerns, or want me to change something, feel free to bring it up. For example, if we come up with a better way than dependency-injecting kerberos client objects from `gokrb5`, I'll be happy to implement it.

* I don't care which GSSAPI/Kerberos PR "wins", I just want to make sure that the end result supports complete functionality that we at Viasat and other typical users might need. For example, if this PR inspires improvements to #563 to support multiple brokers and username+password as an alternative to keytab, I will be fine if #563 gets merged instead of this one.

---

I will post another comment in here later to elaborate on my reasons for some choices I made in this PR, some alternatives I considered, and so on.