### PR TITLE
Add ProbeCoordinator

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -313,6 +313,11 @@ func (c *Conn) DeleteTopics(topics ...string) error {
 	return err
 }
 
+func (c *Conn) ProbeCoordinator() error {
+	_, err := c.findCoordinator(findCoordinatorRequestV0{})
+	return err
+}
+
 // findCoordinator finds the coordinator for the specified group or transaction
 //
 // See http://kafka.apache.org/protocol.html#The_Messages_FindCoordinator


### PR DESCRIPTION
We're experiencing timing issues in our acceptance test setup because it takes a while for the kafka consumer group coordinator to become available and we'd like to be able to probe it instead of adding sleeps to our code.

This PR is just a suggestion, you probably don't want to define this method on the Conn, but it would be really nice if it was somehow possible to wait for the group coordinator to become available.

WDYT?