### PR TITLE
add encoding.TextMarshaler and encoding.TextUnmarshaler implementations

### DIFF
--- a/compress/compress.go
+++ b/compress/compress.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/segmentio/kafka-go/compress/gzip"
@@ -53,6 +54,12 @@ func (c *Compression) UnmarshalText(b []byte) error {
 			*c = Compression(codec.Code())
 			return nil
 		}
+	}
+
+	i, err := strconv.ParseInt(string(b), 10, 64)
+	if err == nil && i >= 0 && i < int64(len(Codecs)) {
+		*c = Compression(i)
+		return nil
 	}
 
 	s := &strings.Builder{}

--- a/compress/compress.go
+++ b/compress/compress.go
@@ -63,7 +63,7 @@ func (c *Compression) UnmarshalText(b []byte) error {
 	}
 
 	s := &strings.Builder{}
-	s.WriteString("none")
+	s.WriteString("none, uncompressed")
 
 	for i, codec := range Codecs[None+1:] {
 		if i < (len(Codecs) - 1) {

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -85,6 +85,24 @@ func testEncodeDecode(t *testing.T, m kafka.Message, codec pkg.Codec) {
 	var r1, r2 []byte
 	var err error
 
+	t.Run("text format of "+codec.Name(), func(t *testing.T) {
+		c := pkg.Compression(codec.Code())
+
+		b, err := c.MarshalText()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x := pkg.Compression(-1)
+		if err := x.UnmarshalText(b); err != nil {
+			t.Fatal(err)
+		}
+
+		if x != c {
+			t.Errorf("compression mismatch after marshal/unmarshal: want=%s got=%s", c, x)
+		}
+	})
+
 	t.Run("encode with "+codec.Name(), func(t *testing.T) {
 		r1, err = compress(codec, m.Value)
 		if err != nil {

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -87,19 +87,26 @@ func testEncodeDecode(t *testing.T, m kafka.Message, codec pkg.Codec) {
 
 	t.Run("text format of "+codec.Name(), func(t *testing.T) {
 		c := pkg.Compression(codec.Code())
-
+		a := strconv.Itoa(int(c))
+		x := pkg.Compression(-1)
+		y := pkg.Compression(-1)
 		b, err := c.MarshalText()
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		x := pkg.Compression(-1)
-		if err := x.UnmarshalText(b); err != nil {
+		if err := x.UnmarshalText([]byte(a)); err != nil {
+			t.Fatal(err)
+		}
+		if err := y.UnmarshalText(b); err != nil {
 			t.Fatal(err)
 		}
 
 		if x != c {
 			t.Errorf("compression mismatch after marshal/unmarshal: want=%s got=%s", c, x)
+		}
+		if y != c {
+			t.Errorf("compression mismatch after marshal/unmarshal: want=%s got=%s", c, y)
 		}
 	})
 

--- a/produce.go
+++ b/produce.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bufio"
 	"context"
+	"encoding"
 	"errors"
 	"fmt"
 	"net"
@@ -32,6 +33,29 @@ func (acks RequiredAcks) String() string {
 		return "unknown"
 	}
 }
+
+func (acks RequiredAcks) MarshalText() ([]byte, error) {
+	return []byte(acks.String()), nil
+}
+
+func (acks *RequiredAcks) UnmarshalText(b []byte) error {
+	switch string(b) {
+	case "none":
+		*acks = RequireNone
+	case "one":
+		*acks = RequireOne
+	case "all":
+		*acks = RequireAll
+	default:
+		return fmt.Errorf("required acks must be one of none, one, or all, not %q", b)
+	}
+	return nil
+}
+
+var (
+	_ encoding.TextMarshaler   = RequiredAcks(0)
+	_ encoding.TextUnmarshaler = (*RequiredAcks)(nil)
+)
 
 // ProduceRequest represents a request sent to a kafka broker to produce records
 // to a topic partition.

--- a/produce.go
+++ b/produce.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/segmentio/kafka-go/protocol"
@@ -47,7 +48,12 @@ func (acks *RequiredAcks) UnmarshalText(b []byte) error {
 	case "all":
 		*acks = RequireAll
 	default:
-		return fmt.Errorf("required acks must be one of none, one, or all, not %q", b)
+		x, err := strconv.ParseInt(string(b), 10, 64)
+		parsed := RequiredAcks(x)
+		if err != nil || (parsed != RequireNone && parsed != RequireOne && parsed != RequireAll) {
+			return fmt.Errorf("required acks must be one of none, one, or all, not %q", b)
+		}
+		*acks = parsed
 	}
 	return nil
 }

--- a/produce_test.go
+++ b/produce_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,18 +16,26 @@ func TestRequiredAcks(t *testing.T) {
 		RequireAll,
 	} {
 		t.Run(acks.String(), func(t *testing.T) {
+			a := strconv.Itoa(int(acks))
+			x := RequiredAcks(-2)
+			y := RequiredAcks(-2)
 			b, err := acks.MarshalText()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			x := RequiredAcks(-1)
-			if err := x.UnmarshalText(b); err != nil {
+			if err := x.UnmarshalText([]byte(a)); err != nil {
+				t.Fatal(err)
+			}
+			if err := y.UnmarshalText(b); err != nil {
 				t.Fatal(err)
 			}
 
 			if x != acks {
-				t.Errorf("required acks mismatch after marshal/unmarshal: want=%s got=%s", acks, x)
+				t.Errorf("required acks mismatch after marshal/unmarshal text: want=%s got=%s", acks, x)
+			}
+			if y != acks {
+				t.Errorf("required acks mismatch after marshal/unmarshal value: want=%s got=%s", acks, y)
 			}
 		})
 	}

--- a/produce_test.go
+++ b/produce_test.go
@@ -8,6 +8,30 @@ import (
 	"github.com/segmentio/kafka-go/compress"
 )
 
+func TestRequiredAcks(t *testing.T) {
+	for _, acks := range []RequiredAcks{
+		RequireNone,
+		RequireOne,
+		RequireAll,
+	} {
+		t.Run(acks.String(), func(t *testing.T) {
+			b, err := acks.MarshalText()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			x := RequiredAcks(-1)
+			if err := x.UnmarshalText(b); err != nil {
+				t.Fatal(err)
+			}
+
+			if x != acks {
+				t.Errorf("required acks mismatch after marshal/unmarshal: want=%s got=%s", acks, x)
+			}
+		})
+	}
+}
+
 func TestClientProduce(t *testing.T) {
 	client, topic, shutdown := newLocalClientAndTopic()
 	defer shutdown()


### PR DESCRIPTION
This PR implements the standard `encoding.TextMarshaler` and `encoding.TextUnmarshaler` interfaces on the `kafka.RequiredAcks` and `kafka.Compression` types.

The intent is to facilitate loading and saving of these configuration values via textual representations; a common use case would be to have them provided in a configuration file, or on the command line of a kafka producer.