### PR TITLE
Allows users to configure the GroupInstanceID

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -367,6 +367,9 @@ type ReaderConfig struct {
 	// The topic to read messages from.
 	Topic string
 
+	// The unique identifier of the consumer instance provided by end user.
+	GroupInstanceID string
+
 	// Partition to read messages from.  Either Partition or GroupID may
 	// be assigned, but not both
 	Partition int
@@ -731,6 +734,7 @@ func NewReader(config ReaderConfig) *Reader {
 			ID:                     r.config.GroupID,
 			Brokers:                r.config.Brokers,
 			Topics:                 r.getTopics(),
+			GroupInstanceID:        r.config.GroupInstanceID,
 			GroupBalancers:         r.config.GroupBalancers,
 			HeartbeatInterval:      r.config.HeartbeatInterval,
 			PartitionWatchInterval: r.config.PartitionWatchInterval,


### PR DESCRIPTION
GroupInstanceID can be configured by setting ReaderConfig.GroupInstanceID which will be passed to the joinGroup and heartbeat requests. If the GroupInstanceID has a value the kafka server will set it as a static member.