### PR TITLE
feat(reader): allow consuming from multiple topics with a group

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/kafka_test.go
+++ b/kafka_test.go
@@ -171,3 +171,17 @@ func BenchmarkUnmarshal(b *testing.B) {
 		})
 	}
 }
+
+type testKafkaLogger struct {
+	Prefix string
+	T      *testing.T
+}
+
+func newTestKafkaLogger(t *testing.T, prefix string) Logger {
+	return &testKafkaLogger{Prefix: prefix, T: t}
+}
+
+func (l *testKafkaLogger) Printf(msg string, args ...interface{}) {
+	l.T.Helper()
+	l.T.Logf(l.Prefix+" "+msg, args...)
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1453,6 +1453,9 @@ func TestConsumerGroupWithGroupTopicsMultple(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
 	conf := ReaderConfig{
 		Brokers:                []string{"localhost:9092"},
 		GroupID:                makeGroupID(),
@@ -1464,37 +1467,48 @@ func TestConsumerGroupWithGroupTopicsMultple(t *testing.T) {
 	}
 
 	r := NewReader(conf)
-	defer r.Close()
 
-	recvErr := make(chan error, len(conf.GroupTopics))
-	go func() {
-		msg, err := r.ReadMessage(ctx)
-		t.Log(msg)
-		recvErr <- err
-	}()
+	w := &Writer{
+		Addr:         TCP(r.config.Brokers...),
+		BatchTimeout: 10 * time.Millisecond,
+		BatchSize:    1,
+		Transport:    client.Transport,
+		Logger:       newTestKafkaLogger(t, "Writer:"),
+	}
+	defer w.Close()
 
-	time.Sleep(conf.MaxWait)
+	time.Sleep(time.Second)
 
-	for i, topic := range conf.GroupTopics {
-		client, shutdown := newLocalClientWithTopic(topic, 1)
-		defer shutdown()
-
-		w := &Writer{
-			Addr:         TCP(r.config.Brokers...),
-			Topic:        topic,
-			BatchTimeout: 10 * time.Millisecond,
-			BatchSize:    1,
-			Transport:    client.Transport,
-			Logger:       newTestKafkaLogger(t, fmt.Sprintf("Writer(%d):", i)),
-		}
-		defer w.Close()
-		if err := w.WriteMessages(ctx, Message{Value: []byte(topic)}); err != nil {
-			t.Fatalf("write error: %+v", err)
-		}
+	var msgs []Message
+	for _, topic := range conf.GroupTopics {
+		msgs = append(msgs, Message{Topic: topic})
+	}
+	if err := w.WriteMessages(ctx, msgs...); err != nil {
+		t.Logf("write error: %+v", err)
 	}
 
-	if err := <-recvErr; err != nil {
-		t.Fatalf("read error: %+v", err)
+	wg := new(sync.WaitGroup)
+	wg.Add(len(msgs))
+
+	go func() {
+		wg.Wait()
+		t.Log("closing reader")
+		r.Close()
+	}()
+
+	for {
+		msg, err := r.ReadMessage(ctx)
+		if err != nil {
+			if err == io.EOF {
+				t.Log("reader closed")
+				break
+			}
+
+			t.Fatalf("read error: %+v", err)
+		} else {
+			t.Logf("message read: %+v", msg)
+			wg.Done()
+		}
 	}
 
 	nMsgs := r.Stats().Messages

--- a/reader_test.go
+++ b/reader_test.go
@@ -1343,7 +1343,7 @@ func TestConsumerGroupWithMissingTopic(t *testing.T) {
 	}
 }
 
-func TestConsumerGroupWithSingleTopic(t *testing.T) {
+func TestConsumerGroupWithTopic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -1395,7 +1395,61 @@ func TestConsumerGroupWithSingleTopic(t *testing.T) {
 	}
 }
 
-func TestConsumerGroupWithMultpleTopics(t *testing.T) {
+func TestConsumerGroupWithGroupTopicsSingle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conf := ReaderConfig{
+		Brokers:                []string{"localhost:9092"},
+		GroupID:                makeGroupID(),
+		GroupTopics:            []string{makeTopic()},
+		MaxWait:                time.Second,
+		PartitionWatchInterval: 100 * time.Millisecond,
+		WatchPartitionChanges:  true,
+		Logger:                 newTestKafkaLogger(t, "Reader:"),
+	}
+
+	r := NewReader(conf)
+	defer r.Close()
+
+	recvErr := make(chan error, len(conf.GroupTopics))
+	go func() {
+		msg, err := r.ReadMessage(ctx)
+		t.Log(msg)
+		recvErr <- err
+	}()
+
+	time.Sleep(conf.MaxWait)
+
+	for i, topic := range conf.GroupTopics {
+		client, shutdown := newLocalClientWithTopic(topic, 1)
+		defer shutdown()
+
+		w := &Writer{
+			Addr:         TCP(r.config.Brokers...),
+			Topic:        topic,
+			BatchTimeout: 10 * time.Millisecond,
+			BatchSize:    1,
+			Transport:    client.Transport,
+			Logger:       newTestKafkaLogger(t, fmt.Sprintf("Writer(%d):", i)),
+		}
+		defer w.Close()
+		if err := w.WriteMessages(ctx, Message{Value: []byte(topic)}); err != nil {
+			t.Fatalf("write error: %+v", err)
+		}
+	}
+
+	if err := <-recvErr; err != nil {
+		t.Fatalf("read error: %+v", err)
+	}
+
+	nMsgs := r.Stats().Messages
+	if nMsgs != int64(len(conf.GroupTopics)) {
+		t.Fatalf("expected to receive %d messages, but got %d", len(conf.GroupTopics), nMsgs)
+	}
+}
+
+func TestConsumerGroupWithGroupTopicsMultple(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
This change allows the `Reader` to consume from multiple topics when being used with a consumer group. To opt into this behavior, you supply `config.GroupTopics` instead of `config.Topic`, the default behavior and config is unchanged.

The following open issues would be resolved by this change:
 - #595
 - #564

I've added test cases for several permutations of this new config:
 - `Topic`
 - `GroupTopics` (one value)
 - `GroupTopics` (multiple values)