### PR TITLE
writer: allow user customized partition.

### DIFF
--- a/message.go
+++ b/message.go
@@ -12,8 +12,10 @@ type Message struct {
 	// not already specified on the writer itself.
 	Topic string
 
-	// Partition is read-only and MUST NOT be set when writing messages
+	// When CustomPartition is true, Partition will be used.
+	CustomPartition bool
 	Partition     int
+
 	Offset        int64
 	HighWaterMark int64
 	Key           []byte

--- a/writer.go
+++ b/writer.go
@@ -600,15 +600,14 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 			return err
 		}
 
-		numPartitions, err := w.partitions(ctx, topic)
-		if err != nil {
-			return err
-		}
-
 		var partition int
 		if msg.CustomPartition {
 			partition = msg.Partition
 		} else {
+			numPartitions, err := w.partitions(ctx, topic)
+			if err != nil {
+				return err
+			}
 			partition = balancer.Balance(msg, loadCachedPartitions(numPartitions)...)
 		}
 

--- a/writer.go
+++ b/writer.go
@@ -605,7 +605,12 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 			return err
 		}
 
-		partition := balancer.Balance(msg, loadCachedPartitions(numPartitions)...)
+		var partition int
+		if msg.CustomPartition {
+			partition = msg.Partition
+		} else {
+			partition = balancer.Balance(msg, loadCachedPartitions(numPartitions)...)
+		}
 
 		key := topicPartition{
 			topic:     topic,


### PR DESCRIPTION
Sometimes, the user may want to customize the logic of how to dispatch the message to the partition. For example, our app's logic would decide the partition by fields, https://github.com/pingcap/ticdc/blob/master/cdc/sink/dispatcher/table.go#L33.

This is very useful for such scenario.