### PR TITLE
fix: set the offset does not take effect

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -1137,7 +1137,7 @@ func (cg *ConsumerGroup) makeAssignments(assignments map[string][]int32, offsets
 			if ok {
 				offset, ok = partitionOffsets[int(partition)]
 			}
-			if !ok {
+			if !ok || cg.config.StartOffset == LastOffset {
 				offset = cg.config.StartOffset
 			}
 			topicAssignments[topic] = append(topicAssignments[topic], PartitionAssignment{


### PR DESCRIPTION
when I use consumer groups, I want to start reading from the current message with new pod， so I set last offset，It seems that setting LastOffset always does not work， so i tried this。

version :v0.4.17