### PR TITLE
Retry the writing of messages on transient network errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"syscall"
 )
 
 // Error represents the different error codes that may be returned by kafka.
@@ -505,6 +506,13 @@ func isTemporary(err error) bool {
 		return tempError.Temporary()
 	}
 	return false
+}
+
+func isTransientNetworkError(err error) bool {
+	return errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE)
 }
 
 func silentEOF(err error) error {

--- a/writer.go
+++ b/writer.go
@@ -777,7 +777,7 @@ func (w *Writer) writeBatch(key topicPartition, batch *writeBatch) {
 			log.Printf("error writing messages to %s (partition %d): %s", key.topic, key.partition, err)
 		})
 
-		if !isTemporary(err) {
+		if !isTemporary(err) && !isTransientNetworkError(err) {
 			break
 		}
 	}


### PR DESCRIPTION
After upgrading to 0.4 (v0.4.16) from 0.3 we noticed that if a broker goes down in our kafka cluster, the ongoing writes to its partitions are failing with network connection errors and without any retry attempts.
That causes these writes to fail although they would have succeeded if retried due to the other healthy brokers in the cluster taking the partitions leadership.

I think that although network connection errors are not considered temporary, they should be treated as transient errors in this scenario, as the writer is usually working against a cluster of brokers that tolerates server failures (up to the configured replication factor).

In this PR I’ve added another condition to the breaking retry loop check that validates that the received error is not a transient network error before exiting the loop.

I’ve reproduced the issue locally and validated that this change indeed fixes it.

I would love to hear your thoughts.