### PR TITLE
fix panic cause by waitgroup reuse

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -358,17 +358,17 @@ func (g *Generation) Start(fn func(ctx context.Context)) {
 	case <-g.done:
 		return
 	default:
-		g.wg.Add(1)
-		go func() {
-			fn(genCtx{g})
-			// shut down the generation as soon as one function exits.  this is
-			// different from close() in that it doesn't wait on the wg.
-			g.once.Do(func() {
-				close(g.done)
-			})
-			g.wg.Done()
-		}()
 	}
+	g.wg.Add(1)
+	go func() {
+		fn(genCtx{g})
+		// shut down the generation as soon as one function exits.  this is
+		// different from close() in that it doesn't wait on the wg.
+		g.once.Do(func() {
+			close(g.done)
+		})
+		g.wg.Done()
+	}()
 }
 
 // CommitOffsets commits the provided topic+partition+offset combos to the


### PR DESCRIPTION
## issue desctiption

panic: sync: WaitGroup is reused before previous Wait has returned

## issue cause analysis

when genegration object created, it will only be done called by 

`gen.close()` in one goroutine

and `gen.close()` will only be called when capturing gen.done or cg.done signal 

see: https://github.com/segmentio/kafka-go/blob/main/consumergroup.go#L804-L821

`select {
	case <-cg.done:
		gen.close()
		return memberID, ErrGroupClosed // ErrGroupClosed will trigger leave logic.
	case cg.next <- &gen:
	}

	// wait for generation to complete.  if the CG is closed before the
	// generation is finished, exit and leave the group.
	select {
	case <-cg.done:
		gen.close()
		return memberID, ErrGroupClosed // ErrGroupClosed will trigger leave logic.
	case <-gen.done:
		// time for next generation!  make sure all the current go routines exit
		// before continuing onward.
		gen.close()
		return memberID, nil
	}`

Since gen.close() will run `g.wg.Wait()`, but there is another goroutine would call `gen.Start()`, which will exec `g.wg.Add(1)`
https://github.com/segmentio/kafka-go/blob/main/reader.go#L330-L333

which leads to panic 

![image](https://user-images.githubusercontent.com/8279787/141649334-b7901ccd-7c5c-4209-900b-14e4ba5bdcfc.png)

## solution:
1. add mutex for wg.Add() and wg.Wait() since `generation.Start` may run concurrently with `generation.close`
2. `Start()` function should watch gen.Done before exec `gen.wg.Add(1)`
