### PR TITLE
Explicitly document defaults to RequiredAcks and Async

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -135,12 +135,15 @@ type Writer struct {
 	//  RequireOne  (1)  wait for the leader to acknowledge the writes
 	//  RequireAll  (-1) wait for the full ISR to acknowledge the writes
 	//
+	// Defaults to RequireNone.
 	RequiredAcks RequiredAcks
 
 	// Setting this flag to true causes the WriteMessages method to never block.
 	// It also means that errors are ignored since the caller will not receive
 	// the returned value. Use this only if you don't care about guarantees of
 	// whether the messages were written to kafka.
+	//
+	// Defaults to false.
 	Async bool
 
 	// An optional function called when the writer succeeds or fails the


### PR DESCRIPTION
Background
Was wondering what the default value of RequiredAcks was and was looking across writer.go and writer_test.go files. 
This PR is to help people like me know the same without wondering if there is an override of the same, down the call hierarchy