### PR TITLE
Fix batch offset when a batch has 0 messages

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -245,11 +245,11 @@ func (batch *Batch) readMessage(
 			// consumed or a batch whose connection is in an error state.
 			batch.err = dontExpectEOF(err)
 		case batch.msgs.remaining() == 0:
-			// Log compaction can create batches with 0 messages.
+			// Log compaction can create batches with 0 unread messages.
 			//
 			// If the "next offset" reaches the "originally requested offset"
-			// and we have 0 messages remaining, then there were 0 messages in
-			// the batch.
+			// and we have 0 messages remaining, then there were 0 unread
+			// messages in the batch.
 			//
 			// We normally set the batch offset to the "next" batch offset upon
 			// reading a message but since there were no messages to read we

--- a/message_test.go
+++ b/message_test.go
@@ -541,7 +541,7 @@ func TestMessageSetReaderEmpty(t *testing.T) {
 		return 0, nil
 	}
 
-	offset, timestamp, headers, err := m.readMessage(0, noop, noop)
+	offset, _, timestamp, headers, err := m.readMessage(0, noop, noop)
 	if offset != 0 {
 		t.Errorf("expected offset of 0, get %d", offset)
 	}
@@ -737,12 +737,12 @@ func (r *readerHelper) readMessageErr() (msg Message, err error) {
 	}
 	var timestamp int64
 	var headers []Header
-	r.offset, timestamp, headers, err = r.messageSetReader.readMessage(r.offset, keyFunc, valueFunc)
+	r.offset, _, timestamp, headers, err = r.messageSetReader.readMessage(r.offset, keyFunc, valueFunc)
 	if err != nil {
 		return
 	}
 	msg.Offset = r.offset
-	msg.Time = time.Unix(timestamp / 1000, (timestamp % 1000) * 1000000)
+	msg.Time = time.Unix(timestamp/1000, (timestamp%1000)*1000000)
 	msg.Headers = headers
 	return
 }

--- a/reader.go
+++ b/reader.go
@@ -1494,7 +1494,7 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 			// if there is no new messages at the end of correct batch -
 			// then we need to increment next batch offset manually.
 			if err == io.EOF && msgCount == 0 {
-				//batch.offset++
+				batch.offset++
 			}
 			batch.Close()
 			break

