### PR TITLE
Allow Writer to automatically create topics.

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -360,7 +360,9 @@ func (p *connPool) roundTrip(ctx context.Context, req Request) (Response, error)
 		var requestNeeded bool
 		if m.AllowAutoTopicCreation {
 			for _, topic := range cachedMeta.Topics {
-				requestNeeded = topic.ErrorCode == int16(UnknownTopicOrPartition)
+				if topic.ErrorCode == int16(UnknownTopicOrPartition) {
+					requestNeeded = true
+				}
 			}
 		}
 

--- a/transport.go
+++ b/transport.go
@@ -358,9 +358,9 @@ func (p *connPool) roundTrip(ctx context.Context, req Request) (Response, error)
 		// It's true when we want to auto-create topics and we don't have the topic in our
 		// cache.
 		var requestNeeded bool
-		for _, topic := range cachedMeta.Topics {
-			if topic.ErrorCode == int16(UnknownTopicOrPartition) && m.AllowAutoTopicCreation {
-				requestNeeded = true
+		if m.AllowAutoTopicCreation {
+			for _, topic := range cachedMeta.Topics {
+				requestNeeded = topic.ErrorCode == int16(UnknownTopicOrPartition)
 			}
 		}
 

--- a/transport.go
+++ b/transport.go
@@ -344,14 +344,29 @@ func (p *connPool) roundTrip(ctx context.Context, req Request) (Response, error)
 
 	switch m := req.(type) {
 	case *meta.Request:
-		// We serve metadata requests directly from the transport cache.
+		// We serve metadata requests directly from the transport cache unless
+		// we would like to auto create a topic that isn't in our cache.
 		//
 		// This reduces the number of round trips to kafka brokers while keeping
 		// the logic simple when applying partitioning strategies.
 		if state.err != nil {
 			return nil, state.err
 		}
-		return filterMetadataResponse(m, state.metadata), nil
+
+		cachedMeta := filterMetadataResponse(m, state.metadata)
+		// requestNeeded indicates if we need to send this metadata request to the server.
+		// It's true when we want to auto-create topics and we don't have the topic in our
+		// cache.
+		var requestNeeded bool
+		for _, topic := range cachedMeta.Topics {
+			if topic.ErrorCode == int16(UnknownTopicOrPartition) && m.AllowAutoTopicCreation {
+				requestNeeded = true
+			}
+		}
+
+		if !requestNeeded {
+			return cachedMeta, nil
+		}
 
 	case protocol.Splitter:
 		// Messages that implement the Splitter interface trigger the creation of
@@ -392,6 +407,14 @@ func (p *connPool) roundTrip(ctx context.Context, req Request) (Response, error)
 		}
 
 		p.refreshMetadata(ctx, topicsToRefresh)
+	case *meta.Response:
+		m := req.(*meta.Request)
+		// If we get here with allow auto topic creation then
+		// we didn't have that topic in our cache so we should update
+		// the cache.
+		if m.AllowAutoTopicCreation {
+			p.refreshMetadata(ctx, m.TopicNames)
+		}
 	}
 
 	return r, nil

--- a/transport.go
+++ b/transport.go
@@ -362,6 +362,7 @@ func (p *connPool) roundTrip(ctx context.Context, req Request) (Response, error)
 			for _, topic := range cachedMeta.Topics {
 				if topic.ErrorCode == int16(UnknownTopicOrPartition) {
 					requestNeeded = true
+					break
 				}
 			}
 		}

--- a/writer.go
+++ b/writer.go
@@ -702,7 +702,8 @@ func (w *Writer) partitions(ctx context.Context, topic string) (int, error) {
 	// It is expected that the transport will optimize this request by
 	// caching recent results (the kafka.Transport types does).
 	r, err := client.transport().RoundTrip(ctx, client.Addr, &metadataAPI.Request{
-		TopicNames: []string{topic},
+		TopicNames:             []string{topic},
+		AllowAutoTopicCreation: true,
 	})
 	if err != nil {
 		return 0, err

--- a/writer_test.go
+++ b/writer_test.go
@@ -716,11 +716,12 @@ func testWriterAutoCreateTopic(t *testing.T) {
 
 	msg := Message{Key: []byte("key"), Value: []byte("Hello World")}
 
+	var err error
 	const retries = 5
 	for i := 0; i < retries; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		err := w.WriteMessages(ctx, msg)
+		err = w.WriteMessages(ctx, msg)
 		if errors.Is(err, LeaderNotAvailable) || errors.Is(err, context.DeadlineExceeded) {
 			time.Sleep(time.Millisecond * 250)
 			continue
@@ -730,6 +731,9 @@ func testWriterAutoCreateTopic(t *testing.T) {
 			t.Errorf("unexpected error %v", err)
 			return
 		}
+	}
+	if err != nil {
+		t.Errorf("unable to create topic %v", err)
 	}
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -723,12 +723,12 @@ func testWriterAutoCreateTopic(t *testing.T) {
 	for i := 0; i < retries; i++ {
 		err := w.WriteMessages(ctx, msg)
 		if errors.Is(err, LeaderNotAvailable) {
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 250)
 			continue
 		}
 
 		if err != nil {
-			t.Error("expected error")
+			t.Errorf("unexpected error %v", err)
 			return
 		}
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -704,9 +704,6 @@ func testWriterUnexpectedMessageTopic(t *testing.T) {
 }
 
 func testWriterAutoCreateTopic(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
 	topic := makeTopic()
 	// Assume it's going to get created.
 	defer deleteTopic(t, topic)
@@ -721,8 +718,10 @@ func testWriterAutoCreateTopic(t *testing.T) {
 
 	const retries = 5
 	for i := 0; i < retries; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		err := w.WriteMessages(ctx, msg)
-		if errors.Is(err, LeaderNotAvailable) {
+		if errors.Is(err, LeaderNotAvailable) || errors.Is(err, context.DeadlineExceeded) {
 			time.Sleep(time.Millisecond * 250)
 			continue
 		}


### PR DESCRIPTION
Potential Fix for #683 

Writer now sets AutoCreateTopics to true when calling for metadata.

Transport will now make a metadata request to the server if the metadata cache does not contain the requested topic and AutoCreateTopics is true. We then update the metadata cache after sending the metadata request to the server.