### PR TITLE
Expose metadata request parameters for cluster discovery routine

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -288,11 +288,11 @@ func (t *Transport) context() context.Context {
 	return context.Background()
 }
 
-func (t *Transport) discoverOptions() *DiscoverOptions {
+func (t *Transport) discoverOptions() DiscoverOptions {
 	if t.DiscoverOptions == nil {
-		return &DefaultDiscoverOptions
+		return DefaultDiscoverOptions
 	}
-	return t.DiscoverOptions
+	return *t.DiscoverOptions
 }
 
 type event chan struct{}
@@ -324,7 +324,7 @@ type connPool struct {
 	ctrl  *connGroup           // control connections used for metadata requests
 	state atomic.Value         // cached cluster state
 	// Expose metadata request parameters. Used in discover()
-	discoverOptions *DiscoverOptions
+	discoverOptions DiscoverOptions
 }
 
 type connPoolState struct {

--- a/transport.go
+++ b/transport.go
@@ -130,7 +130,7 @@ type DiscoverOptions struct {
 }
 
 // DefaultDiscoverOptions are the default options for Metadata request parameters.
-var DefaultDiscoverOptions = &DiscoverOptions{
+var DefaultDiscoverOptions = DiscoverOptions{
 	IncludeClusterAuthorizedOperations: true,
 	IncludeTopicAuthorizedOperations:   true,
 	AllowAutoTopicCreation:             false,
@@ -290,7 +290,7 @@ func (t *Transport) context() context.Context {
 
 func (t *Transport) discoverOptions() *DiscoverOptions {
 	if t.DiscoverOptions == nil {
-		return DefaultDiscoverOptions
+		return &DefaultDiscoverOptions
 	}
 	return t.DiscoverOptions
 }


### PR DESCRIPTION
I have received complaints from our kafka cluster admins that service my team was developing produces massive amount of logs on kafka side: 
```
[2021-10-25 13:24:00,836] INFO Principal = User:user_rw is Denied Operation = Alter from host = 1.2.3.4 on resource = Topic:LITERAL:the_topic (kafka.authorizer.logger)
[2021-10-25 13:24:00,836] INFO Principal = User:user_rw is Denied Operation = AlterConfigs from host = 1.2.3.4 on resource = Topic:LITERAL:the_topic (kafka.authorizer.logger)
[2021-10-25 13:24:00,837] INFO Principal = User:user_rw is Denied Operation = Delete from host = 1.2.3.4 on resource = Topic:LITERAL:the_topic (kafka.authorizer.logger)
[2021-10-25 13:24:00,837] INFO Principal = User:user_rw is Denied Operation = DescribeConfigs from host = 1.2.3.4 on resource = Topic:LITERAL:the_topic (kafka.authorizer.logger)
```

After short investigation i have found the reason: `connPool.discover()` routine was sending `Metadata` request with `include_cluster_authorized_operations` and `include_topic_authorized_operations` flags set every 6 seconds (default value for `Transport.MetadataTTL`).

Quick soultion is to set `MetadataTTL` to crazy high value but for the future is a good option to have these parameters exposed.

P.S.
Thanks for the great package for kafka :)