### PR TITLE
fix typos in group structs

### DIFF
--- a/leavegroup_test.go
+++ b/leavegroup_test.go
@@ -126,7 +126,7 @@ func TestClientLeaveGroup(t *testing.T) {
 	}
 
 	for member, assignment := range assignments {
-		sgRequest.Assigments = append(sgRequest.Assigments, SyncGroupRequestAssignment{
+		sgRequest.Assignments = append(sgRequest.Assignments, SyncGroupRequestAssignment{
 			MemberID: member,
 			Assignment: GroupProtocolAssignment{
 				AssignedPartitions: assignment,
@@ -150,8 +150,8 @@ func TestClientLeaveGroup(t *testing.T) {
 		UserData: []byte(userData),
 	}
 
-	if !reflect.DeepEqual(sgResp.Assigment, expectedAssignment) {
-		t.Fatalf("\nexpected assignment to be \n%#v \ngot\n%#v", expectedAssignment, sgResp.Assigment)
+	if !reflect.DeepEqual(sgResp.Assignment, expectedAssignment) {
+		t.Fatalf("\nexpected assignment to be \n%#v \ngot\n%#v", expectedAssignment, sgResp.Assignment)
 	}
 
 	lgResp, err := client.LeaveGroup(ctx, &LeaveGroupRequest{

--- a/syncgroup.go
+++ b/syncgroup.go
@@ -37,7 +37,7 @@ type SyncGroupRequest struct {
 	ProtocolName string
 
 	// The group member assignments.
-	Assigments []SyncGroupRequestAssignment
+	Assignments []SyncGroupRequestAssignment
 }
 
 // SyncGroupRequestAssignment represents an assignement for a goroup memeber.
@@ -67,7 +67,7 @@ type SyncGroupResponse struct {
 	ProtocolName string
 
 	// The member assignment.
-	Assigment GroupProtocolAssignment
+	Assignment GroupProtocolAssignment
 }
 
 // GroupProtocolAssignment represents an assignment of topics and partitions for a group memeber.
@@ -88,17 +88,17 @@ func (c *Client) SyncGroup(ctx context.Context, req *SyncGroupRequest) (*SyncGro
 		GroupInstanceID: req.GroupInstanceID,
 		ProtocolType:    req.ProtocolType,
 		ProtocolName:    req.ProtocolName,
-		Assignments:     make([]syncgroup.RequestAssignment, 0, len(req.Assigments)),
+		Assignments:     make([]syncgroup.RequestAssignment, 0, len(req.Assignments)),
 	}
 
-	for _, assigment := range req.Assigments {
+	for _, assignment := range req.Assignments {
 		assign := consumer.Assignment{
 			Version:            consumer.MaxVersionSupported,
-			AssignedPartitions: make([]consumer.TopicPartition, 0, len(assigment.Assignment.AssignedPartitions)),
-			UserData:           assigment.Assignment.UserData,
+			AssignedPartitions: make([]consumer.TopicPartition, 0, len(assignment.Assignment.AssignedPartitions)),
+			UserData:           assignment.Assignment.UserData,
 		}
 
-		for topic, partitions := range assigment.Assignment.AssignedPartitions {
+		for topic, partitions := range assignment.Assignment.AssignedPartitions {
 			tp := consumer.TopicPartition{
 				Topic:      topic,
 				Partitions: make([]int32, 0, len(partitions)),
@@ -115,7 +115,7 @@ func (c *Client) SyncGroup(ctx context.Context, req *SyncGroupRequest) (*SyncGro
 		}
 
 		syncGroup.Assignments = append(syncGroup.Assignments, syncgroup.RequestAssignment{
-			MemberID:   assigment.MemberID,
+			MemberID:   assignment.MemberID,
 			Assignment: assignBytes,
 		})
 	}
@@ -138,7 +138,7 @@ func (c *Client) SyncGroup(ctx context.Context, req *SyncGroupRequest) (*SyncGro
 		Error:        makeError(r.ErrorCode, ""),
 		ProtocolType: r.ProtocolType,
 		ProtocolName: r.ProtocolName,
-		Assigment: GroupProtocolAssignment{
+		Assignment: GroupProtocolAssignment{
 			AssignedPartitions: make(map[string][]int, len(assignment.AssignedPartitions)),
 			UserData:           assignment.UserData,
 		},
@@ -149,7 +149,7 @@ func (c *Client) SyncGroup(ctx context.Context, req *SyncGroupRequest) (*SyncGro
 			partitions[topicPartition.Topic] = append(partitions[topicPartition.Topic], int(partition))
 		}
 	}
-	res.Assigment.AssignedPartitions = partitions
+	res.Assignment.AssignedPartitions = partitions
 
 	return res, nil
 }

--- a/syncgroup_test.go
+++ b/syncgroup_test.go
@@ -127,7 +127,7 @@ func TestClientSyncGroup(t *testing.T) {
 	}
 
 	for member, assignment := range assignments {
-		sgRequest.Assigments = append(sgRequest.Assigments, SyncGroupRequestAssignment{
+		sgRequest.Assignments = append(sgRequest.Assignments, SyncGroupRequestAssignment{
 			MemberID: member,
 			Assignment: GroupProtocolAssignment{
 				AssignedPartitions: assignment,
@@ -151,8 +151,8 @@ func TestClientSyncGroup(t *testing.T) {
 		UserData: []byte(userData),
 	}
 
-	if !reflect.DeepEqual(sgResp.Assigment, expectedAssignment) {
-		t.Fatalf("\nexpected assignment to be \n%#v \ngot\n%#v", expectedAssignment, sgResp.Assigment)
+	if !reflect.DeepEqual(sgResp.Assignment, expectedAssignment) {
+		t.Fatalf("\nexpected assignment to be \n%#v \ngot\n%#v", expectedAssignment, sgResp.Assignment)
 	}
 }
 


### PR DESCRIPTION
Fix some typos in the request structs for group functions.