### PR TITLE
Close idle connections

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -205,9 +205,6 @@ type Writer struct {
 	// are safe to use concurrently from multiple goroutines, there is no need
 	// for extra synchronization to access this field.
 	roundRobin RoundRobin
-
-	// non-nil when a transport was created by NewWriter, remove in 1.0.
-	transport *Transport
 }
 
 // WriterConfig is a configuration type used to create new instances of Writer.
@@ -489,7 +486,6 @@ func NewWriter(config WriterConfig) *Writer {
 		Logger:       config.Logger,
 		ErrorLogger:  config.ErrorLogger,
 		Transport:    transport,
-		transport:    transport,
 		writerStats:  stats,
 	}
 
@@ -560,8 +556,8 @@ func (w *Writer) Close() error {
 	w.mutex.Unlock()
 	w.group.Wait()
 
-	if w.transport != nil {
-		w.transport.CloseIdleConnections()
+	if t, ok := w.Transport.(interface{ CloseIdleConnections() }); ok {
+		t.CloseIdleConnections()
 	}
 
 	return nil


### PR DESCRIPTION
I stumbled upon the fact that goroutines are left running after `Writer` is closed. I also found issue #599, specifically this comment https://github.com/segmentio/kafka-go/issues/599#issuecomment-967287388 where it was explained as "expected behavior". I am not convinced that it is actually expected and prepared a PR that "fixes" the behavior, I am curious to hear what you think.

Fixes https://github.com/segmentio/kafka-go/issues/599.