### PR TITLE
fix(protocol): fix type assertion error

### DIFF
--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -65,6 +65,7 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 		}
 		brokerResp := m.(*Response)
 		respGroups := []ResponseGroup{}
+
 		for _, brokerResp := range brokerResp.Groups {
 			respGroups = append(
 				respGroups,

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -63,7 +63,7 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 		if err != nil {
 			return nil, err
 		}
-		brokerResp := result.(*Response)
+		brokerResp := m.(*Response)
 
 		respGroups := []ResponseGroup{}
 		for _, brokerResp := range brokerResp.Groups {

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -1,6 +1,8 @@
 package listgroups
 
 import (
+	"fmt"
+
 	"github.com/segmentio/kafka-go/protocol"
 )
 
@@ -57,8 +59,15 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	response := &Response{}
 
 	for r, result := range results {
-		brokerResp := result.(*Response)
-		respGroups := []ResponseGroup{}
+		brokerResp, ok := result.(*Response)
+		if !ok {
+			if err, ok := result.(error); ok {
+				return nil, fmt.Errorf("listgroups.(*Response).Merge: %w", err)
+			}
+			return nil, fmt.Errorf("listgroups.(*Response).Merge expect got %T", result)
+		}
+
+		respGroups := make([]ResponseGroup, 0, len(brokerResp.Groups))
 
 		for _, brokerResp := range brokerResp.Groups {
 			respGroups = append(

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -65,7 +65,6 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 		}
 		brokerResp := m.(*Response)
 		respGroups := []ResponseGroup{}
-		
 		for _, brokerResp := range brokerResp.Groups {
 			respGroups = append(
 				respGroups,

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -65,8 +65,8 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 		}
 		brokerResp := result.(*Response)
 
-		respGroups := make([]ResponseGroup, 0, len(resp.Groups))
-		for _, brokerResp := range resp.Groups {
+		respGroups := []ResponseGroup{}
+		for _, brokerResp := range brokerResp.Groups {
 			respGroups = append(
 				respGroups,
 				ResponseGroup{

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -64,7 +64,6 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 			return nil, err
 		}
 		brokerResp := m.(*Response)
-
 		respGroups := []ResponseGroup{}
 		for _, brokerResp := range brokerResp.Groups {
 			respGroups = append(

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -1,8 +1,6 @@
 package listgroups
 
 import (
-	"fmt"
-
 	"github.com/segmentio/kafka-go/protocol"
 )
 

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -65,6 +65,7 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 		}
 		brokerResp := m.(*Response)
 		respGroups := []ResponseGroup{}
+		
 		for _, brokerResp := range brokerResp.Groups {
 			respGroups = append(
 				respGroups,

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -59,16 +59,12 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	response := &Response{}
 
 	for r, result := range results {
-		brokerResp, ok := result.(*Response)
-		if !ok {
-			if err, ok := result.(error); ok {
-				return nil, fmt.Errorf("listgroups.(*Response).Merge: %w", err)
-			}
-			return nil, fmt.Errorf("listgroups.(*Response).Merge: unexpected got type %T", result)
+		brokerResp, err := Result(result)
+		if err != nil {
+			return nil, err
 		}
 
 		respGroups := make([]ResponseGroup, 0, len(brokerResp.Groups))
-
 		for _, brokerResp := range brokerResp.Groups {
 			respGroups = append(
 				respGroups,
@@ -84,4 +80,20 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	}
 
 	return response, nil
+}
+
+// Result converts r to a Response or an error, or return a custom error if r could be
+// converted to these types.
+func Result(r interface{}) (Response, error) {
+	switch v := r.(type) {
+	case *Response:
+		if v == nil {
+			return Response{}, nil
+		}
+		return *v, nil
+	case error:
+		return Response{}, v
+	default:
+		return Response{}, fmt.Errorf("BUG: result must be a response or an error but not %T", v)
+	}
 }

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -64,7 +64,7 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 			if err, ok := result.(error); ok {
 				return nil, fmt.Errorf("listgroups.(*Response).Merge: %w", err)
 			}
-			return nil, fmt.Errorf("listgroups.(*Response).Merge expect got %T", result)
+			return nil, fmt.Errorf("listgroups.(*Response).Merge: unexpected got type %T", result)
 		}
 
 		respGroups := make([]ResponseGroup, 0, len(brokerResp.Groups))

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -59,15 +59,11 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	response := &Response{}
 
 	for r, result := range results {
-		brokerResp, err := protocol.Result(result)
+		m, err := protocol.Result(result)
 		if err != nil {
 			return nil, err
 		}
-
-		resp, ok := brokerResp.(*Response)
-		if !ok {
-			return nil, fmt.Errorf("BUG: result must be a response but not %T", brokerResp)
-		}
+		brokerResp := result.(*Response)
 
 		respGroups := make([]ResponseGroup, 0, len(resp.Groups))
 		for _, brokerResp := range resp.Groups {

--- a/protocol/listgroups/listgroups.go
+++ b/protocol/listgroups/listgroups.go
@@ -59,13 +59,18 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	response := &Response{}
 
 	for r, result := range results {
-		brokerResp, err := Result(result)
+		brokerResp, err := protocol.Result(result)
 		if err != nil {
 			return nil, err
 		}
 
-		respGroups := make([]ResponseGroup, 0, len(brokerResp.Groups))
-		for _, brokerResp := range brokerResp.Groups {
+		resp, ok := brokerResp.(*Response)
+		if !ok {
+			return nil, fmt.Errorf("BUG: result must be a response but not %T", brokerResp)
+		}
+
+		respGroups := make([]ResponseGroup, 0, len(resp.Groups))
+		for _, brokerResp := range resp.Groups {
 			respGroups = append(
 				respGroups,
 				ResponseGroup{
@@ -80,20 +85,4 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	}
 
 	return response, nil
-}
-
-// Result converts r to a Response or an error, or return a custom error if r could be
-// converted to these types.
-func Result(r interface{}) (Response, error) {
-	switch v := r.(type) {
-	case *Response:
-		if v == nil {
-			return Response{}, nil
-		}
-		return *v, nil
-	case error:
-		return Response{}, v
-	default:
-		return Response{}, fmt.Errorf("BUG: result must be a response or an error but not %T", v)
-	}
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -492,7 +492,7 @@ type Merger interface {
 	Merge(messages []Message, results []interface{}) (Message, error)
 }
 
-// Result converts r to a Message or and error, or panics if r could be be
+// Result converts r to a Message or an error, or panics if r could not be
 // converted to these types.
 func Result(r interface{}) (Message, error) {
 	switch v := r.(type) {


### PR DESCRIPTION
In the event of a sudden network outage (such as a sudden wifi disconnection or vpn request to reconnect), the `ListGroups` method panics because the result is incorrectly asserted as Response, but is actually an `error` type (e.g. `context deadline exceeded` or `*net.OpError` etc)