### PR TITLE
Fix go vet issues: example tests, returning a mutex copy

### DIFF
--- a/example_consumergroup_test.go
+++ b/example_consumergroup_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/segmentio/kafka-go"
 )
 
-func ExampleConsumerGroupParallelReaders() {
+func ExampleGeneration_Start_consumerGroupParallelReaders() {
 	group, err := kafka.NewConsumerGroup(kafka.ConsumerGroupConfig{
 		ID:      "my-group",
 		Brokers: []string{"kafka:9092"},
@@ -60,7 +60,7 @@ func ExampleConsumerGroupParallelReaders() {
 	}
 }
 
-func ExampleConsumerGroupOverwriteOffsets() {
+func ExampleGeneration_CommitOffsets_overwriteOffsets() {
 	group, err := kafka.NewConsumerGroup(kafka.ConsumerGroupConfig{
 		ID:      "my-group",
 		Brokers: []string{"kafka:9092"},

--- a/example_groupbalancer_test.go
+++ b/example_groupbalancer_test.go
@@ -10,11 +10,11 @@ import (
 	"time"
 )
 
-// ExampleAWSRackLocal shows how the RackAffinityGroupBalancer can be used to
-// pair up consumers with brokers in the same AWS availability zone.  This code
-// assumes that each brokers' rack is configured to be the name of the AZ in
-// which it is running.
-func ExampleAWSRackLocal() {
+// ExampleNewReader_rackAffinity shows how the RackAffinityGroupBalancer can be
+// used to pair up consumers with brokers in the same AWS availability zone.
+// This code assumes that each brokers' rack is configured to be the name of the
+// AZ in which it is running.
+func ExampleNewReader_rackAffinity() {
 	r := NewReader(ReaderConfig{
 		Brokers: []string{"kafka:9092"},
 		GroupID: "my-group",

--- a/writer.go
+++ b/writer.go
@@ -912,14 +912,14 @@ func (b *batchQueue) Close() {
 	b.closed = true
 }
 
-func newBatchQueue(initialSize int) batchQueue {
+func newBatchQueue(initialSize int) *batchQueue {
 	bq := batchQueue{
 		queue: make([]*writeBatch, 0, initialSize),
 	}
 
 	bq.cond.L = &bq.mutex
 
-	return bq
+	return &bq
 }
 
 // partitionWriter is a writer for a topic-partion pair. It maintains messaging order
@@ -941,7 +941,7 @@ type partitionWriter struct {
 func newPartitionWriter(w *Writer, key topicPartition) *partitionWriter {
 	writer := &partitionWriter{
 		meta:  key,
-		queue: newBatchQueue(10),
+		queue: *newBatchQueue(10),
 		w:     w,
 	}
 	go func() {

--- a/writer.go
+++ b/writer.go
@@ -867,6 +867,9 @@ func (w *Writer) chooseTopic(msg Message) (string, error) {
 type batchQueue struct {
 	queue []*writeBatch
 
+	// Pointers are used here to make `go vet` happy, and avoid copying mutexes.
+	// It may be better to revert these to non-pointers and avoid the copies in
+	// a different way.
 	mutex *sync.Mutex
 	cond  *sync.Cond
 


### PR DESCRIPTION
Example tests are renamed to fit required naming conventions. This
caused them to be relocated in generated docs.

Also, a minor problem with writer.newBatchQueue is fixed, in order to
avoid an unnecessary copy of a newly created object holding a mutex.
