### PR TITLE
change writer retries stat from summary to counter

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -356,7 +356,7 @@ type WriterStats struct {
 	BatchTime  DurationStats `metric:"kafka.writer.batch.seconds"`
 	WriteTime  DurationStats `metric:"kafka.writer.write.seconds"`
 	WaitTime   DurationStats `metric:"kafka.writer.wait.seconds"`
-	Retries    int64         `metric:"kafka.writer.retries.count"`
+	Retries    int64         `metric:"kafka.writer.retries.count" type:"counter"`
 	BatchSize  SummaryStats  `metric:"kafka.writer.batch.size"`
 	BatchBytes SummaryStats  `metric:"kafka.writer.batch.bytes"`
 

--- a/writer.go
+++ b/writer.go
@@ -356,7 +356,7 @@ type WriterStats struct {
 	BatchTime  DurationStats `metric:"kafka.writer.batch.seconds"`
 	WriteTime  DurationStats `metric:"kafka.writer.write.seconds"`
 	WaitTime   DurationStats `metric:"kafka.writer.wait.seconds"`
-	Retries    SummaryStats  `metric:"kafka.writer.retries.count"`
+	Retries    int64         `metric:"kafka.writer.retries.count"`
 	BatchSize  SummaryStats  `metric:"kafka.writer.batch.size"`
 	BatchBytes SummaryStats  `metric:"kafka.writer.batch.bytes"`
 
@@ -403,7 +403,7 @@ type writerStats struct {
 	batchTime      summary
 	writeTime      summary
 	waitTime       summary
-	retries        summary
+	retries        counter
 	batchSize      summary
 	batchSizeBytes summary
 }


### PR DESCRIPTION
Fixes #1005 

Technically a breaking change but it seems simple enough for applications to address, any use of the `retries` metric prior to this change would have likely been erroneous anyways.