### PR TITLE
add port to SASL metadata

### DIFF
--- a/address.go
+++ b/address.go
@@ -20,16 +20,9 @@ func makeNetAddr(network string, addresses []string) net.Addr {
 }
 
 func makeAddr(network, address string) net.Addr {
-	host, port, _ := net.SplitHostPort(address)
-	if port == "" {
-		port = "9092"
-	}
-	if host == "" {
-		host = address
-	}
 	return &networkAddress{
 		network: network,
-		address: net.JoinHostPort(host, port),
+		address: canonicalAddress(address),
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -241,11 +240,10 @@ func (c *Conn) loadVersions() (apiVersionMap, error) {
 // connection was established to.
 func (c *Conn) Broker() Broker {
 	addr := c.conn.RemoteAddr()
-	host, port, _ := net.SplitHostPort(addr.String())
-	portNumber, _ := strconv.Atoi(port)
+	host, port, _ := splitHostPortNumber(addr.String())
 	return Broker{
 		Host: host,
-		Port: portNumber,
+		Port: port,
 		ID:   int(c.broker),
 		Rack: c.rack,
 	}

--- a/dialer.go
+++ b/dialer.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"strconv"
@@ -281,8 +282,13 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 	conn := NewConnWith(c, connCfg)
 
 	if d.SASLMechanism != nil {
+		host, port, err := splitHostPortNumber(address)
+		if err != nil {
+			return nil, err
+		}
 		metadata := &sasl.Metadata{
-			Host: address,
+			Host: host,
+			Port: port,
 		}
 		if err := d.authenticateSASL(sasl.WithMetadata(ctx, metadata), conn); err != nil {
 			_ = conn.Close()
@@ -435,12 +441,26 @@ func backoff(attempt int, min time.Duration, max time.Duration) time.Duration {
 	return d
 }
 
+func canonicalAddress(s string) string {
+	return net.JoinHostPort(splitHostPort(s))
+}
+
 func splitHostPort(s string) (host string, port string) {
 	host, port, _ = net.SplitHostPort(s)
 	if len(host) == 0 && len(port) == 0 {
 		host = s
+		port = "9092"
 	}
 	return
+}
+
+func splitHostPortNumber(s string) (host string, portNumber int, err error) {
+	host, port := splitHostPort(s)
+	portNumber, err = strconv.Atoi(port)
+	if err != nil {
+		return host, 0, fmt.Errorf("%s: %w", s, err)
+	}
+	return host, portNumber, nil
 }
 
 func lookupHost(ctx context.Context, address string, resolver Resolver) (string, error) {
@@ -466,10 +486,6 @@ func lookupHost(ctx context.Context, address string, resolver Resolver) (string,
 				port = resolvedPort
 			}
 		}
-	}
-
-	if port == "" {
-		port = "9092"
 	}
 
 	return net.JoinHostPort(host, port), nil

--- a/sasl/sasl.go
+++ b/sasl/sasl.go
@@ -50,6 +50,7 @@ type Metadata struct {
 	// Host is the address of the broker the authentication will be
 	// performed on.
 	Host string
+	Port int
 }
 
 // WithMetadata returns a copy of the context with associated Metadata.


### PR DESCRIPTION
Follow up to https://github.com/segmentio/kafka-go/pull/725, this PR adds a `Port` field to the `sasl.Metadata` type as a way to ensure that the `Host` does not contain the port number. This would be helpful to the implementation of https://github.com/segmentio/kafka-go/pull/763