### PR TITLE
fix: omit {Cluster,Topic}AuthorizedOperations

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -585,10 +585,7 @@ func (p *connPool) discover(ctx context.Context, wake <-chan event) {
 			p.update(ctx, nil, err)
 		} else {
 			res := make(async, 1)
-			req := &meta.Request{
-				IncludeClusterAuthorizedOperations: true,
-				IncludeTopicAuthorizedOperations:   true,
-			}
+			req := &meta.Request{}
 			deadline, cancel := context.WithTimeout(ctx, p.metadataTTL)
 			c.reqs <- connRequest{
 				ctx: deadline,


### PR DESCRIPTION
kafka-go doesn't appear to actually make use of either the
ClusterAuthorizedOperations nor the per-topic TopicAuthorizedOperations
responses anywhere in its code, so this is causing unecessary load on
the brokers as this is a non-trivial thing for them to determine each
time.

Contributes-to: #818