### PR TITLE
Fix metadata requests leak

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -317,7 +317,7 @@ func (p *connPool) ref() {
 }
 
 func (p *connPool) unref() {
-	if atomic.AddUintptr(&p.refc, ^uintptr(0)) == 0 {
+	if atomic.AddUintptr(&p.refc, ^uintptr(0)) != 0 {
 		p.mutex.Lock()
 		defer p.mutex.Unlock()
 


### PR DESCRIPTION
As far as I can tell, `p.refc` keeps track of the amount of times `ref()` was invoked. `ref()` is invoked 2 times before `conPool` `p` is created, hence the starting value is 2. After this, every invocation of `ref()` increments `p.refc`. 

Every time `unref()` is invoked, `p.refc` is decremented. My guess is that we never want to invoke `unref()` more times than `ref` was invoked. Hence `unref()` should take effect exactly when `p.refc != 0`

Fixes #803 