### PR TITLE
fix formatting + require Go 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ some features available from the Kafka API may not be implemented yet.
 
 ## Golang version
 
-`kafka-go` is currently compatible with golang version from 1.13+. To use with older versions of golang use release [v0.2.5](https://github.com/segmentio/kafka-go/releases/tag/v0.2.5).
+`kafka-go` is currently compatible with golang version from 1.15+. To use with older versions of golang use release [v0.2.5](https://github.com/segmentio/kafka-go/releases/tag/v0.2.5).
 
 ## Connection [![GoDoc](https://godoc.org/github.com/segmentio/kafka-go?status.svg)](https://godoc.org/github.com/segmentio/kafka-go#Conn)
 

--- a/createpartitions_test.go
+++ b/createpartitions_test.go
@@ -21,11 +21,11 @@ func TestClientCreatePartitions(t *testing.T) {
 
 	res, err := client.CreatePartitions(context.Background(), &CreatePartitionsRequest{
 		Topics: []TopicPartitionsConfig{
-			TopicPartitionsConfig{
+			{
 				Name:  topic,
 				Count: 2,
 				TopicPartitionAssignments: []TopicPartitionAssignment{
-					TopicPartitionAssignment{
+					{
 						BrokerIDs: []int32{1},
 					},
 				},

--- a/fetch.go
+++ b/fetch.go
@@ -101,7 +101,7 @@ func (c *Client) Fetch(ctx context.Context, req *FetchRequest) (*FetchResponse, 
 		r, err := c.ListOffsets(ctx, &ListOffsetsRequest{
 			Addr: req.Addr,
 			Topics: map[string][]OffsetRequest{
-				topic: []OffsetRequest{{
+				topic: {{
 					Partition: partition,
 					Timestamp: offset,
 				}},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/segmentio/kafka-go
 
-go 1.13
+go 1.15
 
 require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21

--- a/protocol/reflect.go
+++ b/protocol/reflect.go
@@ -1,3 +1,4 @@
+//go:build !unsafe
 // +build !unsafe
 
 package protocol

--- a/protocol/reflect_unsafe.go
+++ b/protocol/reflect_unsafe.go
@@ -1,3 +1,4 @@
+//go:build unsafe
 // +build unsafe
 
 package protocol

--- a/read_test.go
+++ b/read_test.go
@@ -17,15 +17,15 @@ type VarIntTestCase struct {
 
 func TestReadVarInt(t *testing.T) {
 	testCases := []*VarIntTestCase{
-		&VarIntTestCase{v: 0, r: 3, tc: []byte{0, 1, 10, 0}},
-		&VarIntTestCase{v: -1, r: 3, tc: []byte{1, 1, 10, 0}},
-		&VarIntTestCase{v: 1, r: 3, tc: []byte{2, 1, 10, 0}},
-		&VarIntTestCase{v: -2, r: 3, tc: []byte{3, 1, 10, 0}},
-		&VarIntTestCase{v: 2, r: 3, tc: []byte{4, 1, 10, 0}},
-		&VarIntTestCase{v: 64, r: 2, tc: []byte{128, 1, 10, 0}},
-		&VarIntTestCase{v: -64, r: 3, tc: []byte{127, 1, 10, 0}},
-		&VarIntTestCase{v: -196, r: 2, tc: []byte{135, 3, 10, 0}},
-		&VarIntTestCase{v: -24772, r: 1, tc: []byte{135, 131, 3, 0}},
+		{v: 0, r: 3, tc: []byte{0, 1, 10, 0}},
+		{v: -1, r: 3, tc: []byte{1, 1, 10, 0}},
+		{v: 1, r: 3, tc: []byte{2, 1, 10, 0}},
+		{v: -2, r: 3, tc: []byte{3, 1, 10, 0}},
+		{v: 2, r: 3, tc: []byte{4, 1, 10, 0}},
+		{v: 64, r: 2, tc: []byte{128, 1, 10, 0}},
+		{v: -64, r: 3, tc: []byte{127, 1, 10, 0}},
+		{v: -196, r: 2, tc: []byte{135, 3, 10, 0}},
+		{v: -24772, r: 1, tc: []byte{135, 131, 3, 0}},
 	}
 
 	for _, tc := range testCases {

--- a/reader_test.go
+++ b/reader_test.go
@@ -311,7 +311,6 @@ func createTopic(t *testing.T, topic string, partitions int) {
 		t.FailNow()
 	}
 
-
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 

--- a/write_test.go
+++ b/write_test.go
@@ -25,14 +25,14 @@ type WriteVarIntTestCase struct {
 
 func TestWriteVarInt(t *testing.T) {
 	testCases := []*WriteVarIntTestCase{
-		&WriteVarIntTestCase{v: []byte{0}, tc: 0},
-		&WriteVarIntTestCase{v: []byte{2}, tc: 1},
-		&WriteVarIntTestCase{v: []byte{1}, tc: -1},
-		&WriteVarIntTestCase{v: []byte{3}, tc: -2},
-		&WriteVarIntTestCase{v: []byte{128, 2}, tc: 128},
-		&WriteVarIntTestCase{v: []byte{254, 1}, tc: 127},
-		&WriteVarIntTestCase{v: []byte{142, 6}, tc: 391},
-		&WriteVarIntTestCase{v: []byte{142, 134, 6}, tc: 49543},
+		{v: []byte{0}, tc: 0},
+		{v: []byte{2}, tc: 1},
+		{v: []byte{1}, tc: -1},
+		{v: []byte{3}, tc: -2},
+		{v: []byte{128, 2}, tc: 128},
+		{v: []byte{254, 1}, tc: 127},
+		{v: []byte{142, 6}, tc: 391},
+		{v: []byte{142, 134, 6}, tc: 49543},
 	}
 
 	for _, tc := range testCases {
@@ -203,7 +203,7 @@ func TestWriteV2RecordBatch(t *testing.T) {
 	msgs := make([]Message, 15)
 	for i := range msgs {
 		value := fmt.Sprintf("Sample message content: %d!", i)
-		msgs[i] = Message{Key: []byte("Key"), Value: []byte(value), Headers: []Header{Header{Key: "hk", Value: []byte("hv")}}}
+		msgs[i] = Message{Key: []byte("Key"), Value: []byte(value), Headers: []Header{{Key: "hk", Value: []byte("hv")}}}
 	}
 
 	w := &Writer{

--- a/writer_test.go
+++ b/writer_test.go
@@ -486,8 +486,8 @@ func testWriterBatchSize(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := w.WriteMessages(ctx, []Message{
-		Message{Value: []byte("Hi")}, // 24 Bytes
-		Message{Value: []byte("By")}, // 24 Bytes
+		{Value: []byte("Hi")}, // 24 Bytes
+		{Value: []byte("By")}, // 24 Bytes
 	}...); err != nil {
 		t.Error(err)
 		return
@@ -537,8 +537,8 @@ func testWriterSmallBatchBytes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := w.WriteMessages(ctx, []Message{
-		Message{Value: []byte("Hi")}, // 24 Bytes
-		Message{Value: []byte("By")}, // 24 Bytes
+		{Value: []byte("Hi")}, // 24 Bytes
+		{Value: []byte("By")}, // 24 Bytes
 	}...); err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
I ran `gofmt -s` to address some of the issues reported by https://goreportcard.com/report/github.com/segmentio/kafka-go

I also changed the minimum required Go version to 1.15 since older versions aren't being maintained anymore.