### PR TITLE
README.md: Don't print excess characters in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ batch := conn.ReadBatch(10e3, 1e6) // fetch 10KB min, 1MB max
 
 b := make([]byte, 10e3) // 10KB max per message
 for {
-    _, err := batch.Read(b)
+    n, err := batch.Read(b)
     if err != nil {
         break
     }
-    fmt.Println(string(b))
+    fmt.Println(string(b[:n]))
 }
 
 if err := batch.Close(); err != nil {


### PR DESCRIPTION
Fixes issue https://github.com/segmentio/kafka-go/issues/760