### PR TITLE
Only refresh metadata on success (#672)

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -60,6 +60,9 @@ func TestIssue672(t *testing.T) {
 			case <-ctx.Done():
 				return
 			case e := <-wake:
+				if e == nil {
+					return
+				}
 				e.trigger()
 			}
 		}

--- a/transport_test.go
+++ b/transport_test.go
@@ -3,8 +3,13 @@ package kafka
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol"
+	"github.com/segmentio/kafka-go/protocol/createtopics"
 )
 
 func TestIssue477(t *testing.T) {
@@ -30,5 +35,130 @@ func TestIssue477(t *testing.T) {
 		t.Log(err)
 	} else {
 		t.Error("no error was reported when attempting to establish a TLS connection to a non-TLS endpoint")
+	}
+}
+
+func TestIssue672(t *testing.T) {
+	// ensure the test times out if the bug is re-introduced
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// we'll simulate a situation with one good topic and one bad topic (bad configuration)
+	const brokenTopicName = "bad-topic"
+	const okTopicName = "good-topic"
+
+	// make the connection pool think it's immediately ready to send
+	ready := make(chan struct{})
+	close(ready)
+
+	// allow the system to wake as much as it wants
+	wake := make(chan event)
+	defer close(wake)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e := <-wake:
+				e.trigger()
+			}
+		}
+	}()
+
+	// handle requests by immediately resolving them with a create topics response,
+	// the "bad topic" will have an error value
+	requests := make(chan connRequest, 1)
+	defer close(requests)
+	go func() {
+		request := <-requests
+		request.res.resolve(&createtopics.Response{
+			ThrottleTimeMs: 0,
+			Topics: []createtopics.ResponseTopic{
+				{
+					Name:         brokenTopicName,
+					ErrorCode:    int16(InvalidPartitionNumber),
+					ErrorMessage: InvalidPartitionNumber.Description(),
+				},
+				{
+					Name:              okTopicName,
+					NumPartitions:     1,
+					ReplicationFactor: 1,
+				},
+			},
+		})
+	}()
+
+	pool := &connPool{
+		ready: ready,
+		wake:  wake,
+		conns: map[int32]*connGroup{},
+	}
+
+	// configure the state so it can find the good topic, but not the one that fails to create
+	pool.setState(connPoolState{
+		layout: protocol.Cluster{
+			Topics: map[string]protocol.Topic{
+				okTopicName: {
+					Name: okTopicName,
+					Partitions: map[int32]protocol.Partition{
+						0: {},
+					},
+				},
+			},
+		},
+	})
+
+	// trick the connection pool into thinking it has a valid connection to a broker
+	pool.conns[0] = &connGroup{
+		pool:   pool,
+		broker: Broker{},
+		idleConns: []*conn{
+			{
+				reqs: requests,
+			},
+		},
+	}
+
+	// perform the round trip:
+	// - if the issue is presenting this will hang waiting for metadata to arrive that will
+	//   never arrive, causing a deadline timeout.
+	// - if the issue is fixed this will resolve almost instantaneously
+	r, err := pool.roundTrip(ctx, &createtopics.Request{
+		Topics: []createtopics.RequestTopic{
+			{
+				Name:              brokenTopicName,
+				NumPartitions:     0,
+				ReplicationFactor: 1,
+			},
+			{
+				Name:              okTopicName,
+				NumPartitions:     1,
+				ReplicationFactor: 1,
+			},
+		},
+	})
+	// detect if the issue is presenting using the context timeout (note that checking the err return value
+	// isn't good enough as the original implementation didn't return the context cancellation error due to
+	// being run in a defer)
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("issue 672 is presenting! roundTrip should not have timed out")
+	}
+
+	// ancillary assertions as general house-keeping, not directly related to the issue:
+
+	// we're not expecting any errors in this test
+	if err != nil {
+		t.Fatalf("unexpected error provoking connection pool roundTrip: %v", err)
+	}
+
+	// we expect a response containing the errors from the broker
+	if r == nil {
+		t.Fatal("expected a non-nil response")
+	}
+
+	// we expect to have the create topic response with created earlier
+	_, ok := r.(*createtopics.Response)
+	if !ok {
+		t.Fatalf("expected a createtopics.Response but got %T", r)
 	}
 }


### PR DESCRIPTION
Whilst I've made the changes that were agreed in the [GitHub issue](https://github.com/segmentio/kafka-go/issues/672), I haven't done any testing. Please advise on any testing you'd like me to do, above and beyond the unit tests that I assume will be run automatically on the PR after I've submitted it.

Note: I will endeavor to test that this change _actually fixes_ the issue on Monday when I'm back at work (and have access to the codebase where the issue presents).