### PR TITLE
Document default value for ReaderConfig.MaxWait

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -381,6 +381,8 @@ type ReaderConfig struct {
 
 	// Maximum amount of time to wait for new data to come when fetching batches
 	// of messages from kafka.
+	//
+	// Default: 10s
 	MaxWait time.Duration
 
 	// ReadLagInterval sets the frequency at which the reader lag is updated.


### PR DESCRIPTION
**What**: Document the default value for `ReaderConfig.MaxWait`
**Why**: Makes it clearer — the reader of the configuration does not need to look into the implementation to know the default
**How**: Add a comment on top of the MaxWait definition

Source where the default is being set:
https://github.com/segmentio/kafka-go/blob/master/reader.go#L629 :

```
	if config.MaxWait == 0 {
		config.MaxWait = 10 * time.Second
	}
```

Disclaimer: Not used to contribute to OS projects .
Thanks: For the time dedicated creating/maintaining the project




