### PR TITLE
re-order protocol/joingroup response fields

### DIFF
--- a/protocol/joingroup/joingroup.go
+++ b/protocol/joingroup/joingroup.go
@@ -45,8 +45,8 @@ type Response struct {
 	ThrottleTimeMS int32            `kafka:"min=v2,max=v7"`
 	ErrorCode      int16            `kafka:"min=v0,max=v7"`
 	GenerationID   int32            `kafka:"min=v0,max=v7"`
-	ProtocolName   string           `kafka:"min=v0,max=v5|min=v6,max=v6,compact|min=v7,max=v7,compact,nullable"`
 	ProtocolType   string           `kafka:"min=v7,max=v7,compact,nullable"`
+	ProtocolName   string           `kafka:"min=v0,max=v5|min=v6,max=v6,compact|min=v7,max=v7,compact,nullable"`
 	LeaderID       string           `kafka:"min=v0,max=v5|min=v6,max=v7,compact"`
 	MemberID       string           `kafka:"min=v0,max=v5|min=v6,max=v7,compact"`
 	Members        []ResponseMember `kafka:"min=v0,max=v7"`


### PR DESCRIPTION
ProtocolType comes before ProtocolName

```
JoinGroup Response (Version: 7) => throttle_time_ms error_code generation_id protocol_type protocol_name leader member_id [members] TAG_BUFFER 
  throttle_time_ms => INT32
  error_code => INT16
  generation_id => INT32
  protocol_type => COMPACT_NULLABLE_STRING
  protocol_name => COMPACT_NULLABLE_STRING
  leader => COMPACT_STRING
  member_id => COMPACT_STRING
  members => member_id group_instance_id metadata TAG_BUFFER 
    member_id => COMPACT_STRING
    group_instance_id => COMPACT_NULLABLE_STRING
    metadata => COMPACT_BYTES
```