### PR TITLE
WIP: Allow Writer to auto-create topics (Fixes #683)

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -356,11 +356,10 @@ func TestDialerResolver(t *testing.T) {
 			}
 
 			// Write a message to ensure the partition gets created.
-			w := NewWriter(WriterConfig{
-				Brokers: []string{"localhost:9092"},
-				Topic:   topic,
-				Dialer:  &d,
-			})
+			w := Writer{
+				Addr:  TCP("localhost:9092"),
+				Topic: topic,
+			}
 			w.WriteMessages(context.Background(), Message{})
 			w.Close()
 

--- a/transport.go
+++ b/transport.go
@@ -344,11 +344,14 @@ func (p *connPool) roundTrip(ctx context.Context, req Request) (Response, error)
 
 	switch m := req.(type) {
 	case *meta.Request:
-		// We serve metadata requests directly from the transport cache.
+		// We serve metadata requests directly from the transport cache unless
+		// we are explicitly requesting auto-topic creation.
 		//
 		// This reduces the number of round trips to kafka brokers while keeping
 		// the logic simple when applying partitioning strategies.
-		if state.err != nil {
+		if m.AllowAutoTopicCreation {
+			p.refreshMetadata(ctx, m.TopicNames)
+		} else if state.err != nil {
 			return nil, state.err
 		}
 		return filterMetadataResponse(m, state.metadata), nil

--- a/writer.go
+++ b/writer.go
@@ -831,7 +831,8 @@ func (w *Writer) partitions(ctx context.Context, topic string) (int, error) {
 	// It is expected that the transport will optimize this request by
 	// caching recent results (the kafka.Transport types does).
 	r, err := client.transport().RoundTrip(ctx, client.Addr, &metadataAPI.Request{
-		TopicNames: []string{topic},
+		TopicNames:             []string{topic},
+		AllowAutoTopicCreation: true,
 	})
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Addresses #683 by enabling auto-topic creation from `kafka.Writer.WriteMessages` 

Auto-topic creation is still asynchronous, so you are still likely to run into a "in the middle of a leader election" error if the topic has not yet been created, and you will need to keep retrying until Kafka creates the topic. 

This is still a WIP, just putting the idea out there for initial feedback. 