### PR TITLE
fix: don't assume the header count will be positive

### DIFF
--- a/message_reader.go
+++ b/message_reader.go
@@ -318,10 +318,12 @@ func (r *messageSetReader) readMessageV2(_ int64, key readBytesFunc, val readByt
 	if err = r.readVarInt(&headerCount); err != nil {
 		return
 	}
-	headers = make([]Header, headerCount)
-	for i := 0; i < int(headerCount); i++ {
-		if err = r.readMessageHeader(&headers[i]); err != nil {
-			return
+	if headerCount > 0 {
+		headers = make([]Header, headerCount)
+		for i := range headers {
+			if err = r.readMessageHeader(&headers[i]); err != nil {
+				return
+			}
 		}
 	}
 	lastOffset = r.header.firstOffset + int64(r.header.v2.lastOffsetDelta)


### PR DESCRIPTION
It seems the change in https://github.com/segmentio/kafka-go/pull/551 either did not make it to the main branch, or was reverted at some point.

It was reported in https://github.com/segmentio/kafka-go/issues/874.

I don't know under which conditions Kafka would return a negative header count but apparently kafka does this sometimes 🤷 