### PR TITLE
Make Writer tests more resilient

### DIFF
--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -16,7 +16,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	kafka "github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go"
 	pkg "github.com/segmentio/kafka-go/compress"
 	"github.com/segmentio/kafka-go/compress/gzip"
 	"github.com/segmentio/kafka-go/compress/lz4"
@@ -147,7 +147,7 @@ func testCompressedMessages(t *testing.T, codec pkg.Codec) {
 				}
 				offset++
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			if err := w.WriteMessages(ctx, batch...); err != nil {
 				t.Errorf("error sending batch %d, reason: %+v", i+1, err)
 			}

--- a/consumergroup_test.go
+++ b/consumergroup_test.go
@@ -3,8 +3,6 @@ package kafka
 import (
 	"context"
 	"errors"
-	"log"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -323,7 +321,7 @@ func TestConsumerGroup(t *testing.T) {
 				HeartbeatInterval: 2 * time.Second,
 				RebalanceTimeout:  2 * time.Second,
 				RetentionTime:     time.Hour,
-				Logger:            log.New(os.Stdout, "cg-test: ", 0),
+				Logger:            &testKafkaLogger{T: t},
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -569,7 +567,7 @@ func TestConsumerGroupErrors(t *testing.T) {
 				connect: func(*Dialer, ...string) (coordinator, error) {
 					return mc, nil
 				},
-				Logger: log.New(os.Stdout, "cg-errors-test: ", 0),
+				Logger: &testKafkaLogger{T: t},
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/describegroups_test.go
+++ b/describegroups_test.go
@@ -63,9 +63,6 @@ func TestClientDescribeGroups(t *testing.T) {
 		t.Skip("Skipping because kafka version is 2.3.1")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
 	client, shutdown := newLocalClient()
 	defer shutdown()
 
@@ -78,6 +75,10 @@ func TestClientDescribeGroups(t *testing.T) {
 	w := newTestWriter(WriterConfig{
 		Topic: topic,
 	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	err := w.WriteMessages(
 		ctx,
 		Message{

--- a/listgroups_test.go
+++ b/listgroups_test.go
@@ -42,9 +42,6 @@ func TestListGroupsResponseV1(t *testing.T) {
 }
 
 func TestClientListGroups(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
 	client, shutdown := newLocalClient()
 	defer shutdown()
 
@@ -57,6 +54,10 @@ func TestClientListGroups(t *testing.T) {
 	w := newTestWriter(WriterConfig{
 		Topic: topic,
 	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	err := w.WriteMessages(
 		ctx,
 		Message{


### PR DESCRIPTION
- Increase some timeouts
- When creating a test topic, block until it's ready
- Wrap some errors to help debug tests 

Tests do seem to run more reliably (ran with `-count=20` and they don't fail as often now), but the downside is that they take longer to run (~2-3 min instead of ~1m) 

I broke this out of #719 because I kept getting intermittent failures there, and I'm trying to isolate them away from the refactoring changes. 