### PR TITLE
Update WriteErrors error message

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"syscall"
 )
 
@@ -701,5 +702,9 @@ func (err WriteErrors) Count() int {
 }
 
 func (err WriteErrors) Error() string {
-	return fmt.Sprintf("kafka write errors (%d/%d)", err.Count(), len(err))
+	var sb strings.Builder
+	for i, writeError := range err {
+		sb.WriteString(fmt.Sprintf("Message %d: %s \n", i, writeError.Error()))
+	}
+	return fmt.Sprintf("kafka write errors (%d/%d), errors: %s", err.Count(), len(err), sb.String())
 }

--- a/error.go
+++ b/error.go
@@ -685,7 +685,6 @@ func makeError(code int16, message string) error {
 //		// handle other errors
 //		...
 //	}
-//
 type WriteErrors []error
 
 // Count counts the number of non-nil errors in err.
@@ -704,6 +703,9 @@ func (err WriteErrors) Count() int {
 func (err WriteErrors) Error() string {
 	var sb strings.Builder
 	for i, writeError := range err {
+		if writeError == nil {
+			continue
+		}
 		fmt.Fprintf(&sb, "Message %d: %s \n", i, writeError.Error())
 	}
 	return fmt.Sprintf("kafka write errors (%d/%d), errors: %s", err.Count(), len(err), sb.String())

--- a/error.go
+++ b/error.go
@@ -700,12 +700,13 @@ func (err WriteErrors) Count() int {
 }
 
 func (err WriteErrors) Error() string {
-	var errors []string
+	errCount := err.Count()
+	errors := make([]string, 0, errCount)
 	for _, writeError := range err {
 		if writeError == nil {
 			continue
 		}
 		errors = append(errors, writeError.Error())
 	}
-	return fmt.Sprintf("Kafka write errors (%d/%d), errors: %v", err.Count(), len(err), errors)
+	return fmt.Sprintf("Kafka write errors (%d/%d), errors: %v", errCount, len(err), errors)
 }

--- a/error.go
+++ b/error.go
@@ -704,7 +704,7 @@ func (err WriteErrors) Count() int {
 func (err WriteErrors) Error() string {
 	var sb strings.Builder
 	for i, writeError := range err {
-		sb.WriteString(fmt.Sprintf("Message %d: %s \n", i, writeError.Error()))
+		fmt.Fprintf(&sb, "Message %d: %s \n", i, writeError.Error())
 	}
 	return fmt.Sprintf("kafka write errors (%d/%d), errors: %s", err.Count(), len(err), sb.String())
 }

--- a/error.go
+++ b/error.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"syscall"
 )
 
@@ -701,12 +700,12 @@ func (err WriteErrors) Count() int {
 }
 
 func (err WriteErrors) Error() string {
-	var sb strings.Builder
-	for i, writeError := range err {
+	var errors []string
+	for _, writeError := range err {
 		if writeError == nil {
 			continue
 		}
-		fmt.Fprintf(&sb, "Message %d: %s \n", i, writeError.Error())
+		errors = append(errors, writeError.Error())
 	}
-	return fmt.Sprintf("kafka write errors (%d/%d), errors: %s", err.Count(), len(err), sb.String())
+	return fmt.Sprintf("Kafka write errors (%d/%d), errors: %v", err.Count(), len(err), errors)
 }


### PR DESCRIPTION
We can't see the actual errors of our batch write request. It creates new error and this error does not contain any information about the error return fmt.Sprintf("kafka write errors (%d/%d)", err.Count(), len(err)). We need to see the detail of the error.

Issue thread: https://github.com/segmentio/kafka-go/issues/957