### PR TITLE
Preserve message order across batches.

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -189,7 +189,7 @@ type Writer struct {
 	closed uint32
 	group  sync.WaitGroup
 
-	// Manages the curret set of partition-topic writers.
+	// Manages the current set of partition-topic writers.
 	mutex   sync.Mutex
 	writers map[topicPartition]*ptWriter
 

--- a/writer.go
+++ b/writer.go
@@ -1139,7 +1139,7 @@ func (ptw *ptWriter) close() {
 		ptw.currBatch = nil
 		batch.trigger()
 	}
-
+	ptw.w = nil
 	ptw.queue.Close()
 
 	ptw.group.Wait()

--- a/writer.go
+++ b/writer.go
@@ -896,8 +896,9 @@ func (b *batchQueue) Get() *writeBatch {
 		return nil
 	}
 
-	var batch *writeBatch
-	batch, b.queue = b.queue[0], b.queue[1:]
+	batch := b.queue[0]
+	b.queue[0] = nil
+	b.queue = b.queue[1:]
 
 	return batch
 }

--- a/writer.go
+++ b/writer.go
@@ -189,9 +189,9 @@ type Writer struct {
 	closed uint32
 	group  sync.WaitGroup
 
-	// Manages the current batch being aggregated on the writer.
+	// Manages the curret set of partition-topic writers.
 	mutex   sync.Mutex
-	batches map[topicPartition]*writeBatch
+	writers map[topicPartition]*ptWriter
 
 	// writer stats are all made of atomic values, no need for synchronization.
 	// Use a pointer to ensure 64-bit alignment of the values. The once value is
@@ -511,15 +511,11 @@ func NewWriter(config WriterConfig) *Writer {
 // io.ErrClosedPipe.
 func (w *Writer) Close() error {
 	w.markClosed()
-	// If batches are pending, trigger them so messages get sent.
 	w.mutex.Lock()
 
-	for _, batch := range w.batches {
-		batch.trigger()
-	}
-
-	for partition := range w.batches {
-		delete(w.batches, partition)
+	// close all writers to trigger any pending batches
+	for _, writer := range w.writers {
+		writer.close()
 	}
 
 	w.mutex.Unlock()
@@ -653,156 +649,27 @@ func (w *Writer) batchMessages(messages []Message, assignments map[topicPartitio
 		batches = make(map[*writeBatch][]int32, len(assignments))
 	}
 
-	batchSize := w.batchSize()
-	batchBytes := w.batchBytes()
-
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	if w.batches == nil {
-		w.batches = map[topicPartition]*writeBatch{}
+	if w.writers == nil {
+		w.writers = map[topicPartition]*ptWriter{}
 	}
 
 	for key, indexes := range assignments {
-		for _, i := range indexes {
-		assignMessage:
-			batch := w.batches[key]
-			if batch == nil {
-				batch = w.newWriteBatch(key)
-				w.batches[key] = batch
-			}
-			if !batch.add(messages[i], batchSize, batchBytes) {
-				batch.trigger()
-				delete(w.batches, key)
-				goto assignMessage
-			}
-			if batch.full(batchSize, batchBytes) {
-				batch.trigger()
-				delete(w.batches, key)
-			}
-			if !w.Async {
-				batches[batch] = append(batches[batch], i)
-			}
+		writer := w.writers[key]
+		if writer == nil {
+			writer = newPartitionWriter(w, key)
+			w.writers[key] = writer
+		}
+		wbatches := writer.writeMessages(messages, indexes)
+
+		for batch, idxs := range wbatches {
+			batches[batch] = idxs
 		}
 	}
 
 	return batches
-}
-
-func (w *Writer) newWriteBatch(key topicPartition) *writeBatch {
-	batch := newWriteBatch(time.Now(), w.batchTimeout())
-	w.group.Add(1)
-	go func() {
-		defer w.group.Done()
-		w.writeBatch(key, batch)
-	}()
-	return batch
-}
-
-func (w *Writer) writeBatch(key topicPartition, batch *writeBatch) {
-	// This goroutine has taken ownership of the batch, it is responsible
-	// for waiting for the batch to be ready (because it became full), or
-	// to timeout.
-	select {
-	case <-batch.timer.C:
-		// The batch timed out, we want to detach it from the writer to
-		// prevent more messages from being added.
-		w.mutex.Lock()
-		if batch == w.batches[key] {
-			delete(w.batches, key)
-		}
-		w.mutex.Unlock()
-
-	case <-batch.ready:
-		// The batch became full, it was removed from the writer and its
-		// ready channel was closed. We need to close the timer to avoid
-		// having it leak until it expires.
-		batch.timer.Stop()
-	}
-
-	stats := w.stats()
-	stats.batchTime.observe(int64(time.Since(batch.time)))
-	stats.batchSize.observe(int64(len(batch.msgs)))
-	stats.batchSizeBytes.observe(batch.bytes)
-
-	var res *ProduceResponse
-	var err error
-
-	for attempt, maxAttempts := 0, w.maxAttempts(); attempt < maxAttempts; attempt++ {
-		if attempt != 0 {
-			stats.retries.observe(1)
-			// TODO: should there be a way to asynchronously cancel this
-			// operation?
-			//
-			// * If all goroutines that added message to this batch have stopped
-			//   waiting for it, should we abort?
-			//
-			// * If the writer has been closed? It reduces the durability
-			//   guarantees to abort, but may be better to avoid long wait times
-			//   on close.
-			//
-			delay := backoff(attempt, 100*time.Millisecond, 1*time.Second)
-			w.withLogger(func(log Logger) {
-				log.Printf("backing off %s writing %d messages to %s (partition: %d)", delay, len(batch.msgs), key.topic, key.partition)
-			})
-			time.Sleep(delay)
-		}
-
-		w.withLogger(func(log Logger) {
-			log.Printf("writing %d messages to %s (partition: %d)", len(batch.msgs), key.topic, key.partition)
-		})
-
-		start := time.Now()
-		res, err = w.produce(key, batch)
-
-		stats.writes.observe(1)
-		stats.messages.observe(int64(len(batch.msgs)))
-		stats.bytes.observe(batch.bytes)
-		// stats.writeTime used to report the duration of WriteMessages, but the
-		// implementation was broken and reporting values in the nanoseconds
-		// range. In kafka-go 0.4, we recylced this value to instead report the
-		// duration of produce requests, and changed the stats.waitTime value to
-		// report the time that kafka has throttled the requests for.
-		stats.writeTime.observe(int64(time.Since(start)))
-
-		if res != nil {
-			err = res.Error
-			stats.waitTime.observe(int64(res.Throttle))
-		}
-
-		if err == nil {
-			break
-		}
-
-		stats.errors.observe(1)
-
-		w.withErrorLogger(func(log Logger) {
-			log.Printf("error writing messages to %s (partition %d): %s", key.topic, key.partition, err)
-		})
-
-		if !isTemporary(err) && !isTransientNetworkError(err) {
-			break
-		}
-	}
-
-	if res != nil {
-		for i := range batch.msgs {
-			m := &batch.msgs[i]
-			m.Topic = key.topic
-			m.Partition = int(key.partition)
-			m.Offset = res.BaseOffset + int64(i)
-
-			if m.Time.IsZero() {
-				m.Time = res.LogAppendTime
-			}
-		}
-	}
-
-	if w.Completion != nil {
-		w.Completion(batch.msgs, err)
-	}
-
-	batch.complete(err)
 }
 
 func (w *Writer) produce(key topicPartition, batch *writeBatch) (*ProduceResponse, error) {
@@ -990,6 +857,292 @@ func (w *Writer) chooseTopic(msg Message) (string, error) {
 	}
 
 	return w.Topic, nil
+}
+
+type batchQueue struct {
+	queue []*writeBatch
+
+	cond   sync.Cond
+	closed bool
+}
+
+func (b *batchQueue) Put(batch *writeBatch) bool {
+	b.cond.L.Lock()
+	defer b.cond.L.Unlock()
+	defer b.cond.Broadcast()
+
+	if b.closed {
+		return false
+	}
+	b.queue = append(b.queue, batch)
+	return true
+}
+
+func (b *batchQueue) Get(batches []*writeBatch) []*writeBatch {
+	b.cond.L.Lock()
+	defer b.cond.L.Unlock()
+
+	for len(b.queue) == 0 && !b.closed {
+		b.cond.Wait()
+	}
+
+	var i int
+	for i = 0; i < cap(batches) && i < len(b.queue); i++ {
+		batches = append(batches, b.queue[i])
+		b.queue[i] = nil
+	}
+
+	b.queue = b.queue[i:]
+
+	return batches
+}
+
+func (b *batchQueue) Close() {
+	b.cond.L.Lock()
+	defer b.cond.L.Unlock()
+	defer b.cond.Broadcast()
+
+	b.closed = true
+}
+
+func newBatchQueue(initialSize int) *batchQueue {
+	return &batchQueue{
+		queue: make([]*writeBatch, 0, initialSize),
+		cond: sync.Cond{
+			L: &sync.Mutex{},
+		},
+	}
+}
+
+// ptWriter is a writer for a topic-partion pair. It maintains messaging order
+// across batches of messages.
+type ptWriter struct {
+	meta  topicPartition
+	queue *batchQueue
+
+	mutex     sync.Mutex
+	currBatch *writeBatch
+
+	group sync.WaitGroup
+
+	// reference to the writer that owns this batch. Used for the produce logic
+	// as well as stat tracking
+	w *Writer
+}
+
+func newPartitionWriter(w *Writer, key topicPartition) *ptWriter {
+	writer := &ptWriter{
+		meta:  key,
+		queue: newBatchQueue(10),
+		w:     w,
+	}
+	go writer.writeBatches()
+
+	return writer
+}
+
+func (ptw *ptWriter) writeBatches() {
+	ptw.group.Add(1)
+	defer ptw.group.Done()
+
+	// Should we make this configurable?
+	batches := make([]*writeBatch, 0, 10)
+
+	for {
+		batches = ptw.queue.Get(batches)
+
+		// The only time we can return 0 batches is when the queue is closed
+		// and empty. If the queue is closed that means
+		// the Writer is closed so once we're here it's time to exit.
+		if len(batches) == 0 {
+			return
+		}
+
+		for _, batch := range batches {
+			ptw.writeBatch(batch)
+		}
+		batches = batches[:0]
+	}
+}
+
+func (ptw *ptWriter) writeMessages(msgs []Message, indexes []int32) map[*writeBatch][]int32 {
+	ptw.group.Add(1)
+	defer ptw.group.Done()
+
+	var batches map[*writeBatch][]int32
+	if !ptw.w.Async {
+		batches = make(map[*writeBatch][]int32, 1)
+	}
+	batchSize := ptw.w.batchSize()
+	batchBytes := ptw.w.batchBytes()
+
+	ptw.mutex.Lock()
+	defer ptw.mutex.Unlock()
+
+	for _, i := range indexes {
+	assignMessage:
+		batch := ptw.currBatch
+		if batch == nil {
+			batch = ptw.newWriteBatch()
+			ptw.currBatch = batch
+		}
+		if !batch.add(msgs[i], batchSize, batchBytes) {
+			batch.trigger()
+			ptw.queue.Put(batch)
+			ptw.currBatch = nil
+			goto assignMessage
+		}
+
+		if batch.full(batchSize, batchBytes) {
+			batch.trigger()
+			ptw.queue.Put(batch)
+			ptw.currBatch = nil
+		}
+
+		if !ptw.w.Async {
+			batches[batch] = append(batches[batch], i)
+		}
+	}
+	return batches
+}
+
+func (ptw *ptWriter) newWriteBatch() *writeBatch {
+	batch := newWriteBatch(time.Now(), ptw.w.batchTimeout())
+	ptw.group.Add(1)
+	go func() {
+		defer ptw.group.Done()
+		ptw.awaitBatch(batch)
+	}()
+	return batch
+}
+
+// awaitBatch waits for a batch to either fill up or time out.
+// If the batch is full it only stops the timer, if the timer
+// expires it will queue the batch for writing if needed.
+func (ptw *ptWriter) awaitBatch(batch *writeBatch) {
+	select {
+	case <-batch.timer.C:
+		ptw.mutex.Lock()
+		// detach the batch from the writer if we're still attached
+		// and queue for writing.
+		// Only the current batch can expire, all previous batches were already written to the queue.
+		// If writeMesseages locks pw.mutex after the timer fires but before this goroutine
+		// can lock pw.mutex it will either have filled the batch and enqueued it which will mean
+		// pw.currBatch != batch so we just move on.
+		// Otherwise, we detach the batch from the ptWriter and enqueue it for writing.
+		if ptw.currBatch == batch {
+			ptw.queue.Put(batch)
+			ptw.currBatch = nil
+		}
+		ptw.mutex.Unlock()
+	case <-batch.ready:
+		// The batch became full, it was removed from the ptwriter and its
+		// ready channel was closed. We need to close the timer to avoid
+		// having it leak until it expires.
+		batch.timer.Stop()
+	}
+}
+
+func (ptw *ptWriter) writeBatch(batch *writeBatch) {
+	stats := ptw.w.stats()
+	stats.batchTime.observe(int64(time.Since(batch.time)))
+	stats.batchSize.observe(int64(len(batch.msgs)))
+	stats.batchSizeBytes.observe(batch.bytes)
+
+	var res *ProduceResponse
+	var err error
+	key := ptw.meta
+	for attempt, maxAttempts := 0, ptw.w.maxAttempts(); attempt < maxAttempts; attempt++ {
+		if attempt != 0 {
+			stats.retries.observe(1)
+			// TODO: should there be a way to asynchronously cancel this
+			// operation?
+			//
+			// * If all goroutines that added message to this batch have stopped
+			//   waiting for it, should we abort?
+			//
+			// * If the writer has been closed? It reduces the durability
+			//   guarantees to abort, but may be better to avoid long wait times
+			//   on close.
+			//
+			delay := backoff(attempt, 100*time.Millisecond, 1*time.Second)
+			ptw.w.withLogger(func(log Logger) {
+				log.Printf("backing off %s writing %d messages to %s (partition: %d)", delay, len(batch.msgs), key.topic, key.partition)
+			})
+			time.Sleep(delay)
+		}
+
+		ptw.w.withLogger(func(log Logger) {
+			log.Printf("writing %d messages to %s (partition: %d)", len(batch.msgs), key.topic, key.partition)
+		})
+
+		start := time.Now()
+		res, err = ptw.w.produce(key, batch)
+
+		stats.writes.observe(1)
+		stats.messages.observe(int64(len(batch.msgs)))
+		stats.bytes.observe(batch.bytes)
+		// stats.writeTime used to report the duration of WriteMessages, but the
+		// implementation was broken and reporting values in the nanoseconds
+		// range. In kafka-go 0.4, we recylced this value to instead report the
+		// duration of produce requests, and changed the stats.waitTime value to
+		// report the time that kafka has throttled the requests for.
+		stats.writeTime.observe(int64(time.Since(start)))
+
+		if res != nil {
+			err = res.Error
+			stats.waitTime.observe(int64(res.Throttle))
+		}
+
+		if err == nil {
+			break
+		}
+
+		stats.errors.observe(1)
+
+		ptw.w.withErrorLogger(func(log Logger) {
+			log.Printf("error writing messages to %s (partition %d): %s", key.topic, key.partition, err)
+		})
+
+		if !isTemporary(err) && !isTransientNetworkError(err) {
+			break
+		}
+	}
+
+	if res != nil {
+		for i := range batch.msgs {
+			m := &batch.msgs[i]
+			m.Topic = key.topic
+			m.Partition = int(key.partition)
+			m.Offset = res.BaseOffset + int64(i)
+
+			if m.Time.IsZero() {
+				m.Time = res.LogAppendTime
+			}
+		}
+	}
+
+	if ptw.w.Completion != nil {
+		ptw.w.Completion(batch.msgs, err)
+	}
+
+	batch.complete(err)
+}
+
+func (ptw *ptWriter) close() {
+	ptw.mutex.Lock()
+	defer ptw.mutex.Unlock()
+
+	if ptw.currBatch != nil {
+		batch := ptw.currBatch
+		ptw.queue.Put(batch)
+		ptw.currBatch = nil
+		batch.trigger()
+	}
+
+	ptw.queue.Close()
+
+	ptw.group.Wait()
 }
 
 type writeBatch struct {

--- a/writer_test.go
+++ b/writer_test.go
@@ -53,7 +53,7 @@ func testBatchQueuePutWakesSleepingGetter(t *testing.T) {
 	var wg sync.WaitGroup
 	ready := make(chan struct{})
 	go func() {
-		wg.Add(2)
+		wg.Add(1)
 		defer wg.Done()
 		close(ready)
 		dequeueBatch = bq.Get(dequeueBatch)


### PR DESCRIPTION
Attempt to preserve message order across batches.

Fixes #686 