### PR TITLE
Typo: Fixes "Code of Contact" to "Code of Conduct"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ software.
 
 #### Note:
 
-In order to better align  with our newly adopted Code of Contact, the kafka-go project has renamed our default branch to `main`.  
+In order to better align with our newly adopted Code of Conduct, the kafka-go project has renamed our default branch to `main`.  
 For the full details of our Code Of Conduct see [this](./CODE_OF_CONDUCT.md) document.
 
 ## Migrating to 0.4


### PR DESCRIPTION
I was reading the README and stumbled over this tiny typo referring to a "Code of Contact" in one place, which I assume is supposed to be a "Code of Conduct". The following sentence states it correctly. 

HTH.