### PR TITLE
Clarify Min/Max Bytes config for consumers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -97,7 +97,14 @@ type ConnConfig struct {
 
 // ReadBatchConfig is a configuration object used for reading batches of messages.
 type ReadBatchConfig struct {
+	// MinBytes indicates to the broken the minimum size a batch of messages must
+	// be when consuming. Setting a high minimum on a low-volume topic can result
+	// in messages appearing delayed if they never reach the minimum.
 	MinBytes int
+
+	// MaxBytes indicates to the broker the maximum size a batch of messages must
+	// be when consuming. A broker will truncate a message to respect this config,
+	// so use a value higher than the size of your largest message.
 	MaxBytes int
 
 	// IsolationLevel controls the visibility of transactional records.

--- a/conn.go
+++ b/conn.go
@@ -97,7 +97,7 @@ type ConnConfig struct {
 
 // ReadBatchConfig is a configuration object used for reading batches of messages.
 type ReadBatchConfig struct {
-	// MinBytes indicates to the broken the minimum size a batch of messages must
+	// MinBytes indicates to the broker the minimum size a batch of messages must
 	// be when consuming. Setting a high minimum on a low-volume topic can result
 	// in messages appearing delayed if they never reach the minimum.
 	MinBytes int

--- a/conn.go
+++ b/conn.go
@@ -97,14 +97,15 @@ type ConnConfig struct {
 
 // ReadBatchConfig is a configuration object used for reading batches of messages.
 type ReadBatchConfig struct {
-	// MinBytes indicates to the broker the minimum size a batch of messages must
-	// be when consuming. Setting a high minimum on a low-volume topic can result
-	// in messages appearing delayed if they never reach the minimum.
+	// MinBytes indicates to the broker the minimum batch size that the consumer
+	// will accept. Setting a high minimum when consuming from a low-volume topic
+	// may result in delayed delivery when the broker does not have enough data to
+	// satisfy the defined minimum.
 	MinBytes int
 
-	// MaxBytes indicates to the broker the maximum size a batch of messages must
-	// be when consuming. A broker will truncate a message to respect this config,
-	// so use a value higher than the size of your largest message.
+	// MaxBytes indicates to the broker the maximum batch size that the consumer
+	// will accept. The broker will truncate a message to satisfy this maximum, so
+	// choose a value that is high enough for your largest message size.
 	MaxBytes int
 
 	// IsolationLevel controls the visibility of transactional records.

--- a/conn_test.go
+++ b/conn_test.go
@@ -589,11 +589,11 @@ func testConnReadBatchWithNoMinMaxBytes(t *testing.T, conn *Conn) {
 	}
 
 	if err := batch.Close(); err != nil {
-		t.Fatal("error trying to close batch")
+		t.Fatalf("error trying to close batch: %s", err)
 	}
 
 	if err := batch.Err(); err != nil {
-		t.Fatal("broken batch")
+		t.Fatalf("broken batch: %s", err)
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -187,8 +187,9 @@ func TestConn(t *testing.T) {
 		},
 
 		{
-			scenario: "read a batch with no explicit min or max bytes",
-			function: testConnReadBatchWithNoMinMaxBytes,
+			scenario:   "read a batch with no explicit min or max bytes",
+			function:   testConnReadBatchWithNoMinMaxBytes,
+			minVersion: "0.11.0",
 		},
 
 		{

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/reader.go
+++ b/reader.go
@@ -345,7 +345,7 @@ type ReaderConfig struct {
 	// set.
 	QueueCapacity int
 
-	// MinBytes indicates to the broken the minimum size a batch of messages must
+	// MinBytes indicates to the broker the minimum size a batch of messages must
 	// be when consuming. Setting a high minimum on a low-volume topic can result
 	// in messages appearing delayed if they never reach the minimum.
 	//

--- a/reader.go
+++ b/reader.go
@@ -345,16 +345,17 @@ type ReaderConfig struct {
 	// set.
 	QueueCapacity int
 
-	// MinBytes indicates to the broker the minimum size a batch of messages must
-	// be when consuming. Setting a high minimum on a low-volume topic can result
-	// in messages appearing delayed if they never reach the minimum.
+	// MinBytes indicates to the broker the minimum batch size that the consumer
+	// will accept. Setting a high minimum when consuming from a low-volume topic
+	// may result in delayed delivery when the broker does not have enough data to
+	// satisfy the defined minimum.
 	//
 	// Default: 1
 	MinBytes int
 
-	// MaxBytes indicates to the broker the maximum size a batch of messages must
-	// be when consuming. A broker will truncate a message to respect this config,
-	// so use a value higher than the size of your largest message.
+	// MaxBytes indicates to the broker the maximum batch size that the consumer
+	// will accept. The broker will truncate a message to satisfy this maximum, so
+	// choose a value that is high enough for your largest message size.
 	//
 	// Default: 1MB
 	MaxBytes int

--- a/reader.go
+++ b/reader.go
@@ -345,8 +345,18 @@ type ReaderConfig struct {
 	// set.
 	QueueCapacity int
 
-	// Min and max number of bytes to fetch from kafka in each request.
+	// MinBytes indicates to the broken the minimum size a batch of messages must
+	// be when consuming. Setting a high minimum on a low-volume topic can result
+	// in messages appearing delayed if they never reach the minimum.
+	//
+	// Default: 1
 	MinBytes int
+
+	// MaxBytes indicates to the broker the maximum size a batch of messages must
+	// be when consuming. A broker will truncate a message to respect this config,
+	// so use a value higher than the size of your largest message.
+	//
+	// Default: 1MB
 	MaxBytes int
 
 	// Maximum amount of time to wait for new data to come when fetching batches


### PR DESCRIPTION
This PR aims to address some concerns raised by #607 and #608 by adding some much-needed clarity on the `MinBytes` and `MaxBytes` configuration used by `Reader` and `Conn.ReadBatch`.

In the case of `ReaderConfig`, default values are documented more clearly, and should be configured explicitly in the event of problems described later on.

In the case of `Conn`, using it with no defined value (ie: 0) for `MinBytes` and `MaxBytes` has undefined behavior. Upon adding a test case for this, it can be observed that in Kafka 0.10, this configuration will result in a batch error, but Kafka 0.11+ are able to handle this without issue. As such, the test case will give an exception to 0.10 and we can revisit if this behavior seems to regress in future versions of Kafka.