### PR TITLE
feat(sasl): enrich authentication context with metadata

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -282,7 +282,6 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 		metadata := &sasl.Metadata{
 			BrokerAddress: address,
 		}
-
 		if err := d.authenticateSASL(sasl.WithMetadata(ctx, metadata), conn); err != nil {
 			_ = conn.Close()
 			return nil, err

--- a/dialer.go
+++ b/dialer.go
@@ -280,7 +280,7 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 
 	if d.SASLMechanism != nil {
 		metadata := &sasl.Metadata{
-			BrokerAddress: address,
+			Host: address,
 		}
 		if err := d.authenticateSASL(sasl.WithMetadata(ctx, metadata), conn); err != nil {
 			_ = conn.Close()

--- a/dialer.go
+++ b/dialer.go
@@ -279,7 +279,11 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 	conn := NewConnWith(c, connCfg)
 
 	if d.SASLMechanism != nil {
-		if err := d.authenticateSASL(ctx, conn); err != nil {
+		metadata := sasl.Metadata{
+			Address: address,
+		}
+
+		if err := d.authenticateSASL(metadata.WithContext(ctx), conn); err != nil {
 			_ = conn.Close()
 			return nil, err
 		}

--- a/dialer.go
+++ b/dialer.go
@@ -280,7 +280,7 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 
 	if d.SASLMechanism != nil {
 		metadata := sasl.Metadata{
-			Address: address,
+			BrokerAddress: address,
 		}
 
 		if err := d.authenticateSASL(metadata.WithContext(ctx), conn); err != nil {

--- a/dialer.go
+++ b/dialer.go
@@ -279,11 +279,11 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 	conn := NewConnWith(c, connCfg)
 
 	if d.SASLMechanism != nil {
-		metadata := sasl.Metadata{
+		metadata := &sasl.Metadata{
 			BrokerAddress: address,
 		}
 
-		if err := d.authenticateSASL(metadata.WithContext(ctx), conn); err != nil {
+		if err := d.authenticateSASL(sasl.WithMetadata(ctx, metadata), conn); err != nil {
 			_ = conn.Close()
 			return nil, err
 		}

--- a/sasl/sasl.go
+++ b/sasl/sasl.go
@@ -47,7 +47,9 @@ type StateMachine interface {
 
 // Metadata contains additional data for performing SASL authentication.
 type Metadata struct {
-	Address string
+	// BrokerAddress is the address of the broker the authentication will be
+	// performed on.
+	BrokerAddress string
 }
 
 // WithContext returns a copy of the context with associated Metadata.
@@ -57,8 +59,6 @@ func (m *Metadata) WithContext(ctx context.Context) context.Context {
 
 // MetadataFromContext retrieves the Metadata from the context.
 func MetadataFromContext(ctx context.Context) *Metadata {
-	if m, ok := ctx.Value(ctxKey{}).(*Metadata); ok {
-		return m
-	}
-	return nil
+	m, _ := ctx.Value(ctxKey{}).(*Metadata)
+	return m
 }

--- a/sasl/sasl.go
+++ b/sasl/sasl.go
@@ -52,8 +52,8 @@ type Metadata struct {
 	BrokerAddress string
 }
 
-// WithContext returns a copy of the context with associated Metadata.
-func (m *Metadata) WithContext(ctx context.Context) context.Context {
+// WithMetadata returns a copy of the context with associated Metadata.
+func WithMetadata(ctx context.Context, m *Metadata) context.Context {
 	return context.WithValue(ctx, ctxKey{}, m)
 }
 

--- a/sasl/sasl.go
+++ b/sasl/sasl.go
@@ -2,6 +2,8 @@ package sasl
 
 import "context"
 
+type ctxKey struct{}
+
 // Mechanism implements the SASL state machine for a particular mode of
 // authentication.  It is used by the kafka.Dialer to perform the SASL
 // handshake.
@@ -41,4 +43,22 @@ type StateMachine interface {
 	// the client has been successfully authenticated, then the done return
 	// value will be true.
 	Next(ctx context.Context, challenge []byte) (done bool, response []byte, err error)
+}
+
+// Metadata contains additional data for performing SASL authentication.
+type Metadata struct {
+	Address string
+}
+
+// WithContext returns a copy of the context with associated Metadata.
+func (m *Metadata) WithContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKey{}, m)
+}
+
+// MetadataFromContext retrieves the Metadata from the context.
+func MetadataFromContext(ctx context.Context) *Metadata {
+	if m, ok := ctx.Value(ctxKey{}).(*Metadata); ok {
+		return m
+	}
+	return nil
 }

--- a/sasl/sasl.go
+++ b/sasl/sasl.go
@@ -47,7 +47,7 @@ type StateMachine interface {
 
 // Metadata contains additional data for performing SASL authentication.
 type Metadata struct {
-	// BrokerAddress is the address of the broker the authentication will be
+	// Host is the address of the broker the authentication will be
 	// performed on.
 	BrokerAddress string
 }

--- a/sasl/sasl.go
+++ b/sasl/sasl.go
@@ -49,7 +49,7 @@ type StateMachine interface {
 type Metadata struct {
 	// Host is the address of the broker the authentication will be
 	// performed on.
-	BrokerAddress string
+	Host string
 }
 
 // WithMetadata returns a copy of the context with associated Metadata.

--- a/transport.go
+++ b/transport.go
@@ -1161,7 +1161,10 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 	pc.SetDeadline(time.Time{})
 
 	if g.pool.sasl != nil {
-		if err := authenticateSASL(ctx, pc, g.pool.sasl); err != nil {
+		metadata := sasl.Metadata{
+			Address: netAddr.String(),
+		}
+		if err := authenticateSASL(metadata.WithContext(ctx), pc, g.pool.sasl); err != nil {
 			return nil, err
 		}
 	}

--- a/transport.go
+++ b/transport.go
@@ -1164,7 +1164,7 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 		metadata := sasl.Metadata{
 			BrokerAddress: netAddr.String(),
 		}
-		if err := authenticateSASL(metadata.WithContext(ctx), pc, g.pool.sasl); err != nil {
+		if err := authenticateSASL(sasl.WithMetadata(ctx, &metadata), pc, g.pool.sasl); err != nil {
 			return nil, err
 		}
 	}

--- a/transport.go
+++ b/transport.go
@@ -1162,7 +1162,7 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 
 	if g.pool.sasl != nil {
 		metadata := &sasl.Metadata{
-			BrokerAddress: netAddr.String(),
+			Host: netAddr.String(),
 		}
 		if err := authenticateSASL(sasl.WithMetadata(ctx, metadata), pc, g.pool.sasl); err != nil {
 			return nil, err

--- a/transport.go
+++ b/transport.go
@@ -1161,10 +1161,10 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 	pc.SetDeadline(time.Time{})
 
 	if g.pool.sasl != nil {
-		metadata := sasl.Metadata{
+		metadata := &sasl.Metadata{
 			BrokerAddress: netAddr.String(),
 		}
-		if err := authenticateSASL(sasl.WithMetadata(ctx, &metadata), pc, g.pool.sasl); err != nil {
+		if err := authenticateSASL(sasl.WithMetadata(ctx, metadata), pc, g.pool.sasl); err != nil {
 			return nil, err
 		}
 	}

--- a/transport.go
+++ b/transport.go
@@ -1162,7 +1162,7 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 
 	if g.pool.sasl != nil {
 		metadata := sasl.Metadata{
-			Address: netAddr.String(),
+			BrokerAddress: netAddr.String(),
 		}
 		if err := authenticateSASL(metadata.WithContext(ctx), pc, g.pool.sasl); err != nil {
 			return nil, err


### PR DESCRIPTION
Picking up from https://github.com/segmentio/kafka-go/pull/563 and https://github.com/segmentio/kafka-go/pull/598, this PR only does the necessary changes to have additional metadata propagated to the authentication functions so it can be used for authenticating. Currently it's only the address (needed by GSSAPI).

I chose the context approach because it requires the least amount of changes to existing code.