### PR TITLE
Refactor Writer tests 

### DIFF
--- a/addoffsetstotxn_test.go
+++ b/addoffsetstotxn_test.go
@@ -2,9 +2,7 @@ package kafka
 
 import (
 	"context"
-	"log"
 	"net"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -50,7 +48,7 @@ func TestClientAddOffsetsToTxn(t *testing.T) {
 		HeartbeatInterval: 2 * time.Second,
 		RebalanceTimeout:  2 * time.Second,
 		RetentionTime:     time.Hour,
-		Logger:            log.New(os.Stdout, "cg-test: ", 0),
+		Logger:            LoggerFunc(t.Logf),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/addoffsetstotxn_test.go
+++ b/addoffsetstotxn_test.go
@@ -28,7 +28,7 @@ func TestClientAddOffsetsToTxn(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	respc, err := waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
+	respc, err := waitForCoordinatorIndefinitely(ctx, t, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     transactionalID,
 		KeyType: CoordinatorKeyTypeConsumer,
@@ -66,7 +66,7 @@ func TestClientAddOffsetsToTxn(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	respc, err = waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
+	respc, err = waitForCoordinatorIndefinitely(ctx, t, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     transactionalID,
 		KeyType: CoordinatorKeyTypeTransaction,

--- a/addpartitionstotxn_test.go
+++ b/addpartitionstotxn_test.go
@@ -34,7 +34,7 @@ func TestClientAddPartitionsToTxn(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	respc, err := waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
+	respc, err := waitForCoordinatorIndefinitely(ctx, t, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     transactionalID,
 		KeyType: CoordinatorKeyTypeTransaction,

--- a/batch.go
+++ b/batch.go
@@ -197,9 +197,13 @@ func (batch *Batch) ReadMessage() (Message, error) {
 			return
 		},
 	)
+
+	if err != nil {
+		err = fmt.Errorf("batch.ReadMessage: error in readMessage: %w", err)
+	}
+
 	for batch.conn != nil && offset < batch.conn.offset {
 		if err != nil {
-			err = fmt.Errorf("batch.ReadMessage: error in readMessage: %w", err)
 			break
 		}
 		offset, timestamp, headers, err = batch.readMessage(

--- a/batch_test.go
+++ b/batch_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -30,11 +31,11 @@ func TestBatchDontExpectEOF(t *testing.T) {
 
 	batch := conn.ReadBatch(1024, 8192)
 
-	if _, err := batch.ReadMessage(); err != io.ErrUnexpectedEOF {
+	if _, err := batch.ReadMessage(); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Error("bad error when reading message:", err)
 	}
 
-	if err := batch.Close(); err != io.ErrUnexpectedEOF {
+	if err := batch.Close(); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Error("bad error when closing the batch:", err)
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -103,7 +103,8 @@ func makeTopic() string {
 	return fmt.Sprintf("kafka-go-%016x", rand.Int63())
 }
 
-// generate a topic name based on the test name
+// makeTopicT generates a topic name based on the test name.
+// This makes it easier to trace back a topic to a specific test.
 func makeTopicT(t *testing.T) string {
 	s := fmt.Sprintf("%s-%d", t.Name(), time.Now().Unix())
 	return strings.NewReplacer("/", "_", "#", "_").Replace(s)

--- a/conn_test.go
+++ b/conn_test.go
@@ -9,11 +9,13 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
-	ktesting "github.com/segmentio/kafka-go/testing"
 	"golang.org/x/net/nettest"
+
+	ktesting "github.com/segmentio/kafka-go/testing"
 )
 
 type timeout struct{}
@@ -99,6 +101,12 @@ func init() {
 
 func makeTopic() string {
 	return fmt.Sprintf("kafka-go-%016x", rand.Int63())
+}
+
+// generate a topic name based on the test name
+func makeTopicT(t *testing.T) string {
+	s := fmt.Sprintf("%s-%d", t.Name(), time.Now().Unix())
+	return strings.ReplaceAll(s, "/", "_")
 }
 
 func makeGroupID() string {

--- a/conn_test.go
+++ b/conn_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -103,10 +104,14 @@ func makeTopic() string {
 	return fmt.Sprintf("kafka-go-%016x", rand.Int63())
 }
 
+// Use an atomic counter for makeTopicT so 2 topics created quickly from the same test
+// don't collide
+var topicCounter int64
+
 // makeTopicT generates a topic name based on the test name.
 // This makes it easier to trace back a topic to a specific test.
 func makeTopicT(t *testing.T) string {
-	s := fmt.Sprintf("%s-%d", t.Name(), time.Now().Unix())
+	s := fmt.Sprintf("%s-%d", t.Name(), atomic.AddInt64(&topicCounter, 1))
 	return strings.NewReplacer("/", "_", "#", "_").Replace(s)
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -106,7 +106,7 @@ func makeTopic() string {
 // generate a topic name based on the test name
 func makeTopicT(t *testing.T) string {
 	s := fmt.Sprintf("%s-%d", t.Name(), time.Now().Unix())
-	return strings.ReplaceAll(s, "/", "_")
+	return strings.NewReplacer("/", "_", "#", "_").Replace(s)
 }
 
 func makeGroupID() string {

--- a/conn_test.go
+++ b/conn_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -508,7 +509,7 @@ func testConnSeekDontCheck(t *testing.T, conn *Conn) {
 		t.Error("bad offset:", offset)
 	}
 
-	if _, err := conn.ReadMessage(1024); err != OffsetOutOfRange {
+	if _, err := conn.ReadMessage(1024); !errors.Is(err, OffsetOutOfRange) {
 		t.Error("unexpected error:", err)
 	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -104,13 +104,13 @@ func makeTopic() string {
 	return fmt.Sprintf("kafka-go-%016x", rand.Int63())
 }
 
-// Use an atomic counter for makeTopicT so 2 topics created quickly from the same test
+// Use an atomic counter for makeTestTopic so 2 topics created quickly from the same test
 // don't collide
 var topicCounter int64
 
-// makeTopicT generates a topic name based on the test name.
+// makeTestTopic generates a topic name based on the test name.
 // This makes it easier to trace back a topic to a specific test.
-func makeTopicT(t *testing.T) string {
+func makeTestTopic(t testing.TB) string {
 	s := fmt.Sprintf("%s-%d", t.Name(), atomic.AddInt64(&topicCounter, 1))
 	return strings.NewReplacer("/", "_", "#", "_").Replace(s)
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -107,7 +107,8 @@ func makeTopic() string {
 
 // Use an atomic counter for makeTestTopic so 2 topics created quickly from the same test
 // don't collide
-var topicCounter int64
+// Start the counter at current time so topics between test runs don't collide
+var topicCounter = time.Now().UnixNano()
 
 // makeTestTopic generates a topic name based on the test name.
 // This makes it easier to trace back a topic to a specific test.

--- a/consumergroup_test.go
+++ b/consumergroup_test.go
@@ -93,17 +93,114 @@ func TestValidateConsumerGroupConfig(t *testing.T) {
 		errorOccured bool
 	}{
 		{config: ConsumerGroupConfig{}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, HeartbeatInterval: 2}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: -1}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", SessionTimeout: -1}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: 2, SessionTimeout: -1}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: 2, SessionTimeout: 2, RebalanceTimeout: -2}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: 2, SessionTimeout: 2, RebalanceTimeout: 2, RetentionTime: -1}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: 2, SessionTimeout: 2, RebalanceTimeout: 2, RetentionTime: 1, StartOffset: 123}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: 2, SessionTimeout: 2, RebalanceTimeout: 2, RetentionTime: 1, PartitionWatchInterval: -1}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: 2, SessionTimeout: 2, RebalanceTimeout: 2, RetentionTime: 1, PartitionWatchInterval: 1, JoinGroupBackoff: -1}, errorOccured: true},
-		{config: ConsumerGroupConfig{Brokers: []string{"broker1"}, Topics: []string{"t1"}, ID: "group1", HeartbeatInterval: 2, SessionTimeout: 2, RebalanceTimeout: 2, RetentionTime: 1, PartitionWatchInterval: 1, JoinGroupBackoff: 1}, errorOccured: false},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:           []string{"broker1"},
+				HeartbeatInterval: 2,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers: []string{"broker1"},
+				Topics:  []string{"t1"},
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:           []string{"broker1"},
+				Topics:            []string{"t1"},
+				ID:                "group1",
+				HeartbeatInterval: -1,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:        []string{"broker1"},
+				Topics:         []string{"t1"},
+				ID:             "group1",
+				SessionTimeout: -1,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:           []string{"broker1"},
+				Topics:            []string{"t1"},
+				ID:                "group1",
+				HeartbeatInterval: 2,
+				SessionTimeout:    -1,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:           []string{"broker1"},
+				Topics:            []string{"t1"},
+				ID:                "group1",
+				HeartbeatInterval: 2,
+				SessionTimeout:    2,
+				RebalanceTimeout:  -2,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:           []string{"broker1"},
+				Topics:            []string{"t1"},
+				ID:                "group1",
+				HeartbeatInterval: 2,
+				SessionTimeout:    2,
+				RebalanceTimeout:  2,
+				RetentionTime:     -1,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:           []string{"broker1"},
+				Topics:            []string{"t1"},
+				ID:                "group1",
+				HeartbeatInterval: 2,
+				SessionTimeout:    2,
+				RebalanceTimeout:  2,
+				RetentionTime:     1,
+				StartOffset:       123,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:                []string{"broker1"},
+				Topics:                 []string{"t1"},
+				ID:                     "group1",
+				HeartbeatInterval:      2,
+				SessionTimeout:         2,
+				RebalanceTimeout:       2,
+				RetentionTime:          1,
+				PartitionWatchInterval: -1,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:                []string{"broker1"},
+				Topics:                 []string{"t1"},
+				ID:                     "group1",
+				HeartbeatInterval:      2,
+				SessionTimeout:         2,
+				RebalanceTimeout:       2,
+				RetentionTime:          1,
+				PartitionWatchInterval: 1,
+				JoinGroupBackoff:       -1,
+			}, errorOccured: true,
+		},
+		{
+			config: ConsumerGroupConfig{
+				Brokers:                []string{"broker1"},
+				Topics:                 []string{"t1"},
+				ID:                     "group1",
+				HeartbeatInterval:      2,
+				SessionTimeout:         2,
+				RebalanceTimeout:       2,
+				RetentionTime:          1,
+				PartitionWatchInterval: 1,
+				JoinGroupBackoff:       1,
+			}, errorOccured: false,
+		},
 	}
 	for _, test := range tests {
 		err := test.config.Validate()

--- a/consumergroup_test.go
+++ b/consumergroup_test.go
@@ -247,7 +247,7 @@ func TestConsumerGroup(t *testing.T) {
 					t.Errorf("expected generation 1 not to be nil")
 				}
 				if err != nil {
-					t.Errorf("expected no error, but got %+v", err)
+					t.Fatalf("expected no error, but got %+v", err)
 				}
 				// returning from this function should cause the generation to
 				// exit.
@@ -310,7 +310,6 @@ func TestConsumerGroup(t *testing.T) {
 
 	topic := makeTopic()
 	createTopic(t, topic, 1)
-	defer deleteTopic(t, topic)
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {

--- a/describegroups.go
+++ b/describegroups.go
@@ -348,7 +348,7 @@ func decodeMemberMetadata(rawMetadata []byte) (DescribeGroupsResponseMemberMetad
 	}
 
 	if remain != 0 {
-		return mm, fmt.Errorf("Got non-zero number of bytes remaining: %d", remain)
+		return mm, fmt.Errorf("decodeMemberMetadata: Got non-zero number of bytes remaining: %d", remain)
 	}
 
 	return mm, nil
@@ -406,7 +406,7 @@ func decodeMemberAssignments(rawAssignments []byte) (DescribeGroupsResponseAssig
 	}
 
 	if remain != 0 {
-		return ma, fmt.Errorf("Got non-zero number of bytes remaining: %d", remain)
+		return ma, fmt.Errorf("decodeMemberAssignments: Got non-zero number of bytes remaining: %d", remain)
 	}
 
 	return ma, nil

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -347,22 +347,13 @@ func TestDialerResolver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			topic := makeTopic()
+			topic := makeTopicT(t)
 			createTopic(t, topic, 1)
 			defer deleteTopic(t, topic)
 
 			d := Dialer{
 				Resolver: &mockResolver{addrs: test.resolver},
 			}
-
-			// Write a message to ensure the partition gets created.
-			w := NewWriter(WriterConfig{
-				Brokers: []string{"localhost:9092"},
-				Topic:   topic,
-				Dialer:  &d,
-			})
-			w.WriteMessages(context.Background(), Message{})
-			w.Close()
 
 			partitions, err := d.LookupPartitions(ctx, "tcp", test.address, topic)
 			if err != nil {

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -347,7 +347,7 @@ func TestDialerResolver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.scenario, func(t *testing.T) {
-			topic := makeTopicT(t)
+			topic := makeTestTopic(t)
 			createTopic(t, topic, 1)
 			defer deleteTopic(t, topic)
 

--- a/electleaders_test.go
+++ b/electleaders_test.go
@@ -18,7 +18,6 @@ func TestClientElectLeaders(t *testing.T) {
 
 	topic := makeTopic()
 	createTopic(t, topic, 2)
-	defer deleteTopic(t, topic)
 
 	// Local kafka only has 1 broker, so leader elections are no-ops.
 	resp, err := client.ElectLeaders(

--- a/error.go
+++ b/error.go
@@ -567,7 +567,7 @@ func makeError(code int16, message string) error {
 	return fmt.Errorf("%w: %s", Error(code), message)
 }
 
-// WriteError is returned by kafka.(*Writer).WriteMessages when the writer is
+// WriteErrors is returned by kafka.(*Writer).WriteMessages when the writer is
 // not configured to write messages asynchronously. WriteError values contain
 // a list of errors where each entry matches the position of a message in the
 // WriteMessages call. The program can determine the status of each message by
@@ -602,6 +602,11 @@ func (err WriteErrors) Count() int {
 	return n
 }
 
+// Error prints the Error of the first error plus the number of messages out of
+// all messages passed to WriteMessages which encountered an error
 func (err WriteErrors) Error() string {
-	return fmt.Sprintf("kafka write errors (%d/%d)", err.Count(), len(err))
+	if err.Count() < 1 {
+		return ""
+	}
+	return fmt.Sprintf("kafka-go.WriteErrors: %s (%d/%d)", err[0].Error(), err.Count(), len(err))
 }

--- a/findcoordinator_test.go
+++ b/findcoordinator_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -48,7 +47,7 @@ func TestClientFindCoordinator(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	resp, err := waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
+	resp, err := waitForCoordinatorIndefinitely(ctx, t, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     "TransactionalID-1",
 		KeyType: CoordinatorKeyTypeTransaction,
@@ -64,8 +63,9 @@ func TestClientFindCoordinator(t *testing.T) {
 }
 
 // WaitForCoordinatorIndefinitely is a blocking call till a coordinator is found
-func waitForCoordinatorIndefinitely(ctx context.Context, c *Client, req *FindCoordinatorRequest) (*FindCoordinatorResponse, error) {
-	fmt.Println("Trying to find Coordinator.")
+func waitForCoordinatorIndefinitely(ctx context.Context, t testing.TB, c *Client, req *FindCoordinatorRequest) (*FindCoordinatorResponse, error) {
+	t.Helper()
+	t.Log("Trying to find Coordinator.")
 	resp, err := c.FindCoordinator(ctx, req)
 
 	for shouldRetryfindingCoordinator(resp, err) && ctx.Err() == nil {

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"log"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -27,7 +25,7 @@ func TestClientHeartbeat(t *testing.T) {
 		HeartbeatInterval: 2 * time.Second,
 		RebalanceTimeout:  2 * time.Second,
 		RetentionTime:     time.Hour,
-		Logger:            log.New(os.Stdout, "cg-test: ", 0),
+		Logger:            LoggerFunc(t.Logf),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/initproducerid_test.go
+++ b/initproducerid_test.go
@@ -22,7 +22,7 @@ func TestClientInitProducerId(t *testing.T) {
 	// Wait for kafka setup and Coordinator to be available.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	respc, err := waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
+	respc, err := waitForCoordinatorIndefinitely(ctx, t, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     tid,
 		KeyType: CoordinatorKeyTypeTransaction,

--- a/offsetcommit_test.go
+++ b/offsetcommit_test.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"log"
-	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -90,7 +88,7 @@ func TestClientOffsetCommit(t *testing.T) {
 		HeartbeatInterval: 2 * time.Second,
 		RebalanceTimeout:  2 * time.Second,
 		RetentionTime:     time.Hour,
-		Logger:            log.New(os.Stdout, "cg-test: ", 0),
+		Logger:            LoggerFunc(t.Logf),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/reader_test.go
+++ b/reader_test.go
@@ -341,7 +341,7 @@ func deleteTopic(t *testing.T, topic ...string) {
 	conn.SetDeadline(time.Now().Add(10 * time.Second))
 
 	if err := conn.DeleteTopics(topic...); err != nil {
-		t.Fatal(err)
+		t.Logf("deleteTopic: error deleting %v: %s", topic, err.Error())
 	}
 }
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -310,57 +310,6 @@ func createTopic(t *testing.T, topic string, partitions int) {
 		t.Error(err)
 		t.FailNow()
 	}
-
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	waitForTopic(ctx, t, topic)
-}
-
-// Block until topic exists
-func waitForTopic(ctx context.Context, t *testing.T, topic string) {
-	t.Helper()
-
-	for {
-		select {
-		case <-ctx.Done():
-			t.Fatalf("reached deadline before verifying topic existence")
-		default:
-		}
-
-		cli := &Client{
-			Addr:    TCP("localhost:9092"),
-			Timeout: 5 * time.Second,
-		}
-
-		response, err := cli.Metadata(ctx, &MetadataRequest{
-			Addr:   cli.Addr,
-			Topics: []string{topic},
-		})
-		if err != nil {
-			t.Fatalf("waitForTopic: error listing topics: %s", err.Error())
-		}
-
-		// Find a topic which has at least 1 partition in the metadata response
-		for _, top := range response.Topics {
-			if top.Name != topic {
-				continue
-			}
-
-			numPartitions := len(top.Partitions)
-			t.Logf("waitForTopic: found topic %q with %d partitions",
-				topic, numPartitions)
-
-			if numPartitions > 0 {
-				return
-			}
-		}
-
-		t.Logf("retrying after 1s")
-		time.Sleep(time.Second)
-		continue
-	}
 }
 
 func deleteTopic(t *testing.T, topic ...string) {

--- a/txnoffsetcommit_test.go
+++ b/txnoffsetcommit_test.go
@@ -2,8 +2,6 @@ package kafka
 
 import (
 	"context"
-	"log"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -104,7 +102,7 @@ func TestClientTxnOffsetCommit(t *testing.T) {
 		HeartbeatInterval: 2 * time.Second,
 		RebalanceTimeout:  2 * time.Second,
 		RetentionTime:     time.Hour,
-		Logger:            log.New(os.Stdout, "cg-test: ", 0),
+		Logger:            LoggerFunc(t.Logf),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/txnoffsetcommit_test.go
+++ b/txnoffsetcommit_test.go
@@ -53,7 +53,7 @@ func TestClientTxnOffsetCommit(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	respc, err := waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
+	respc, err := waitForCoordinatorIndefinitely(ctx, t, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     transactionalID,
 		KeyType: CoordinatorKeyTypeTransaction,
@@ -68,7 +68,7 @@ func TestClientTxnOffsetCommit(t *testing.T) {
 
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
-	respc, err = waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
+	respc, err = waitForCoordinatorIndefinitely(ctx, t, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,
 		Key:     transactionalID,
 		KeyType: CoordinatorKeyTypeConsumer,

--- a/writer_test.go
+++ b/writer_test.go
@@ -382,7 +382,8 @@ func testWriterRoundRobin1(t *testing.T, w *Writer) {
 
 	msgs, err := readPartition(topic, 0, offset)
 	if err != nil {
-		t.Error("error reading partition", err)
+		w.Logger.Printf("error reading partition: %s", err.Error())
+		t.Fail()
 		return
 	}
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -257,6 +257,9 @@ func TestWriter(t *testing.T) {
 					if err != nil {
 						t.Fatal(err.Error())
 					}
+					t.Cleanup(func() {
+						deleteTopic(t, cfg.Topic)
+					})
 				}
 				if test.writer.Addr != nil {
 					cfg.Brokers = []string{test.writer.Addr.String()}
@@ -279,6 +282,9 @@ func TestWriter(t *testing.T) {
 					if err != nil {
 						t.Fatal(err.Error())
 					}
+					t.Cleanup(func() {
+						deleteTopic(t, w.Topic)
+					})
 				}
 				if w.Addr == nil {
 					w.Addr = TCP("localhost:9092")
@@ -648,6 +654,9 @@ func testWriterSmallBatchBytes(t *testing.T, w *Writer) {
 func testWriterMultipleTopics(t *testing.T, w *Writer) {
 	topic1 := makeTopic()
 	createTopic(t, topic1, 1)
+	t.Cleanup(func() {
+		deleteTopic(t, topic1)
+	})
 
 	offset1, err := readOffset(topic1, 0)
 	if err != nil {
@@ -656,6 +665,9 @@ func testWriterMultipleTopics(t *testing.T, w *Writer) {
 
 	topic2 := makeTopic()
 	createTopic(t, topic2, 1)
+	t.Cleanup(func() {
+		deleteTopic(t, topic2)
+	})
 
 	offset2, err := readOffset(topic2, 0)
 	if err != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -109,7 +109,7 @@ func TestWriter(t *testing.T) {
 
 		// the literal Writer - used directly for literal tests and converted to
 		// WriterConfig for constructor tests
-		writer *Writer
+		writer Writer
 
 		// set the topic on the Writer
 		setTopic bool
@@ -125,14 +125,13 @@ func TestWriter(t *testing.T) {
 			function:    testWriterClose,
 			setTopic:    true,
 			createTopic: true,
-			writer:      &Writer{},
 		},
 		{
 			scenario:    "writing 1 message through a writer using round-robin balancing produces 1 message to the first partition",
 			function:    testWriterRoundRobin1,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				Balancer: &RoundRobin{},
 			},
 		},
@@ -141,7 +140,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterMaxAttemptsErr,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				Addr:        TCP("localhost:9999"),
 				Balancer:    &RoundRobin{},
 				MaxAttempts: 3,
@@ -152,7 +151,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterMaxBytes,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				BatchBytes: 25,
 			},
 		},
@@ -161,7 +160,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterBatchBytes,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				BatchBytes:   48,
 				BatchTimeout: math.MaxInt32 * time.Second,
 				Balancer:     &RoundRobin{},
@@ -172,7 +171,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterBatchSize,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				BatchSize:    2,
 				BatchTimeout: math.MaxInt32 * time.Second,
 				Balancer:     &RoundRobin{},
@@ -183,7 +182,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterSmallBatchBytes,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				BatchBytes:   25,
 				BatchTimeout: 50 * time.Millisecond,
 				Balancer:     &RoundRobin{},
@@ -192,14 +191,14 @@ func TestWriter(t *testing.T) {
 		{
 			scenario: "writing messages to multiple topics",
 			function: testWriterMultipleTopics,
-			writer: &Writer{
+			writer: Writer{
 				Balancer: &RoundRobin{},
 			},
 		},
 		{
 			scenario: "writing messages without specifying a topic",
 			function: testWriterMissingTopic,
-			writer: &Writer{
+			writer: Writer{
 				Balancer: &RoundRobin{},
 			},
 		},
@@ -208,7 +207,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterUnexpectedMessageTopic,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				Balancer: &RoundRobin{},
 			},
 		},
@@ -217,7 +216,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterInvalidPartition,
 			setTopic:    true,
 			createTopic: true,
-			writer: &Writer{
+			writer: Writer{
 				Balancer:    &staticBalancer{partition: -1},
 				MaxAttempts: 1,
 			},
@@ -233,15 +232,17 @@ func TestWriter(t *testing.T) {
 		}
 
 		// client for making topics if necessary
-		client := &Client{}
+		client := &Client{
+			Addr: test.writer.Addr,
+		}
 
-		if test.writer == nil || test.writer.Addr == nil {
+		if client.Addr == nil {
 			client.Addr = TCP("localhost:9092")
-		} else {
-			client.Addr = test.writer.Addr
 		}
 
 		t.Run(test.scenario, func(t *testing.T) {
+			t.Parallel()
+
 			// run test against deprecated constructor style
 			t.Run("constructor", func(t *testing.T) {
 				t.Parallel()
@@ -308,7 +309,7 @@ func TestWriter(t *testing.T) {
 						t.Fatal(err)
 					}
 				})
-				testFunc(t, w)
+				testFunc(t, &w)
 			})
 		})
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -517,7 +518,7 @@ func readPartition(topic string, partition int, offset int64) (msgs []Message, e
 		var msg Message
 
 		if msg, err = batch.ReadMessage(); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = nil
 			}
 			if err != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -510,7 +510,6 @@ func readPartition(topic string, partition int, offset int64) (msgs []Message, e
 	defer conn.Close()
 
 	conn.Seek(offset, SeekAbsolute)
-	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
 	batch := conn.ReadBatch(0, 1000000000)
 	defer batch.Close()
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -253,7 +253,7 @@ func TestWriter(t *testing.T) {
 				}
 
 				if test.setTopic {
-					cfg.Topic = makeTopicT(t)
+					cfg.Topic = makeTestTopic(t)
 				}
 				if test.createTopic {
 					err := clientCreateTopic(client, cfg.Topic, test.partitions)
@@ -282,7 +282,7 @@ func TestWriter(t *testing.T) {
 				w.Logger = &testKafkaLogger{T: t}
 
 				if test.setTopic {
-					w.Topic = makeTopicT(t)
+					w.Topic = makeTestTopic(t)
 				}
 				if test.createTopic {
 					err := clientCreateTopic(client, w.Topic, test.partitions)
@@ -321,7 +321,7 @@ func testWriterClose(t *testing.T, w *Writer) {
 // Converting to standalone test since constructor does not support Transport
 // configuration
 func TestWriterRequiredAcksNone(t *testing.T) {
-	topic := makeTopicT(t)
+	topic := makeTestTopic(t)
 	createTopic(t, topic, 1)
 
 	transport := &Transport{}
@@ -663,7 +663,7 @@ func testWriterSmallBatchBytes(t *testing.T, w *Writer) {
 }
 
 func testWriterMultipleTopics(t *testing.T, w *Writer) {
-	topic1 := makeTopicT(t)
+	topic1 := makeTestTopic(t)
 	createTopic(t, topic1, 1)
 	t.Cleanup(func() {
 		deleteTopic(t, topic1)
@@ -674,7 +674,7 @@ func testWriterMultipleTopics(t *testing.T, w *Writer) {
 		t.Fatal(err)
 	}
 
-	topic2 := makeTopicT(t)
+	topic2 := makeTestTopic(t)
 	createTopic(t, topic2, 1)
 	t.Cleanup(func() {
 		deleteTopic(t, topic2)

--- a/writer_test.go
+++ b/writer_test.go
@@ -241,6 +241,7 @@ func TestWriter(t *testing.T) {
 		t.Run(test.scenario, func(t *testing.T) {
 			// run test against deprecated constructor style
 			t.Run("constructor", func(t *testing.T) {
+				t.Parallel()
 
 				cfg := WriterConfig{
 					Balancer:     test.writer.Balancer,
@@ -248,9 +249,11 @@ func TestWriter(t *testing.T) {
 					BatchBytes:   int(test.writer.BatchBytes),
 					BatchSize:    test.writer.BatchSize,
 					BatchTimeout: test.writer.BatchTimeout,
+					Logger:       &testKafkaLogger{T: t},
 				}
+
 				if test.setTopic {
-					cfg.Topic = makeTopic()
+					cfg.Topic = makeTopicT(t)
 				}
 				if test.createTopic {
 					err := clientCreateTopic(client, cfg.Topic, test.partitions)
@@ -273,9 +276,13 @@ func TestWriter(t *testing.T) {
 
 			// run test against struct literal style
 			t.Run("literal", func(t *testing.T) {
+				t.Parallel()
+
 				w := test.writer
+				w.Logger = &testKafkaLogger{T: t}
+
 				if test.setTopic {
-					w.Topic = makeTopic()
+					w.Topic = makeTopicT(t)
 				}
 				if test.createTopic {
 					err := clientCreateTopic(client, w.Topic, test.partitions)
@@ -314,7 +321,7 @@ func testWriterClose(t *testing.T, w *Writer) {
 // Converting to standalone test since constructor does not support Transport
 // configuration
 func TestWriterRequiredAcksNone(t *testing.T) {
-	topic := makeTopic()
+	topic := makeTopicT(t)
 	createTopic(t, topic, 1)
 
 	transport := &Transport{}
@@ -652,7 +659,7 @@ func testWriterSmallBatchBytes(t *testing.T, w *Writer) {
 }
 
 func testWriterMultipleTopics(t *testing.T, w *Writer) {
-	topic1 := makeTopic()
+	topic1 := makeTopicT(t)
 	createTopic(t, topic1, 1)
 	t.Cleanup(func() {
 		deleteTopic(t, topic1)
@@ -663,7 +670,7 @@ func testWriterMultipleTopics(t *testing.T, w *Writer) {
 		t.Fatal(err)
 	}
 
-	topic2 := makeTopic()
+	topic2 := makeTopicT(t)
 	createTopic(t, topic2, 1)
 	t.Cleanup(func() {
 		deleteTopic(t, topic2)

--- a/writer_test.go
+++ b/writer_test.go
@@ -125,6 +125,7 @@ func TestWriter(t *testing.T) {
 			function:    testWriterClose,
 			setTopic:    true,
 			createTopic: true,
+			writer:      &Writer{},
 		},
 		{
 			scenario:    "writing 1 message through a writer using round-robin balancing produces 1 message to the first partition",
@@ -232,11 +233,12 @@ func TestWriter(t *testing.T) {
 		}
 
 		// client for making topics if necessary
-		client := &Client{
-			Addr: test.writer.Addr,
-		}
-		if client.Addr == nil {
+		client := &Client{}
+
+		if test.writer == nil || test.writer.Addr == nil {
 			client.Addr = TCP("localhost:9092")
+		} else {
+			client.Addr = test.writer.Addr
 		}
 
 		t.Run(test.scenario, func(t *testing.T) {
@@ -413,7 +415,12 @@ func TestValidateWriter(t *testing.T) {
 	}{
 		{config: WriterConfig{}, errorOccurred: true},
 		{
-			config:        WriterConfig{Brokers: []string{"broker1", "broker2"}},
+			config: WriterConfig{
+				Brokers: []string{
+					"broker1",
+					"broker2",
+				},
+			},
 			errorOccurred: false,
 		},
 		{


### PR DESCRIPTION
This is split out as a prerequisite to #700 since that PR is breaking the Writer tests, so I'm trying to isolate the orthogonal changes as much as possible.

- Add test coverage for `Writer{}` literal instantiation 
- Keep test coverage for deprecated `NewWriter()` constructor since it's still in use 