### PR TITLE
Allow the resolver to override the port setting

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -480,11 +480,13 @@ func lookupHost(ctx context.Context, address string, resolver Resolver) (string,
 			// we'll always prefer the resolved host
 			host = resolvedHost
 
-			// in the case of port though, the provided address takes priority, and we
-			// only use the resolved address to set the port when not specified
-			if port == "" {
+			// resolved port only takes priority if explicitly provided
+			// Purpose: access the kafka-cluster behind a firewall via portforwarding on a jump host
+			// this should never be set at a regula host lookup
+			if resolvedPort != "" {
 				port = resolvedPort
 			}
+
 		}
 	}
 


### PR DESCRIPTION
The custom resolver couldn't override the default port even if id had been explicitly provided.
The reason for that is unclear as it contradicts the open closed principle.
Why: Common address resolvers should alway only return the host. If a port is being provided this has been intended.

Purpose of this Patch:
Access a kafka cluster behind a firewall via portforwarding on a jump host.
jumphost: 9095 -> kafkahost1:9092, jumphost: 9096 -> kafkahost2:9092, ...