### PR TITLE
protocol: Use standardized result type checking

### DIFF
--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -88,19 +88,14 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	response := &Response{}
 
 	for _, result := range results {
-		switch v := result.(type) {
-		case *Response:
-			response.Resources = append(
-				response.Resources,
-				v.Resources...,
-			)
-
-		case error:
-			return nil, v
-
-		default:
-			panic(fmt.Sprintf("unknown result type in Merge: %T", result))
+		m, err := protocol.Result(result)
+		if err != nil {
+			return nil, err
 		}
+		response.Resources = append(
+			response.Resources,
+			m.(*Response).Resources...,
+		)
 	}
 
 	return response, nil

--- a/protocol/describeconfigs/describeconfigs.go
+++ b/protocol/describeconfigs/describeconfigs.go
@@ -1,7 +1,6 @@
 package describeconfigs
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/segmentio/kafka-go/protocol"

--- a/protocol/describeconfigs/describeconfigs_test.go
+++ b/protocol/describeconfigs/describeconfigs_test.go
@@ -59,7 +59,7 @@ func TestResponse_Merge(t *testing.T) {
 	t.Run("panic with unexpected type", func(t *testing.T) {
 		defer func() {
 			msg := recover()
-			if msg != "unknown result type in Merge: string" {
+			if msg != "BUG: result must be a message or an error but not string" {
 				t.Fatal("unexpected panic", msg)
 			}
 		}()

--- a/protocol/describeconfigs/describeconfigs_test.go
+++ b/protocol/describeconfigs/describeconfigs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/segmentio/kafka-go/protocol"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResponse_Merge(t *testing.T) {
@@ -59,9 +60,7 @@ func TestResponse_Merge(t *testing.T) {
 	t.Run("panic with unexpected type", func(t *testing.T) {
 		defer func() {
 			msg := recover()
-			if msg != "BUG: result must be a message or an error but not string" {
-				t.Fatal("unexpected panic", msg)
-			}
+			require.Equal(t, "BUG: result must be a message or an error but not string", msg)
 		}()
 		r := &Response{}
 

--- a/protocol/describeconfigs/describeconfigs_test.go
+++ b/protocol/describeconfigs/describeconfigs_test.go
@@ -2,6 +2,7 @@ package describeconfigs
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -60,7 +61,7 @@ func TestResponse_Merge(t *testing.T) {
 	t.Run("panic with unexpected type", func(t *testing.T) {
 		defer func() {
 			msg := recover()
-			require.Equal(t, "BUG: result must be a message or an error but not string", msg)
+			require.Equal(t, "BUG: result must be a message or an error but not string", fmt.Sprintf("%s", msg))
 		}()
 		r := &Response{}
 

--- a/protocol/describegroups/describegroups.go
+++ b/protocol/describegroups/describegroups.go
@@ -74,7 +74,11 @@ func (r *Response) Merge(requests []protocol.Message, results []interface{}) (
 	response := &Response{}
 
 	for _, result := range results {
-		response.Groups = append(response.Groups, result.(*Response).Groups...)
+		m, err := protocol.Result(result)
+		if err != nil {
+			return nil, err
+		}
+		response.Groups = append(response.Groups, m.(*Response).Groups...)
 	}
 
 	return response, nil


### PR DESCRIPTION
Fixing the rest of the issues pointed out by https://github.com/segmentio/kafka-go/pull/931