### PR TITLE
Ensure tests run under Go 1.16

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -742,7 +742,7 @@ func (r *readerHelper) readMessageErr() (msg Message, err error) {
 		return
 	}
 	msg.Offset = r.offset
-	msg.Time = time.UnixMilli(timestamp)
+	msg.Time = time.Unix(timestamp / 1000, (timestamp % 1000) * 1000000)
 	msg.Headers = headers
 	return
 }


### PR DESCRIPTION
Uses of time.UnixMilli() introduced recently, which only work with Go
1.17 or higher, are replaced with equivalent code that works under Go
1.16. If/when this module moves past Go 1.16, these changes may be
reverted.
