### PR TITLE
#726 remove reader safetyTimeout

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1514,16 +1514,7 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 	var size int64
 	var bytes int64
 
-	const safetyTimeout = 10 * time.Second
-	deadline := time.Now().Add(safetyTimeout)
-	conn.SetReadDeadline(deadline)
-
 	for {
-		if now := time.Now(); deadline.Sub(now) < (safetyTimeout / 2) {
-			deadline = now.Add(safetyTimeout)
-			conn.SetReadDeadline(deadline)
-		}
-
 		if msg, err = batch.ReadMessage(); err != nil {
 			batch.Close()
 			break


### PR DESCRIPTION
PR removes reader `safetyTimeout` 
 because `SetReadDeadline` already configured using `maxWait ` at line [1500](https://github.com/segmentio/kafka-go/blob/main/reader.go#L1500),  if not configurable it could cause some clients to timeout or context gets cancelled 