--- a/reader.go
+++ b/reader.go
@@ -1492,7 +1492,7 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 
 		if msg, err = batch.ReadMessage(); err != nil {
 			// if there is no new messages at the end of correct batch -
-			// then we need to advance next batch offset manually.
+			// then we need to increment next batch offset manually.
 			if err == io.EOF && msgCount == 0 {
 				batch.offset++
 			}

--- a/reader.go
+++ b/reader.go
@@ -1491,6 +1491,8 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 		}
 
 		if msg, err = batch.ReadMessage(); err != nil {
+			// if there is no new messages at the and of correct batch -
+			// then we need to advance next batch offset manually.
 			if err == io.EOF && msgCount == 0 {
 				batch.offset++
 			}

--- a/reader.go
+++ b/reader.go
@@ -1483,7 +1483,6 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 	deadline := time.Now().Add(safetyTimeout)
 	conn.SetReadDeadline(deadline)
 
-	msgCount := 0
 	for {
 		if now := time.Now(); deadline.Sub(now) < (safetyTimeout / 2) {
 			deadline = now.Add(safetyTimeout)
@@ -1491,15 +1490,9 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 		}
 
 		if msg, err = batch.ReadMessage(); err != nil {
-			// if there is no new messages at the end of correct batch -
-			// then we need to increment next batch offset manually.
-			if err == io.EOF && msgCount == 0 {
-				batch.offset++
-			}
 			batch.Close()
 			break
 		}
-		msgCount++
 
 		n := int64(len(msg.Key) + len(msg.Value))
 		r.stats.messages.observe(1)

--- a/reader.go
+++ b/reader.go
@@ -1494,7 +1494,7 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 			// if there is no new messages at the end of correct batch -
 			// then we need to increment next batch offset manually.
 			if err == io.EOF && msgCount == 0 {
-				batch.offset++
+				//batch.offset++
 			}
 			batch.Close()
 			break

--- a/reader.go
+++ b/reader.go
@@ -1491,7 +1491,7 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 		}
 
 		if msg, err = batch.ReadMessage(); err != nil {
-			// if there is no new messages at the and of correct batch -
+			// if there is no new messages at the end of correct batch -
 			// then we need to advance next batch offset manually.
 			if err == io.EOF && msgCount == 0 {
 				batch.offset++

--- a/reader_test.go
+++ b/reader_test.go
@@ -1736,7 +1736,7 @@ func TestReaderReadCompactedMessage(t *testing.T) {
 
 	msgs := makeTestDuplicateSequence()
 
-	writeMessagesForCompationCheck(t, topic, msgs)
+	writeMessagesForCompactionCheck(t, topic, msgs)
 
 	// need some time for compaction to start with guarantee
 	// practice shows that 10-20s is not enough
@@ -1754,7 +1754,8 @@ func TestReaderReadCompactedMessage(t *testing.T) {
 	}
 }
 
-func writeMessagesForCompationCheck(t *testing.T, topic string, msgs []Message) {
+// writeMessagesForCompactionCheck writes messages with specific writer configuration
+func writeMessagesForCompactionCheck(t *testing.T, topic string, msgs []Message) {
 	t.Helper()
 
 	wr := NewWriter(WriterConfig{
@@ -1766,7 +1767,6 @@ func writeMessagesForCompationCheck(t *testing.T, topic string, msgs []Message) 
 	})
 	err := wr.WriteMessages(context.Background(), msgs...)
 	if err != nil {
-		t.Error(err)
 		t.Fatal(err)
 	}
 
@@ -1774,15 +1774,11 @@ func writeMessagesForCompationCheck(t *testing.T, topic string, msgs []Message) 
 
 // makeTestDuplicateSequence creates messages for compacted log testing
 func makeTestDuplicateSequence() []Message {
-	//base := time.Now()
 	var msgs []Message
-
 	for i := 0; i < 10; i++ {
 		msgs = append(msgs, dups(strconv.Itoa(i+1), strconv.Itoa(i), 1, 2)...)
-
 		msgs = append(msgs, Message{
-			Key: []byte("key-mid"),
-			//Time:  base.Add(time.Duration(i) * time.Millisecond).Truncate(time.Millisecond),
+			Key:   []byte("key-mid"),
 			Value: []byte("key-mid"),
 		})
 	}
@@ -1799,19 +1795,16 @@ func countKeys(msgs []Message) int {
 }
 
 func dups(first, second string, firstCount, secondCount int) []Message {
-	//base := time.Now()
 	res := make([]Message, firstCount+secondCount)
 	for i := 0; i < firstCount; i++ {
 		res[i] = Message{
-			Key: []byte(first),
-			//Time:  base.Add(time.Duration(i) * time.Millisecond).Truncate(time.Millisecond),
+			Key:   []byte(first),
 			Value: []byte(first + "_" + strconv.Itoa(i)),
 		}
 	}
 	for i := 0; i < secondCount; i++ {
 		res[firstCount+i] = Message{
-			Key: []byte(second),
-			//Time:  base.Add(time.Duration(i) * time.Millisecond).Truncate(time.Millisecond),
+			Key:   []byte(second),
 			Value: []byte(second + "_" + strconv.Itoa(i)),
 		}
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1805,12 +1805,6 @@ func TestReaderTruncatedResponse(t *testing.T) {
 // guarantee that at least 1 batch can be compacted down to 0 "unread" messages
 // with at least 1 "old" message otherwise the batch is skipped entirely.
 func TestReaderReadCompactedMessage(t *testing.T) {
-	if os.Getenv("KAFKA_VERSION") == "2.0.1" {
-		// There is something odd with this kafka version that causes some
-		// duplicate messages to not be compacted away.
-		t.Skip("Skipping test because kafka version is 2.0.1")
-	}
-
 	topic := makeTopic()
 	createTopicWithCompaction(t, topic, 1)
 	defer deleteTopic(t, topic)
@@ -1824,7 +1818,8 @@ func TestReaderReadCompactedMessage(t *testing.T) {
 		expectedKeys[string(msg.Key)] = 1
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	// kafka 2.0.1 is extra slow
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
 	defer cancel()
 	for {
 		success := func() bool {

--- a/reader_test.go
+++ b/reader_test.go
@@ -1857,14 +1857,6 @@ func createTopicWithCompaction(t *testing.T, topic string, partitions int) {
 				ConfigValue: "10",
 			},
 			{
-				ConfigName:  "max.compaction.lag.ms",
-				ConfigValue: "10",
-			},
-			//{
-			//	ConfigName:  "max.message.bytes",
-			//	ConfigValue: "130",
-			//},
-			{
 				ConfigName:  "segment.bytes",
 				ConfigValue: "220",
 			},

--- a/reader_test.go
+++ b/reader_test.go
@@ -1854,13 +1854,10 @@ func createTopicWithCompaction(t *testing.T, topic string, partitions int) {
 					ConfigValue: "compact",
 				}, {
 					ConfigName:  "delete.retention.ms",
-					ConfigValue: "0",
+					ConfigValue: "10",
 				}, {
 					ConfigName:  "max.compaction.lag.ms",
-					ConfigValue: "1",
-				}, {
-					ConfigName:  "retention.bytes",
-					ConfigValue: "-1",
+					ConfigValue: "10",
 				}, {
 					ConfigName:  "max.message.bytes",
 					ConfigValue: "130",

--- a/reader_test.go
+++ b/reader_test.go
@@ -1781,8 +1781,10 @@ func writeMessagesForCompactionCheck(t *testing.T, topic string, msgs []Message)
 	t.Helper()
 
 	wr := NewWriter(WriterConfig{
-		Brokers:   []string{"localhost:9092"},
-		BatchSize: 2,
+		Brokers: []string{"localhost:9092"},
+		// Batch size must be large enough to have multiple compacted records
+		// for testing more edge cases.
+		BatchSize: 3,
 		Async:     false,
 		Topic:     topic,
 		Balancer:  &LeastBytes{},

--- a/reader_test.go
+++ b/reader_test.go
@@ -1843,31 +1843,32 @@ func createTopicWithCompaction(t *testing.T, topic string, partitions int) {
 
 	conn.SetDeadline(time.Now().Add(10 * time.Second))
 
-	_, err = conn.createTopics(createTopicsRequestV0{
-		Topics: []createTopicsRequestV0Topic{
+	err = conn.CreateTopics(TopicConfig{
+		Topic:             topic,
+		NumPartitions:     partitions,
+		ReplicationFactor: 1,
+		ConfigEntries: []ConfigEntry{
 			{
-				Topic:             topic,
-				NumPartitions:     int32(partitions),
-				ReplicationFactor: 1,
-				//ConfigEntries: []createTopicsRequestV0ConfigEntry{{
-				//	ConfigName:  "cleanup.policy",
-				//	ConfigValue: "compact",
-				//}, {
-				//	ConfigName:  "delete.retention.ms",
-				//	ConfigValue: "10",
-				//}, {
-				//	ConfigName:  "max.compaction.lag.ms",
-				//	ConfigValue: "10",
-				//}, {
-				//	ConfigName:  "max.message.bytes",
-				//	ConfigValue: "130",
-				//}, {
-				//	ConfigName:  "segment.bytes",
-				//	ConfigValue: "220",
-				//}},
+				ConfigName:  "cleanup.policy",
+				ConfigValue: "compact",
+			},
+			{
+				ConfigName:  "delete.retention.ms",
+				ConfigValue: "10",
+			},
+			{
+				ConfigName:  "max.compaction.lag.ms",
+				ConfigValue: "10",
+			},
+			{
+				ConfigName:  "max.message.bytes",
+				ConfigValue: "130",
+			},
+			{
+				ConfigName:  "segment.bytes",
+				ConfigValue: "220",
 			},
 		},
-		Timeout: milliseconds(time.Second),
 	})
 	switch err {
 	case nil:

--- a/reader_test.go
+++ b/reader_test.go
@@ -1724,7 +1724,8 @@ func TestErrorCannotConnectGroupSubscription(t *testing.T) {
 //
 // This test forces varying sized chunks of duplicated messages along with
 // configuring the topic with a minimal `segment.bytes` in order to
-// guarantee that at least 1 batch can be compacted down to 0 messages.
+// guarantee that at least 1 batch can be compacted down to 0 "unread" messages
+// with at least 1 "old" message otherwise the batch is skipped entirely.
 func TestReaderReadCompactedMessage(t *testing.T) {
 	topic := makeTopic()
 	createTopicWithCompaction(t, topic, 1)

--- a/reader_test.go
+++ b/reader_test.go
@@ -1805,6 +1805,12 @@ func TestReaderTruncatedResponse(t *testing.T) {
 // guarantee that at least 1 batch can be compacted down to 0 "unread" messages
 // with at least 1 "old" message otherwise the batch is skipped entirely.
 func TestReaderReadCompactedMessage(t *testing.T) {
+	if os.Getenv("KAFKA_VERSION") == "2.0.1" {
+		// There is something odd with this kafka version that causes some
+		// duplicate messages to not be compacted away.
+		t.Skip("Skipping test because kafka version is 2.0.1")
+	}
+
 	topic := makeTopic()
 	createTopicWithCompaction(t, topic, 1)
 	defer deleteTopic(t, topic)

--- a/reader_test.go
+++ b/reader_test.go
@@ -1849,22 +1849,22 @@ func createTopicWithCompaction(t *testing.T, topic string, partitions int) {
 				Topic:             topic,
 				NumPartitions:     int32(partitions),
 				ReplicationFactor: 1,
-				ConfigEntries: []createTopicsRequestV0ConfigEntry{{
-					ConfigName:  "cleanup.policy",
-					ConfigValue: "compact",
-				}, {
-					ConfigName:  "delete.retention.ms",
-					ConfigValue: "10",
-				}, {
-					ConfigName:  "max.compaction.lag.ms",
-					ConfigValue: "10",
-				}, {
-					ConfigName:  "max.message.bytes",
-					ConfigValue: "130",
-				}, {
-					ConfigName:  "segment.bytes",
-					ConfigValue: "220",
-				}},
+				//ConfigEntries: []createTopicsRequestV0ConfigEntry{{
+				//	ConfigName:  "cleanup.policy",
+				//	ConfigValue: "compact",
+				//}, {
+				//	ConfigName:  "delete.retention.ms",
+				//	ConfigValue: "10",
+				//}, {
+				//	ConfigName:  "max.compaction.lag.ms",
+				//	ConfigValue: "10",
+				//}, {
+				//	ConfigName:  "max.message.bytes",
+				//	ConfigValue: "130",
+				//}, {
+				//	ConfigName:  "segment.bytes",
+				//	ConfigValue: "220",
+				//}},
 			},
 		},
 		Timeout: milliseconds(time.Second),

--- a/reader_test.go
+++ b/reader_test.go
@@ -1860,10 +1860,10 @@ func createTopicWithCompaction(t *testing.T, topic string, partitions int) {
 				ConfigName:  "max.compaction.lag.ms",
 				ConfigValue: "10",
 			},
-			{
-				ConfigName:  "max.message.bytes",
-				ConfigValue: "130",
-			},
+			//{
+			//	ConfigName:  "max.message.bytes",
+			//	ConfigValue: "130",
+			//},
 			{
 				ConfigName:  "segment.bytes",
 				ConfigValue: "220",
@@ -1876,7 +1876,7 @@ func createTopicWithCompaction(t *testing.T, topic string, partitions int) {
 	case TopicAlreadyExists:
 		// ok
 	default:
-		err = fmt.Errorf("creaetTopic, conn.createtTopics: %w", err)
+		err = fmt.Errorf("createTopic, conn.createtTopics: %w", err)
 		t.Error(err)
 		t.FailNow()
 	}


### PR DESCRIPTION
Based off of https://github.com/segmentio/kafka-go/pull/807 and also related to https://github.com/segmentio/kafka-go/pull/709

```
Move the fix inside `Batch.readMessage`

The reasoning is that `Batch.readMessage` is normally where we update
the batch offset so the goal is to do this additional update to the
batch offset in the same location.

Also adjusts the test case retry so that the test case may finish
earlier than the previous sleep time while also giving the test more
time to finish to reduce flakiness.

The test case also now ensures that the final state is fully compacted
before declaring success.
```

The solution has been updated to jump to the last offset as indicated by the response header. In addition a test is added to ensure that the new way of moving offsets still works when the message is truncated.