### PR TITLE
add unit tests for protocol/

### DIFF
--- a/protocol/alterconfigs/alterconfigs_test.go
+++ b/protocol/alterconfigs/alterconfigs_test.go
@@ -17,7 +17,7 @@ func TestAlterConfigsRequest(t *testing.T) {
 		ValidateOnly: true,
 		Resources: []alterconfigs.RequestResources{
 			{
-				ResourceType: 0,
+				ResourceType: 1,
 				ResourceName: "foo",
 				Configs: []alterconfigs.RequestConfig{
 					{
@@ -33,7 +33,7 @@ func TestAlterConfigsRequest(t *testing.T) {
 		ValidateOnly: true,
 		Resources: []alterconfigs.RequestResources{
 			{
-				ResourceType: 0,
+				ResourceType: 1,
 				ResourceName: "foo",
 				Configs: []alterconfigs.RequestConfig{
 					{
@@ -51,9 +51,9 @@ func TestAlterConfigsResponse(t *testing.T) {
 		ThrottleTimeMs: 500,
 		Responses: []alterconfigs.ResponseResponses{
 			{
-				ErrorCode:    0,
+				ErrorCode:    1,
 				ErrorMessage: "foo",
-				ResourceType: 0,
+				ResourceType: 1,
 				ResourceName: "foo",
 			},
 		},
@@ -63,9 +63,9 @@ func TestAlterConfigsResponse(t *testing.T) {
 		ThrottleTimeMs: 500,
 		Responses: []alterconfigs.ResponseResponses{
 			{
-				ErrorCode:    0,
+				ErrorCode:    1,
 				ErrorMessage: "foo",
-				ResourceType: 0,
+				ResourceType: 1,
 				ResourceName: "foo",
 			},
 		},

--- a/protocol/alterconfigs/alterconfigs_test.go
+++ b/protocol/alterconfigs/alterconfigs_test.go
@@ -1,0 +1,73 @@
+package alterconfigs_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go/protocol/alterconfigs"
+	"github.com/segmentio/kafka-go/protocol/prototest"
+)
+
+const (
+	v0 = 0
+	v1 = 1
+)
+
+func TestAlterConfigsRequest(t *testing.T) {
+	prototest.TestRequest(t, v0, &alterconfigs.Request{
+		ValidateOnly: true,
+		Resources: []alterconfigs.RequestResources{
+			{
+				ResourceType: 0,
+				ResourceName: "foo",
+				Configs: []alterconfigs.RequestConfig{
+					{
+						Name:  "foo",
+						Value: "foo",
+					},
+				},
+			},
+		},
+	})
+
+	prototest.TestRequest(t, v1, &alterconfigs.Request{
+		ValidateOnly: true,
+		Resources: []alterconfigs.RequestResources{
+			{
+				ResourceType: 0,
+				ResourceName: "foo",
+				Configs: []alterconfigs.RequestConfig{
+					{
+						Name:  "foo",
+						Value: "foo",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAlterConfigsResponse(t *testing.T) {
+	prototest.TestResponse(t, v0, &alterconfigs.Response{
+		ThrottleTimeMs: 500,
+		Responses: []alterconfigs.ResponseResponses{
+			{
+				ErrorCode:    0,
+				ErrorMessage: "foo",
+				ResourceType: 0,
+				ResourceName: "foo",
+			},
+		},
+	})
+
+	prototest.TestResponse(t, v1, &alterconfigs.Response{
+		ThrottleTimeMs: 500,
+		Responses: []alterconfigs.ResponseResponses{
+			{
+				ErrorCode:    0,
+				ErrorMessage: "foo",
+				ResourceType: 0,
+				ResourceName: "foo",
+			},
+		},
+	})
+}

--- a/protocol/createpartitions/createpartitions_test.go
+++ b/protocol/createpartitions/createpartitions_test.go
@@ -52,7 +52,7 @@ func TestCreatePartitionsResponse(t *testing.T) {
 		Results: []createpartitions.ResponseResult{
 			{
 				Name:         "foo",
-				ErrorCode:    0,
+				ErrorCode:    1,
 				ErrorMessage: "foo",
 			},
 		},
@@ -63,7 +63,7 @@ func TestCreatePartitionsResponse(t *testing.T) {
 		Results: []createpartitions.ResponseResult{
 			{
 				Name:         "foo",
-				ErrorCode:    0,
+				ErrorCode:    1,
 				ErrorMessage: "foo",
 			},
 		},

--- a/protocol/createpartitions/createpartitions_test.go
+++ b/protocol/createpartitions/createpartitions_test.go
@@ -1,0 +1,71 @@
+package createpartitions_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go/protocol/createpartitions"
+	"github.com/segmentio/kafka-go/protocol/prototest"
+)
+
+const (
+	v0 = 0
+	v1 = 1
+)
+
+func TestCreatePartitionsRequest(t *testing.T) {
+	prototest.TestRequest(t, v0, &createpartitions.Request{
+		Topics: []createpartitions.RequestTopic{
+			{
+				Name:  "foo",
+				Count: 1,
+				Assignments: []createpartitions.RequestAssignment{
+					{
+						BrokerIDs: []int32{1, 2, 3},
+					},
+				},
+			},
+		},
+		TimeoutMs:    500,
+		ValidateOnly: false,
+	})
+
+	prototest.TestRequest(t, v1, &createpartitions.Request{
+		Topics: []createpartitions.RequestTopic{
+			{
+				Name:  "foo",
+				Count: 1,
+				Assignments: []createpartitions.RequestAssignment{
+					{
+						BrokerIDs: []int32{1, 2, 3},
+					},
+				},
+			},
+		},
+		TimeoutMs:    500,
+		ValidateOnly: false,
+	})
+}
+
+func TestCreatePartitionsResponse(t *testing.T) {
+	prototest.TestResponse(t, v0, &createpartitions.Response{
+		ThrottleTimeMs: 500,
+		Results: []createpartitions.ResponseResult{
+			{
+				Name:         "foo",
+				ErrorCode:    0,
+				ErrorMessage: "foo",
+			},
+		},
+	})
+
+	prototest.TestResponse(t, v1, &createpartitions.Response{
+		ThrottleTimeMs: 500,
+		Results: []createpartitions.ResponseResult{
+			{
+				Name:         "foo",
+				ErrorCode:    0,
+				ErrorMessage: "foo",
+			},
+		},
+	})
+}

--- a/protocol/deletetopics/deletetopics_test.go
+++ b/protocol/deletetopics/deletetopics_test.go
@@ -1,0 +1,74 @@
+package deletetopics_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go/protocol/deletetopics"
+	"github.com/segmentio/kafka-go/protocol/prototest"
+)
+
+const (
+	v0 = 0
+	v1 = 1
+	v3 = 3
+)
+
+func TestDeleteTopicsRequest(t *testing.T) {
+	prototest.TestRequest(t, v0, &deletetopics.Request{
+		TopicNames: []string{"foo", "bar"},
+		TimeoutMs:  500,
+	})
+
+	prototest.TestRequest(t, v1, &deletetopics.Request{
+		TopicNames: []string{"foo", "bar"},
+		TimeoutMs:  500,
+	})
+
+	prototest.TestRequest(t, v3, &deletetopics.Request{
+		TopicNames: []string{"foo", "bar"},
+		TimeoutMs:  500,
+	})
+}
+
+func TestDeleteTopicsResponse(t *testing.T) {
+	prototest.TestResponse(t, v0, &deletetopics.Response{
+		Responses: []deletetopics.ResponseTopic{
+			{
+				Name:      "foo",
+				ErrorCode: 0,
+			},
+			{
+				Name:      "bar",
+				ErrorCode: 0,
+			},
+		},
+	})
+
+	prototest.TestResponse(t, v1, &deletetopics.Response{
+		ThrottleTimeMs: 500,
+		Responses: []deletetopics.ResponseTopic{
+			{
+				Name:      "foo",
+				ErrorCode: 0,
+			},
+			{
+				Name:      "bar",
+				ErrorCode: 0,
+			},
+		},
+	})
+
+	prototest.TestResponse(t, v3, &deletetopics.Response{
+		ThrottleTimeMs: 500,
+		Responses: []deletetopics.ResponseTopic{
+			{
+				Name:      "foo",
+				ErrorCode: 0,
+			},
+			{
+				Name:      "bar",
+				ErrorCode: 0,
+			},
+		},
+	})
+}

--- a/protocol/deletetopics/deletetopics_test.go
+++ b/protocol/deletetopics/deletetopics_test.go
@@ -35,11 +35,11 @@ func TestDeleteTopicsResponse(t *testing.T) {
 		Responses: []deletetopics.ResponseTopic{
 			{
 				Name:      "foo",
-				ErrorCode: 0,
+				ErrorCode: 1,
 			},
 			{
 				Name:      "bar",
-				ErrorCode: 0,
+				ErrorCode: 1,
 			},
 		},
 	})
@@ -49,11 +49,11 @@ func TestDeleteTopicsResponse(t *testing.T) {
 		Responses: []deletetopics.ResponseTopic{
 			{
 				Name:      "foo",
-				ErrorCode: 0,
+				ErrorCode: 1,
 			},
 			{
 				Name:      "bar",
-				ErrorCode: 0,
+				ErrorCode: 1,
 			},
 		},
 	})
@@ -63,11 +63,11 @@ func TestDeleteTopicsResponse(t *testing.T) {
 		Responses: []deletetopics.ResponseTopic{
 			{
 				Name:      "foo",
-				ErrorCode: 0,
+				ErrorCode: 1,
 			},
 			{
 				Name:      "bar",
-				ErrorCode: 0,
+				ErrorCode: 1,
 			},
 		},
 	})

--- a/protocol/electleaders/electleaders_test.go
+++ b/protocol/electleaders/electleaders_test.go
@@ -52,7 +52,7 @@ func TestElectLeadersResponse(t *testing.T) {
 
 	prototest.TestResponse(t, v1, &electleaders.Response{
 		ThrottleTime: 500,
-		ErrorCode:    0,
+		ErrorCode:    1,
 		ReplicaElectionResults: []electleaders.ResponseReplicaElectionResult{
 			{
 				Topic: "foo",

--- a/protocol/electleaders/electleaders_test.go
+++ b/protocol/electleaders/electleaders_test.go
@@ -1,0 +1,67 @@
+package electleaders_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go/protocol/electleaders"
+	"github.com/segmentio/kafka-go/protocol/prototest"
+)
+
+const (
+	v0 = 0
+	v1 = 1
+)
+
+func TestElectLeadersRequest(t *testing.T) {
+	prototest.TestRequest(t, v0, &electleaders.Request{
+		TimeoutMs: 500,
+		TopicPartitions: []electleaders.RequestTopicPartitions{
+			{
+				Topic:        "foo",
+				PartitionIDs: []int32{100, 101, 102},
+			},
+		},
+	})
+
+	prototest.TestRequest(t, v1, &electleaders.Request{
+		ElectionType: 1,
+		TimeoutMs:    500,
+		TopicPartitions: []electleaders.RequestTopicPartitions{
+			{
+				Topic:        "foo",
+				PartitionIDs: []int32{100, 101, 102},
+			},
+		},
+	})
+}
+
+func TestElectLeadersResponse(t *testing.T) {
+	prototest.TestResponse(t, v0, &electleaders.Response{
+		ThrottleTime: 500,
+		ReplicaElectionResults: []electleaders.ResponseReplicaElectionResult{
+			{
+				Topic: "foo",
+				PartitionResults: []electleaders.ResponsePartitionResult{
+					{PartitionID: 100, ErrorCode: 0, ErrorMessage: ""},
+					{PartitionID: 101, ErrorCode: 0, ErrorMessage: ""},
+					{PartitionID: 102, ErrorCode: 0, ErrorMessage: ""},
+				},
+			},
+		},
+	})
+
+	prototest.TestResponse(t, v1, &electleaders.Response{
+		ThrottleTime: 500,
+		ErrorCode:    0,
+		ReplicaElectionResults: []electleaders.ResponseReplicaElectionResult{
+			{
+				Topic: "foo",
+				PartitionResults: []electleaders.ResponsePartitionResult{
+					{PartitionID: 100, ErrorCode: 0, ErrorMessage: ""},
+					{PartitionID: 101, ErrorCode: 0, ErrorMessage: ""},
+					{PartitionID: 102, ErrorCode: 0, ErrorMessage: ""},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Document: https://kafka.apache.org/protocol.html

This PR includes the following commits:

- https://github.com/segmentio/kafka-go/commit/b4e6be33b704cd8ac268f30adfa2600ad834130a: protocol/alterconfigs
- https://github.com/segmentio/kafka-go/pull/695/commits/c859f72577b5e59db9345335bc2cb46c09b1de6a: protocol/createpartitions
- https://github.com/segmentio/kafka-go/pull/695/commits/4fac6aa9e89f3ffb9d8a8b40ac4b5c0209bdd3c1: protocol/deletetopics
- https://github.com/segmentio/kafka-go/pull/695/commits/2c3018278fbf51aca622d0e35b6cd1c9c974098d: protocol/electleaders
