### PR TITLE
advance batch offset where empty message resides at the end

### DIFF
--- a/message.go
+++ b/message.go
@@ -472,6 +472,10 @@ func (r *messageSetReaderV2) readMessage(min int64,
 		if r.remain == 0 {
 			if r.parent != nil {
 				r.readerStack = r.parent
+			} else {
+				// we can't replace the readerstack and there's no bytes remaining left to read
+				err = errEndOfBatch
+				return
 			}
 		}
 

--- a/read.go
+++ b/read.go
@@ -12,7 +12,10 @@ type readable interface {
 	readFrom(*bufio.Reader, int) (int, error)
 }
 
-var errShortRead = errors.New("not enough bytes available to load the response")
+var (
+	errShortRead = errors.New("not enough bytes available to load the response")
+	errEndOfBatch = errors.New("no bytes remaining on a read attempt")
+)
 
 func peekRead(r *bufio.Reader, sz int, n int, f func([]byte)) (int, error) {
 	if n > sz {


### PR DESCRIPTION
We've seen issues in being able to advance grouped consumers where the last record in a batch has no bytes. More details on this issue can be seen here https://github.com/segmentio/kafka-go/issues/621  