### PR TITLE
update isTimeout and isTemporary to properly unwrap errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 )
 
 // Error represents the different error codes that may be returned by kafka.
@@ -493,17 +492,17 @@ func (e Error) Description() string {
 }
 
 func isTimeout(err error) bool {
-	var opError net.Error
-	if errors.As(err, &opError) {
-		return opError.Timeout()
+	var timeoutError interface{ Timeout() bool }
+	if errors.As(err, &timeoutError) {
+		return timeoutError.Timeout()
 	}
 	return false
 }
 
 func isTemporary(err error) bool {
-	var opError net.Error
-	if errors.As(err, &opError) {
-		return opError.Temporary()
+	var tempError interface{ Temporary() bool }
+	if errors.As(err, &tempError) {
+		return tempError.Temporary()
 	}
 	return false
 }

--- a/error.go
+++ b/error.go
@@ -1,8 +1,10 @@
 package kafka
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net"
 )
 
 // Error represents the different error codes that may be returned by kafka.
@@ -491,17 +493,19 @@ func (e Error) Description() string {
 }
 
 func isTimeout(err error) bool {
-	e, ok := err.(interface {
-		Timeout() bool
-	})
-	return ok && e.Timeout()
+	var opError net.Error
+	if errors.As(err, &opError) {
+		return opError.Timeout()
+	}
+	return false
 }
 
 func isTemporary(err error) bool {
-	e, ok := err.(interface {
-		Temporary() bool
-	})
-	return ok && e.Temporary()
+	var opError net.Error
+	if errors.As(err, &opError) {
+		return opError.Temporary()
+	}
+	return false
 }
 
 func silentEOF(err error) error {


### PR DESCRIPTION
the previous implementation does not properly unwrap errors to check if it is a `net.Error`, which was wrapped here:

https://github.com/segmentio/kafka-go/blob/master/produce.go#L139
```
return nil, fmt.Errorf("kafka.(*Client).Produce: %w", err)
```

this leads this issues where the error is not correctly handled when calling `isTemporary` or `isTimeout`

```
error writing messages to TOPIC (partition 12): kafka.(*Client).Produce: dial tcp IP:21948: i/o timeout
```


specifically in the code block here in `writeBatch`
https://github.com/segmentio/kafka-go/blob/master/writer.go#L780-L782

```
		if !isTemporary(err) {
			break
		}
```