### PR TITLE
don't attempt to read messages when offset is greater than hwm

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -857,7 +857,11 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var msgs *messageSetReader
 	if err == nil {
-		msgs, err = newMessageSetReader(&c.rbuf, remain)
+		if highWaterMark < offset {
+			msgs = &messageSetReader{empty: true}
+		} else {
+			msgs, err = newMessageSetReader(&c.rbuf, remain)
+		}
 	}
 	if err == errShortRead {
 		err = checkTimeoutErr(adjustedDeadline)

--- a/conn.go
+++ b/conn.go
@@ -857,7 +857,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var msgs *messageSetReader
 	if err == nil {
-		if highWaterMark < offset {
+		if offset == highWaterMark {
 			msgs = &messageSetReader{empty: true}
 		} else {
 			msgs, err = newMessageSetReader(&c.rbuf, remain)

--- a/conn_test.go
+++ b/conn_test.go
@@ -342,7 +342,13 @@ func TestConn(t *testing.T) {
 			if t1Writer, err = dialer.DialLeader(ctx, tcp, kafka, topic1, 0); err != nil {
 				return
 			}
+			if err = t1Writer.SetRequiredAcks(int(RequireAll)); err != nil {
+				return
+			}
 			if t2Writer, err = dialer.DialLeader(ctx, tcp, kafka, topic2, 0); err != nil {
+				return
+			}
+			if err = t2Writer.SetRequiredAcks(int(RequireAll)); err != nil {
 				return
 			}
 


### PR DESCRIPTION
Based on
> The high watermark offset is the offset of the last message that was
successfully copied to all of the log’s replicas.

the high watermark is the last message that was copied to all of the
logs replicas and consumers should not read past that message.

Previously we stopped reading messages when offset == highWaterMark
which led to messages being skipped when the offset was equal to the
highWaterMark.