### PR TITLE
allow resetting offsets to either earliest or latest

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -1113,7 +1113,14 @@ func (cg *ConsumerGroup) fetchOffsets(conn coordinator, subs map[string][]int32)
 				if partition == pr.Partition {
 					offset := pr.Offset
 					if offset < 0 {
-						offset = cg.config.StartOffset
+						// If offset is one of the magic sentinel numbers (-1, -2), respect it.
+						// Whereas if offset is otherwise negative, set it to the default StartOffset.
+						switch offset {
+						case FirstOffset:
+						case LastOffset:
+						default:
+							offset = cg.config.StartOffset
+						}
 					}
 					offsetsByPartition[int(partition)] = offset
 				}


### PR DESCRIPTION
Kafka has a notion of magic sentinel numbers (-1, -2) for consumer offset values [1],
which are meant to signal that the consumer should start from earliest (first) or
latest (last) available offset for a given partition.

Instead of obeying that signal, we would unconditionally respect the default
`StartOffset` value from the configuration when reading a negative offset upon
synchronizing consumergroup state (such as at initialization).

Hence you could *only* have either "read from earliest" or "read from latest".
behavior from your consumers when you reset the offsets to one of these
sentinel values.

With this change, the consumer will respect the returned value if it is -1
or -2, allowing an operator to start a consumer at earliest or latest irrespective
of the configured value of `StartOffset`.

## Example of consumer offsets working


```
% kafka-console-consumer.sh \
  --bootstrap-server localhost:9092 \
  --consumer-property exclude.internal.topics=false \
  --formatter 'kafka.coordinator.group.GroupMetadataManager$OffsetsMessageFormatter' \
  --topic __consumer_offsets | grep -v __consumer_offset 
...
[test-group,topic-default,0]::[OffsetMetadata[5433,NO_METADATA],CommitTime 1620981162537,ExpirationTime 1621067562537]
[test-group,topic-default,0]::[OffsetMetadata[5434,NO_METADATA],CommitTime 1620981162540,ExpirationTime 1621067562540]
[test-group,topic-default,0]::[OffsetMetadata[5435,NO_METADATA],CommitTime 1620981162543,ExpirationTime 1621067562543]
[test-group,topic-default,0]::[OffsetMetadata[5436,NO_METADATA],CommitTime 1620981162545,ExpirationTime 1621067562545]
# Stop the consumer, while letting the producer continue, then reset the offset to -1 (latest)
[test-group,topic-default,0]::[OffsetMetadata[-1,NO_METADATA],CommitTime 1620981192527,ExpirationTime 1621067592527]
# Restart the consumer.
[test-group,topic-default,0]::[OffsetMetadata[6040,NO_METADATA],CommitTime 1620981518165,ExpirationTime 1621067918165]
# Note that the consumer started at latest, instead of the earliest offset.
[test-group,topic-default,0]::[OffsetMetadata[6041,NO_METADATA],CommitTime 1620981518170,ExpirationTime 1621067918170]
# Stop the consumer again, and reset the offset to -2 (earliest)
[test-group,topic-default,0]::[OffsetMetadata[-2,NO_METADATA],CommitTime 1620981551179,ExpirationTime 1621067951179]
[test-group,topic-default,0]::[OffsetMetadata[1,NO_METADATA],CommitTime 1620981631351,ExpirationTime 1621068031351]
# We see the consumer started at the earliest offset instead of the latest.
[test-group,topic-default,0]::[OffsetMetadata[2,NO_METADATA],CommitTime 1620981631354,ExpirationTime 1621068031354]
[test-group,topic-default,0]::[OffsetMetadata[3,NO_METADATA],CommitTime 1620981631358,ExpirationTime 1621068031358]
[test-group,topic-default,0]::[OffsetMetadata[4,NO_METADATA],CommitTime 1620981631361,ExpirationTime 1621068031361]
[test-group,topic-default,0]::[OffsetMetadata[5,NO_METADATA],CommitTime 1620981631364,ExpirationTime 1621068031364]
```

[1] From the kafka wiki for the [ListOffset API](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetAPI(AKAListOffset)):

> Field: Time
>
> Description:
> Used to ask for all messages before a certain time (ms). There are two special values
> Specify -1 to receive the latest offset (i.e. the offset of the next coming message)
> and -2 to receive the earliest available offset. This applies to all versions of the API.
> Note that because offsets are pulled in descending order, asking for the earliest offset
> will always return you a single element.