### PR TITLE
refactor: enable wrapcheck linter and address all issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,34 @@ linters:
     - gofmt
     - goimports
     - prealloc
+    - wrapcheck
 
   disable:
     # Temporarily disabling so it can be addressed in a dedicated PR.
     - errcheck
     - goerr113
+
+linters-settings:
+  govet:
+    disable:
+      - deepequalerrors
+
+  wrapcheck:
+    ignoreSigs:
+      - .Errorf(
+      - errors.New(
+      - errors.Unwrap(
+      - .Wrap(
+      - .Wrapf(
+      - .WithMessage(
+      - .WithMessagef(
+      - .WithStack(
+      # the list above is the default, with our additions starting below
+      - (context.Context).Err(
+      - .RoundTrip(
+      - .Read(
+      - .Close(
+      - .Flush(
+    ignorePackageGlobs:
+      - bufio
+      - io

--- a/batch.go
+++ b/batch.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -162,7 +163,11 @@ func (batch *Batch) Read(b []byte) (int, error) {
 			}
 			nbytes, err := io.ReadFull(r, b[:nbytes])
 			if err != nil {
-				return size - nbytes, err
+				if errors.Is(err, io.EOF) {
+					return size - nbytes, io.EOF
+				}
+
+				return size - nbytes, fmt.Errorf("batch read failure: %w", err)
 			}
 			return discardN(r, size-nbytes, n-nbytes)
 		},

--- a/compress/compress_test.go
+++ b/compress/compress_test.go
@@ -60,10 +60,10 @@ func compress(codec pkg.Codec, src []byte) ([]byte, error) {
 	w := codec.NewWriter(b)
 	if _, err := io.Copy(w, r); err != nil {
 		w.Close()
-		return nil, err
+		return nil, fmt.Errorf("copy failed: %w", err)
 	}
 	if err := w.Close(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("codec writer could not be closed: %w", err)
 	}
 	return b.Bytes(), nil
 }
@@ -73,10 +73,10 @@ func decompress(codec pkg.Codec, src []byte) ([]byte, error) {
 	r := codec.NewReader(bytes.NewReader(src))
 	if _, err := io.Copy(b, r); err != nil {
 		r.Close()
-		return nil, err
+		return nil, fmt.Errorf("copy failed: %w", err)
 	}
 	if err := r.Close(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("codec reader could not be closed: %w", err)
 	}
 	return b.Bytes(), nil
 }

--- a/compress/snappy/go-xerial-snappy/snappy.go
+++ b/compress/snappy/go-xerial-snappy/snappy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 
 	master "github.com/klauspost/compress/snappy"
 )
@@ -89,7 +90,11 @@ func DecodeInto(dst, src []byte) ([]byte, error) {
 	}
 
 	if !bytes.Equal(src[:8], xerialHeader) {
-		return master.Decode(dst[:cap(dst)], src)
+		data, err := master.Decode(dst[:cap(dst)], src)
+		if err != nil {
+			return data, fmt.Errorf("snappy decode failed: %w", err)
+		}
+		return data, nil
 	}
 
 	if max < sizeOffset+sizeBytes {
@@ -122,7 +127,7 @@ func DecodeInto(dst, src []byte) ([]byte, error) {
 		chunk, err = master.Decode(chunk[:cap(chunk)], src[pos:nextPos])
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("snappy decode failed: %w", err)
 		}
 		pos = nextPos
 		dst = append(dst, chunk...)

--- a/conn.go
+++ b/conn.go
@@ -1243,7 +1243,7 @@ func (c *Conn) readResponse(size int, res interface{}) error {
 func (c *Conn) peekResponseSizeAndID() (int32, int32, error) {
 	b, err := c.rbuf.Peek(8)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("peek for response size and id failed: %w", err)
 	}
 	size, id := makeInt32(b[:4]), makeInt32(b[4:])
 	return size, id, nil

--- a/consumergroup.go
+++ b/consumergroup.go
@@ -455,7 +455,11 @@ func (g *Generation) CommitOffsets(offsets map[string]map[int]int64) error {
 		})
 	}
 
-	return err
+	if err != nil {
+		return fmt.Errorf("could not commit offsets: %w", err)
+	}
+
+	return nil
 }
 
 // heartbeatLoop checks in with the consumer group coordinator at the provided
@@ -1033,7 +1037,7 @@ func (cg *ConsumerGroup) assignTopicPartitions(conn coordinator, group joinGroup
 	// clients: java, python, and librdkafka.
 	// a topic watcher can trigger a rebalance when the topic comes into being.
 	if err != nil && !errors.Is(err, UnknownTopicOrPartition) {
-		return nil, err
+		return nil, fmt.Errorf("unable to read partitions: %w", err)
 	}
 
 	cg.withLogger(func(l Logger) {
@@ -1156,7 +1160,7 @@ func (cg *ConsumerGroup) fetchOffsets(conn coordinator, subs map[string][]int32)
 	}
 	offsets, err := conn.offsetFetch(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not fetch offsets: %w", err)
 	}
 
 	offsetsByTopic := make(map[string]map[int]int64)
@@ -1234,7 +1238,7 @@ func (cg *ConsumerGroup) leaveGroup(memberID string) error {
 
 	_ = coordinator.Close()
 
-	return err
+	return fmt.Errorf("leave group failed: %w", err)
 }
 
 func (cg *ConsumerGroup) withLogger(do func(Logger)) {

--- a/dialer.go
+++ b/dialer.go
@@ -205,7 +205,10 @@ func (d *Dialer) LookupPartition(ctx context.Context, network string, address st
 	case <-ctx.Done():
 		err = ctx.Err()
 	}
-	return prt, err
+	if err != nil {
+		return prt, fmt.Errorf("lookup partition failed: %w", err)
+	}
+	return prt, nil
 }
 
 // LookupPartitions returns the list of partitions that exist for the given topic.
@@ -234,7 +237,10 @@ func (d *Dialer) LookupPartitions(ctx context.Context, network string, address s
 	case <-ctx.Done():
 		err = ctx.Err()
 	}
-	return prt, err
+	if err != nil {
+		return prt, fmt.Errorf("lookup partitions failed: %w", err)
+	}
+	return prt, nil
 }
 
 // connectTLS returns a tls.Conn that has already completed the Handshake.

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -177,7 +178,7 @@ func readRecords(records RecordReader) ([]memoryRecord, error) {
 			if errors.Is(err, io.EOF) {
 				return list, nil
 			}
-			return nil, err
+			return nil, fmt.Errorf("read record failed: %w", err)
 		}
 
 		var (

--- a/kafka.go
+++ b/kafka.go
@@ -1,6 +1,10 @@
 package kafka
 
-import "github.com/segmentio/kafka-go/protocol"
+import (
+	"fmt"
+
+	"github.com/segmentio/kafka-go/protocol"
+)
 
 // Broker represents a kafka broker in a kafka cluster.
 type Broker struct {
@@ -64,14 +68,21 @@ type Partition struct {
 // encode types based on specific versions of kafka APIs, use the Version type
 // instead.
 func Marshal(v interface{}) ([]byte, error) {
-	return protocol.Marshal(-1, v)
+	data, err := protocol.Marshal(-1, v)
+	if err != nil {
+		return nil, fmt.Errorf("protocol marshal failed: %w", err)
+	}
+	return data, nil
 }
 
 // Unmarshal decodes a binary representation from b into v.
 //
 // See Marshal for details.
 func Unmarshal(b []byte, v interface{}) error {
-	return protocol.Unmarshal(b, -1, v)
+	if err := protocol.Unmarshal(b, -1, v); err != nil {
+		return fmt.Errorf("protocol unmarshal failed: %w", err)
+	}
+	return nil
 }
 
 // Version represents a version number for kafka APIs.
@@ -81,12 +92,19 @@ type Version int16
 // fields for which n falls within the min and max versions specified on the
 // struct tag.
 func (n Version) Marshal(v interface{}) ([]byte, error) {
-	return protocol.Marshal(int16(n), v)
+	data, err := protocol.Marshal(int16(n), v)
+	if err != nil {
+		return nil, fmt.Errorf("protocol marshal failed: %w", err)
+	}
+	return data, nil
 }
 
 // Unmarshal is like the top-level Unmarshal function, but will only decode
 // struct fields for which n falls within the min and max versions specified on
 // the struct tag.
 func (n Version) Unmarshal(b []byte, v interface{}) error {
-	return protocol.Unmarshal(b, int16(n), v)
+	if err := protocol.Unmarshal(b, int16(n), v); err != nil {
+		return fmt.Errorf("protocol unmarshal failed: %w", err)
+	}
+	return nil
 }

--- a/protocol/buffer.go
+++ b/protocol/buffer.go
@@ -52,8 +52,10 @@ func ReadAll(b Bytes) ([]byte, error) {
 		return nil, nil
 	}
 	s := make([]byte, b.Len())
-	_, err := io.ReadFull(b, s)
-	return s, err
+	if _, err := io.ReadFull(b, s); err != nil {
+		return s, fmt.Errorf("read failed: %w", err)
+	}
+	return s, nil
 }
 
 type bytesReader struct{ bytes.Reader }

--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -49,7 +50,14 @@ func (d *decoder) Read(b []byte) (int, error) {
 		d.crc32 = crc32.Update(d.crc32, d.table, b[:n])
 	}
 	d.remain -= n
-	return n, err
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return n, io.EOF
+		}
+
+		return n, fmt.Errorf("decoder read failed: %w", err)
+	}
+	return n, nil
 }
 
 func (d *decoder) ReadByte() (byte, error) {

--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -30,7 +30,7 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 		if resource.ResourceType == resourceTypeBroker {
 			brokerID, err := strconv.Atoi(resource.ResourceName)
 			if err != nil {
-				return protocol.Broker{}, err
+				return protocol.Broker{}, fmt.Errorf("resource name %s not convertible to number: %w", resource.ResourceName, err)
 			}
 
 			return cluster.Brokers[int32(brokerID)], nil

--- a/protocol/incrementalalterconfigs/incrementalalterconfigs.go
+++ b/protocol/incrementalalterconfigs/incrementalalterconfigs.go
@@ -2,6 +2,7 @@ package incrementalalterconfigs
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/segmentio/kafka-go/protocol"
@@ -54,7 +55,7 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 		if resource.ResourceType == resourceTypeBroker {
 			brokerID, err := strconv.Atoi(resource.ResourceName)
 			if err != nil {
-				return protocol.Broker{}, err
+				return protocol.Broker{}, fmt.Errorf("resource name %s not convertible to number: %w", resource.ResourceName, err)
 			}
 
 			return cluster.Brokers[int32(brokerID)], nil

--- a/protocol/listoffsets/listoffsets.go
+++ b/protocol/listoffsets/listoffsets.go
@@ -1,6 +1,7 @@
 package listoffsets
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/segmentio/kafka-go/protocol"
@@ -190,8 +191,10 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (pr
 	}
 
 	if errors > 0 && errors == len(results) {
-		_, err := protocol.Result(results[0])
-		return nil, err
+		if _, err := protocol.Result(results[0]); err != nil {
+			return nil, fmt.Errorf("could not convert to message: %w", err)
+		}
+		return nil, nil
 	}
 
 	r.Topics = make([]ResponseTopic, 0, len(topics))

--- a/protocol/record_batch.go
+++ b/protocol/record_batch.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"time"
 )
@@ -102,7 +103,7 @@ func (m *multiRecordReader) ReadRecord() (*Record, error) {
 			return r, nil
 		}
 		if !errors.Is(err, io.EOF) {
-			return nil, err
+			return nil, fmt.Errorf("batch read record failed: %w", err)
 		}
 		m.index++
 	}
@@ -257,7 +258,11 @@ func NewControlBatch(records ...ControlRecord) *ControlBatch {
 }
 
 func (c *ControlBatch) ReadRecord() (*Record, error) {
-	return c.Records.ReadRecord()
+	record, err := c.Records.ReadRecord()
+	if err != nil {
+		return record, fmt.Errorf("ControlBatch: read record failed: %w", err)
+	}
+	return record, nil
 }
 
 func (c *ControlBatch) ReadControlRecord() (*ControlRecord, error) {
@@ -295,7 +300,11 @@ type RecordBatch struct {
 }
 
 func (r *RecordBatch) ReadRecord() (*Record, error) {
-	return r.Records.ReadRecord()
+	record, err := r.Records.ReadRecord()
+	if err != nil {
+		return record, fmt.Errorf("RecordBatch: read record failed: %w", err)
+	}
+	return record, nil
 }
 
 func (r *RecordBatch) Offset() int64 {
@@ -315,7 +324,11 @@ type MessageSet struct {
 }
 
 func (m *MessageSet) ReadRecord() (*Record, error) {
-	return m.Records.ReadRecord()
+	record, err := m.Records.ReadRecord()
+	if err != nil {
+		return record, fmt.Errorf("MessageSet: read record failed: %w", err)
+	}
+	return record, nil
 }
 
 func (m *MessageSet) Offset() int64 {
@@ -351,8 +364,10 @@ func (s *RecordStream) ReadRecord() (*Record, error) {
 				s.index++
 				continue
 			}
+
+			return r, fmt.Errorf("RecordStream: read record failed: %w", err)
 		}
 
-		return r, err
+		return r, nil
 	}
 }

--- a/protocol/record_v1.go
+++ b/protocol/record_v1.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"errors"
+	"fmt"
 	"hash/crc32"
 	"io"
 	"math"
@@ -177,10 +178,10 @@ func (rs *RecordSet) writeToVersion1(buffer *pageBuffer, bufferOffset int64) err
 				return err == nil
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("buffer page scan (%d/%d) failed: %w", bufferOffset, buffer.Size(), err)
 			}
 			if err := compressor.Close(); err != nil {
-				return err
+				return fmt.Errorf("compressor could not be closed: %w", err)
 			}
 
 			buffer.Truncate(int(bufferOffset))

--- a/protocol/record_v2.go
+++ b/protocol/record_v2.go
@@ -277,7 +277,7 @@ func (rs *RecordSet) writeToVersion2(buffer *pageBuffer, bufferOffset int64) err
 
 	if compressor != nil {
 		if err := compressor.Close(); err != nil {
-			return err
+			return fmt.Errorf("compressor could not be closed: %w", err)
 		}
 	}
 

--- a/read.go
+++ b/read.go
@@ -16,7 +16,7 @@ func peekRead(r *bufio.Reader, sz int, n int, f func([]byte)) (int, error) {
 	}
 	b, err := r.Peek(n)
 	if err != nil {
-		return sz, err
+		return sz, fmt.Errorf("peek read failed: %w", err)
 	}
 	f(b)
 	return discardN(r, sz, n)

--- a/record.go
+++ b/record.go
@@ -1,6 +1,8 @@
 package kafka
 
 import (
+	"fmt"
+
 	"github.com/segmentio/kafka-go/protocol"
 )
 
@@ -21,7 +23,13 @@ type Bytes = protocol.Bytes
 func NewBytes(b []byte) Bytes { return protocol.NewBytes(b) }
 
 // ReadAll reads b into a byte slice.
-func ReadAll(b Bytes) ([]byte, error) { return protocol.ReadAll(b) }
+func ReadAll(b Bytes) ([]byte, error) {
+	data, err := protocol.ReadAll(b)
+	if err != nil {
+		return nil, fmt.Errorf("protocol read all failed: %w", err)
+	}
+	return data, nil
+}
 
 // Record is an interface representing a single kafka record.
 //

--- a/resolver.go
+++ b/resolver.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"fmt"
 	"net"
 )
 
@@ -41,7 +42,7 @@ type brokerResolver struct {
 func (r brokerResolver) LookupBrokerIPAddr(ctx context.Context, broker Broker) ([]net.IPAddr, error) {
 	ipAddrs, err := r.LookupIPAddr(ctx, broker.Host)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ip address lookup failed: %w", err)
 	}
 
 	if len(ipAddrs) == 0 {

--- a/sasl/scram/scram.go
+++ b/sasl/scram/scram.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/sha512"
+	"fmt"
 	"hash"
 
 	"github.com/segmentio/kafka-go/sasl"
@@ -63,7 +64,7 @@ func Mechanism(algo Algorithm, username, password string) (sasl.Mechanism, error
 	hashGen := scram.HashGeneratorFcn(algo.Hash)
 	client, err := hashGen.NewClient(username, password, "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not create scram sasl client: %w", err)
 	}
 
 	return &mechanism{
@@ -80,7 +81,7 @@ func (m *mechanism) Start(ctx context.Context) (sasl.StateMachine, []byte, error
 	convo := m.client.NewConversation()
 	str, err := convo.Step("")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("sasl first step failed to initialize: %w", err)
 	}
 	return &session{convo: convo}, []byte(str), nil
 }

--- a/testing/conn.go
+++ b/testing/conn.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 )
@@ -28,5 +29,8 @@ type groupConn struct {
 
 func (c *groupConn) Close() error {
 	defer c.once.Do(c.group.Done)
-	return c.Conn.Close()
+	if err := c.Conn.Close(); err != nil {
+		return fmt.Errorf("could not close kafka connection: %w", err)
+	}
+	return nil
 }

--- a/topics/list_topics.go
+++ b/topics/list_topics.go
@@ -6,6 +6,7 @@ package topics
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/segmentio/kafka-go"
@@ -20,7 +21,7 @@ func List(ctx context.Context, client *kafka.Client) (topics []kafka.Topic, err 
 		Addr: client.Addr,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("metadata request failed: %w", err)
 	}
 
 	return response.Topics, nil

--- a/topics/list_topics_test.go
+++ b/topics/list_topics_test.go
@@ -2,6 +2,7 @@ package topics
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"regexp"
 	"testing"
@@ -68,7 +69,7 @@ func clientCreateTopic(client *kafka.Client, topic string, partitions int) error
 		}},
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("could not create topics: %w", err)
 	}
 
 	// Topic creation seems to be asynchronous. Metadata for the topic partition

--- a/write.go
+++ b/write.go
@@ -147,16 +147,27 @@ func (wb *writeBuffer) write(a interface{}) {
 }
 
 func (wb *writeBuffer) Write(b []byte) (int, error) {
-	return wb.w.Write(b)
+	n, err := wb.w.Write(b)
+	if err != nil {
+		return n, fmt.Errorf("write failed: %w", err)
+	}
+	return n, nil
 }
 
 func (wb *writeBuffer) WriteString(s string) (int, error) {
-	return io.WriteString(wb.w, s)
+	n, err := io.WriteString(wb.w, s)
+	if err != nil {
+		return n, fmt.Errorf("write string failed: %w", err)
+	}
+	return n, nil
 }
 
 func (wb *writeBuffer) Flush() error {
 	if x, ok := wb.w.(interface{ Flush() error }); ok {
-		return x.Flush()
+		if err := x.Flush(); err != nil {
+			return err
+		}
+		return nil
 	}
 	return nil
 }

--- a/writer.go
+++ b/writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -448,7 +449,11 @@ func NewWriter(config WriterConfig) *Writer {
 		if err != nil {
 			return nil, err
 		}
-		return dialer.DialContext(ctx, network, address)
+		conn, err := dialer.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, fmt.Errorf("%s dial %s failed: %w", network, address, err)
+		}
+		return conn, nil
 	}
 
 	idleTimeout := config.IdleConnTimeout


### PR DESCRIPTION
This PR aims to improve our ability to troubleshoot by wrapping more errors with context, relying on the `wrapcheck` linter to detect all places where errors likely should be wrapped.

Opening this as a draft to begin with while we review as a team and see if there are any caveats to worry about when wrapping errors.