### PR TITLE
enable errorlint linter and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
     - bodyclose
+    - errorlint
     - goconst
     - godot
     - gofmt
@@ -10,5 +11,4 @@ linters:
   disable:
     # Temporarily disabling so it can be addressed in a dedicated PR.
     - errcheck
-    - errorlint
     - goerr113

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"net"
@@ -262,7 +263,7 @@ func TestClientProduceAndConsume(t *testing.T) {
 		for {
 			r, err := res.Records.ReadRecord()
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					t.Fatal(err)
 				}
 				break

--- a/compress/snappy/go-xerial-snappy/snappy_test.go
+++ b/compress/snappy/go-xerial-snappy/snappy_test.go
@@ -2,6 +2,7 @@ package snappy
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -92,7 +93,7 @@ func TestSnappyDecodeMalformedTruncatedHeader(t *testing.T) {
 	for i := 0; i < len(xerialHeader); i++ {
 		buf := make([]byte, i)
 		copy(buf, xerialHeader[:i])
-		if _, err := Decode(buf); err != ErrMalformed {
+		if _, err := Decode(buf); !errors.Is(err, ErrMalformed) {
 			t.Errorf("expected ErrMalformed got %v", err)
 		}
 	}
@@ -104,7 +105,7 @@ func TestSnappyDecodeMalformedTruncatedSize(t *testing.T) {
 	for _, size := range sizes {
 		buf := make([]byte, size)
 		copy(buf, xerialHeader)
-		if _, err := Decode(buf); err != ErrMalformed {
+		if _, err := Decode(buf); !errors.Is(err, ErrMalformed) {
 			t.Errorf("expected ErrMalformed got %v", err)
 		}
 	}
@@ -116,7 +117,7 @@ func TestSnappyDecodeMalformedBNoData(t *testing.T) {
 	copy(buf, xerialHeader)
 	// indicate that there's one byte of data to be read
 	buf[len(buf)-1] = 1
-	if _, err := Decode(buf); err != ErrMalformed {
+	if _, err := Decode(buf); !errors.Is(err, ErrMalformed) {
 		t.Errorf("expected ErrMalformed got %v", err)
 	}
 }
@@ -128,7 +129,7 @@ func TestSnappyMasterDecodeFailed(t *testing.T) {
 	buf[len(buf)-2] = 1
 	// A payload which will not decode
 	buf[len(buf)-1] = 1
-	if _, err := Decode(buf); err == ErrMalformed || err == nil {
+	if _, err := Decode(buf); errors.Is(err, ErrMalformed) || err == nil {
 		t.Errorf("unexpected err: %v", err)
 	}
 }

--- a/createtopics.go
+++ b/createtopics.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -384,12 +385,14 @@ func (c *Conn) CreateTopics(topics ...TopicConfig) error {
 	_, err := c.createTopics(createTopicsRequestV0{
 		Topics: requestV0Topics,
 	})
+	if err != nil {
+		if errors.Is(err, TopicAlreadyExists) {
+			// ok
+			return nil
+		}
 
-	switch err {
-	case TopicAlreadyExists:
-		// ok
-		return nil
-	default:
 		return err
 	}
+
+	return nil
 }

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -294,7 +295,7 @@ func TestDialerConnectTLSHonorsContext(t *testing.T) {
 	defer cancel()
 
 	_, err := d.connectTLS(ctx, conn, d.TLS)
-	if context.DeadlineExceeded != err {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected err to be %v; got %v", context.DeadlineExceeded, err)
 		t.FailNow()
 	}

--- a/discard_test.go
+++ b/discard_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"testing"
 )
@@ -52,7 +53,7 @@ func TestDiscardN(t *testing.T) {
 			scenario: "discard more than available",
 			function: func(t *testing.T, r *bufio.Reader, sz int) {
 				remain, err := discardN(r, sz, sz+1)
-				if err != errShortRead {
+				if !errors.Is(err, errShortRead) {
 					t.Errorf("Expected errShortRead, got %v", err)
 				}
 				if remain != 0 {
@@ -64,7 +65,7 @@ func TestDiscardN(t *testing.T) {
 			scenario: "discard returns error",
 			function: func(t *testing.T, r *bufio.Reader, sz int) {
 				remain, err := discardN(r, sz+2, sz+1)
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					t.Errorf("Expected EOF, got %v", err)
 				}
 				if remain != 2 {
@@ -76,7 +77,7 @@ func TestDiscardN(t *testing.T) {
 			scenario: "errShortRead doesn't mask error",
 			function: func(t *testing.T, r *bufio.Reader, sz int) {
 				remain, err := discardN(r, sz+1, sz+2)
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					t.Errorf("Expected EOF, got %v", err)
 				}
 				if remain != 1 {

--- a/message_test.go
+++ b/message_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -551,7 +552,7 @@ func TestMessageSetReaderEmpty(t *testing.T) {
 	if headers != nil {
 		t.Errorf("expected nil headers, got %v", headers)
 	}
-	if err != RequestTimedOut {
+	if !errors.Is(err, RequestTimedOut) {
 		t.Errorf("expected RequestTimedOut, got %v", err)
 	}
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -365,14 +366,15 @@ func parseVersion(s string) (int16, error) {
 }
 
 func dontExpectEOF(err error) error {
-	switch err {
-	case nil:
-		return nil
-	case io.EOF:
-		return io.ErrUnexpectedEOF
-	default:
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return io.ErrUnexpectedEOF
+		}
+
 		return err
 	}
+
+	return nil
 }
 
 type Broker struct {

--- a/protocol/prototest/prototest.go
+++ b/protocol/prototest/prototest.go
@@ -2,6 +2,7 @@ package prototest
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"reflect"
 	"time"
@@ -152,7 +153,7 @@ func deepEqualRecords(r1, r2 protocol.RecordReader) bool {
 		rec2, err2 := r2.ReadRecord()
 
 		if err1 != nil || err2 != nil {
-			return err1 == err2
+			return errors.Is(err1, err2)
 		}
 
 		if !deepEqualRecord(rec1, rec2) {

--- a/protocol/record_batch_test.go
+++ b/protocol/record_batch_test.go
@@ -146,7 +146,7 @@ func assertRecords(t *testing.T, r1, r2 RecordReader) {
 		rec2, err2 := r2.ReadRecord()
 
 		if err1 != nil || err2 != nil {
-			if err1 != err2 {
+			if !errors.Is(err1, err2) {
 				t.Error("errors mismatch:")
 				t.Log("expected:", err2)
 				t.Log("found:   ", err1)

--- a/read_test.go
+++ b/read_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"math"
 	"reflect"
@@ -49,7 +50,7 @@ func TestReadVarIntFailing(t *testing.T) {
 	testCase := []byte{135, 135}
 	rd := bufio.NewReader(bytes.NewReader(testCase))
 	_, err := readVarInt(rd, len(testCase), &v)
-	if err != errShortRead {
+	if !errors.Is(err, errShortRead) {
 		t.Errorf("Expected error while parsing var int: %v", err)
 	}
 }
@@ -160,7 +161,7 @@ func TestReadNewBytes(t *testing.T) {
 		if remain != 0 {
 			t.Error("all bytes should have been consumed")
 		}
-		if err != errShortRead {
+		if !errors.Is(err, errShortRead) {
 			t.Error("should have returned errShortRead")
 		}
 		b, err = r.Peek(0)

--- a/reader.go
+++ b/reader.go
@@ -306,7 +306,7 @@ func (r *Reader) run(cg *ConsumerGroup) {
 			if err == nil {
 				break
 			}
-			if err == r.stctx.Err() {
+			if errors.Is(err, r.stctx.Err()) {
 				return
 			}
 			r.stats.errors.observe(1)
@@ -832,9 +832,7 @@ func (r *Reader) FetchMessage(ctx context.Context) (Message, error) {
 
 				r.mutex.Unlock()
 
-				switch m.error {
-				case nil:
-				case io.EOF:
+				if errors.Is(m.error, io.EOF) {
 					// io.EOF is used as a marker to indicate that the stream
 					// has been closed, in case it was received from the inner
 					// reader we don't want to confuse the program and replace
@@ -1249,17 +1247,17 @@ func (r *reader) run(ctx context.Context, offset int64) {
 		})
 
 		conn, start, err := r.initialize(ctx, offset)
-		switch err {
-		case nil:
-		case OffsetOutOfRange:
-			// This would happen if the requested offset is passed the last
-			// offset on the partition leader. In that case we're just going
-			// to retry later hoping that enough data has been produced.
-			r.withErrorLogger(func(log Logger) {
-				log.Printf("error initializing the kafka reader for partition %d of %s: %s", r.partition, r.topic, OffsetOutOfRange)
-			})
-			continue
-		default:
+		if err != nil {
+			if errors.Is(err, OffsetOutOfRange) {
+				// This would happen if the requested offset is passed the last
+				// offset on the partition leader. In that case we're just going
+				// to retry later hoping that enough data has been produced.
+				r.withErrorLogger(func(log Logger) {
+					log.Printf("error initializing the kafka reader for partition %d of %s: %s", r.partition, r.topic, err)
+				})
+				continue
+			}
+
 			// Perform a configured number of attempts before
 			// reporting first errors, this helps mitigate
 			// situations where the kafka server is temporarily
@@ -1292,18 +1290,18 @@ func (r *reader) run(ctx context.Context, offset int64) {
 				return
 			}
 
-			switch offset, err = r.read(ctx, offset, conn); err {
-			case nil:
+			offset, err = r.read(ctx, offset, conn)
+			if err == nil {
 				errcount = 0
 				continue
-			case io.EOF:
+			} else if errors.Is(err, io.EOF) {
 				// done with this batch of messages...carry on.  note that this
 				// block relies on the batch repackaging real io.EOF errors as
 				// io.UnexpectedEOF.  otherwise, we would end up swallowing real
 				// errors here.
 				errcount = 0
 				continue
-			case UnknownTopicOrPartition:
+			} else if errors.Is(err, UnknownTopicOrPartition) {
 				r.withErrorLogger(func(log Logger) {
 					log.Printf("failed to read from current broker for partition %d of %s at offset %d, topic or parition not found on this broker, %v", r.partition, r.topic, toHumanOffset(offset), r.brokers)
 				})
@@ -1314,7 +1312,7 @@ func (r *reader) run(ctx context.Context, offset int64) {
 				// topic/partition broker combo.
 				r.stats.rebalances.observe(1)
 				break readLoop
-			case NotLeaderForPartition:
+			} else if errors.Is(err, NotLeaderForPartition) {
 				r.withErrorLogger(func(log Logger) {
 					log.Printf("failed to read from current broker for partition %d of %s at offset %d, not the leader", r.partition, r.topic, toHumanOffset(offset))
 				})
@@ -1325,8 +1323,7 @@ func (r *reader) run(ctx context.Context, offset int64) {
 				// partition leader.
 				r.stats.rebalances.observe(1)
 				break readLoop
-
-			case RequestTimedOut:
+			} else if errors.Is(err, RequestTimedOut) {
 				// Timeout on the kafka side, this can be safely retried.
 				errcount = 0
 				r.withLogger(func(log Logger) {
@@ -1334,8 +1331,7 @@ func (r *reader) run(ctx context.Context, offset int64) {
 				})
 				r.stats.timeouts.observe(1)
 				continue
-
-			case OffsetOutOfRange:
+			} else if errors.Is(err, OffsetOutOfRange) {
 				first, last, err := r.readOffsets(conn)
 				if err != nil {
 					r.withErrorLogger(func(log Logger) {
@@ -1363,21 +1359,19 @@ func (r *reader) run(ctx context.Context, offset int64) {
 						log.Printf("the kafka reader is reading passed the last offset for partition %d of %s at offset %d", r.partition, r.topic, toHumanOffset(offset))
 					})
 				}
-
-			case context.Canceled:
+			} else if errors.Is(err, context.Canceled) {
 				// Another reader has taken over, we can safely quit.
 				conn.Close()
 				return
-
-			case errUnknownCodec:
+			} else if errors.Is(err, errUnknownCodec) {
 				// The compression codec is either unsupported or has not been
 				// imported.  This is a fatal error b/c the reader cannot
 				// proceed.
 				r.sendError(ctx, err)
 				break readLoop
-
-			default:
-				if _, ok := err.(Error); ok {
+			} else {
+				var kafkaError Error
+				if errors.As(err, &kafkaError) {
 					r.sendError(ctx, err)
 				} else {
 					r.withErrorLogger(func(log Logger) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -359,21 +359,21 @@ func testWriterMaxBytes(t *testing.T) {
 		t.Error("expected error")
 		return
 	} else if err != nil {
-		switch e := err.(type) {
-		case MessageTooLargeError:
-			if string(e.Message.Value) != string(firstMsg) {
-				t.Errorf("unxpected returned message. Expected: %s, Got %s", firstMsg, e.Message.Value)
+		var messageTooLargeError MessageTooLargeError
+		if errors.As(err, &messageTooLargeError) {
+			if string(messageTooLargeError.Message.Value) != string(firstMsg) {
+				t.Errorf("unxpected returned message. Expected: %s, Got %s", firstMsg, messageTooLargeError.Message.Value)
 				return
 			}
-			if len(e.Remaining) != 1 {
+			if len(messageTooLargeError.Remaining) != 1 {
 				t.Error("expected remaining errors; found none")
 				return
 			}
-			if string(e.Remaining[0].Value) != string(secondMsg) {
-				t.Errorf("unxpected returned message. Expected: %s, Got %s", secondMsg, e.Message.Value)
+			if string(messageTooLargeError.Remaining[0].Value) != string(secondMsg) {
+				t.Errorf("unxpected returned message. Expected: %s, Got %s", secondMsg, messageTooLargeError.Message.Value)
 				return
 			}
-		default:
+		} else {
 			t.Errorf("unexpected error: %s", err)
 			return
 		}

--- a/writer_test.go
+++ b/writer_test.go
@@ -359,21 +359,23 @@ func testWriterMaxBytes(t *testing.T) {
 		t.Error("expected error")
 		return
 	} else if err != nil {
-		var messageTooLargeError MessageTooLargeError
-		if errors.As(err, &messageTooLargeError) {
-			if string(messageTooLargeError.Message.Value) != string(firstMsg) {
-				t.Errorf("unxpected returned message. Expected: %s, Got %s", firstMsg, messageTooLargeError.Message.Value)
+		var e MessageTooLargeError
+		switch {
+		case errors.As(err, &e):
+			if string(e.Message.Value) != string(firstMsg) {
+				t.Errorf("unxpected returned message. Expected: %s, Got %s", firstMsg, e.Message.Value)
 				return
 			}
-			if len(messageTooLargeError.Remaining) != 1 {
+			if len(e.Remaining) != 1 {
 				t.Error("expected remaining errors; found none")
 				return
 			}
-			if string(messageTooLargeError.Remaining[0].Value) != string(secondMsg) {
-				t.Errorf("unxpected returned message. Expected: %s, Got %s", secondMsg, messageTooLargeError.Message.Value)
+			if string(e.Remaining[0].Value) != string(secondMsg) {
+				t.Errorf("unxpected returned message. Expected: %s, Got %s", secondMsg, e.Message.Value)
 				return
 			}
-		} else {
+
+		default:
 			t.Errorf("unexpected error: %s", err)
 			return
 		}


### PR DESCRIPTION
This PR enables the [errorlint](https://github.com/polyfloyd/go-errorlint) linter in golangci-lint. This specifically ensures that errors are properly checked, avoiding things like direct equality (`==`) checks and type coercion/switch, to ensure as much compatibility with improvements to errors in go 1.13+.

This is a continuation of #877, but will need to be followed up by one more PR to enable another linter to ensure we wrap errors coming from external packages.