### PR TITLE
Make fetchOffsets response parse conform to kafka protocol

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -1108,8 +1108,12 @@ func (cg *ConsumerGroup) fetchOffsets(conn coordinator, subs map[string][]int32)
 
 	offsetsByTopic := make(map[string]map[int]int64)
 	for _, res := range offsets.Responses {
-		offsetsByPartition := map[int]int64{}
-		offsetsByTopic[res.Topic] = offsetsByPartition
+		offsetsByPartition, ok := offsetsByTopic[res.Topic]
+		if !ok {
+			offsetsByPartition = map[int]int64{}
+			offsetsByTopic[res.Topic] = offsetsByPartition
+		}
+
 		for _, pr := range res.PartitionResponses {
 			for _, partition := range subs[res.Topic] {
 				if partition == pr.Partition {

--- a/read.go
+++ b/read.go
@@ -241,7 +241,11 @@ func readMapStringInt32(r *bufio.Reader, sz int, v *map[string][]int32) (remain 
 			return
 		}
 
-		content[key] = values
+		if items, ok := content[key]; ok {
+			content[key] = append(items, values...)
+		} else {
+			content[key] = values
+		}
 	}
 	*v = content
 


### PR DESCRIPTION
Here is the definition of offsets fetch request:
https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetFetchRequest

The response is a list of topic partition offset information. We used a map to store topic and the partition offset info and in every loop we create a new map to overwrite the topic. Which means we only allow the topic appear once in the list. But the protocol definition has no such assumption. 

Look at the [implement of the official Java client](https://github.com/apache/kafka/blob/e00c0f3719ad0803620752159ef8315d668735d6/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java#L143):
```java
    public OffsetFetchResponse(int throttleTimeMs, Errors error, Map<TopicPartition, PartitionData> responseData) {
        super(ApiKeys.OFFSET_FETCH);
        Map<String, OffsetFetchResponseTopic> offsetFetchResponseTopicMap = new HashMap<>();
        for (Map.Entry<TopicPartition, PartitionData> entry : responseData.entrySet()) {
            String topicName = entry.getKey().topic();
            OffsetFetchResponseTopic topic = offsetFetchResponseTopicMap.getOrDefault(
                topicName, new OffsetFetchResponseTopic().setName(topicName));
            PartitionData partitionData = entry.getValue();
            topic.partitions().add(new OffsetFetchResponsePartition()
                                       .setPartitionIndex(entry.getKey().partition())
                                       .setErrorCode(partitionData.error.code())
                                       .setCommittedOffset(partitionData.offset)
                                       .setCommittedLeaderEpoch(
                                           partitionData.leaderEpoch.orElse(NO_PARTITION_LEADER_EPOCH))
                                       .setMetadata(partitionData.metadata)
            );
            offsetFetchResponseTopicMap.put(topicName, topic);
        }

        // ...
    }
```
It uses `getOrDefault`  to get the partition offset info of a topic. Which means it allows topic appears multiple times in the response list.