### PR TITLE
feat(client): add topic partition count helper

### DIFF
--- a/topicpartitioncount.go
+++ b/topicpartitioncount.go
@@ -1,0 +1,28 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+)
+
+// TopicPartitionCount returns the number of partitions for a given topic, which
+// can be used by the caller for any sort of balancing/partitioning strategy.
+func (c *Client) TopicPartitionCount(ctx context.Context, topic string) (int, error) {
+	req := MetadataRequest{Topics: []string{topic}}
+	res, err := c.Metadata(ctx, &req)
+	if err != nil {
+		return 0, fmt.Errorf("kafka.(*Client).TopicPartitionCount for Topic '%s': %w", topic, err)
+	}
+
+	if len(res.Topics) > 0 {
+		t := res.Topics[0]
+
+		if t.Error != nil {
+			return 0, fmt.Errorf("kafka.(*Client).TopicPartitionCount for Topic '%s': %w", topic, t.Error)
+		}
+
+		return len(t.Partitions), nil
+	}
+
+	return 0, UnknownTopicOrPartition
+}

--- a/writer.go
+++ b/writer.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	metadataAPI "github.com/segmentio/kafka-go/protocol/metadata"
 )
 
 // The Writer type provides the implementation of a producer of kafka messages
@@ -820,29 +818,7 @@ func (w *Writer) produce(key topicPartition, batch *writeBatch) (*ProduceRespons
 }
 
 func (w *Writer) partitions(ctx context.Context, topic string) (int, error) {
-	client := w.client(w.readTimeout())
-	// Here we use the transport directly as an optimization to avoid the
-	// construction of temporary request and response objects made by the
-	// (*Client).Metadata API.
-	//
-	// It is expected that the transport will optimize this request by
-	// caching recent results (the kafka.Transport types does).
-	r, err := client.transport().RoundTrip(ctx, client.Addr, &metadataAPI.Request{
-		TopicNames: []string{topic},
-	})
-	if err != nil {
-		return 0, err
-	}
-	for _, t := range r.(*metadataAPI.Response).Topics {
-		if t.Name == topic {
-			// This should always hit, unless kafka has a bug.
-			if t.ErrorCode != 0 {
-				return 0, Error(t.ErrorCode)
-			}
-			return len(t.Partitions), nil
-		}
-	}
-	return 0, UnknownTopicOrPartition
+	return w.client(w.readTimeout()).TopicPartitionCount(ctx, topic)
 }
 
 func (w *Writer) markClosed() {


### PR DESCRIPTION
This moves logic for discovering partitions on a topic from `Writer` to `Client`, which should make it easier to write lower-level programs that don't need batching functionality. If accepted, this should fix #617, but opening as a Draft to get some feedback first.