### PR TITLE
Removed the outdated part of the documentation

### DIFF
--- a/describeconfigs.go
+++ b/describeconfigs.go
@@ -14,7 +14,7 @@ type DescribeConfigsRequest struct {
 	// Address of the kafka broker to send the request to.
 	Addr net.Addr
 
-	// List of resources to update.
+	// List of resources to get details for.
 	Resources []DescribeConfigRequestResource
 
 	// Ignored if API version is less than v1

--- a/writer.go
+++ b/writer.go
@@ -307,10 +307,6 @@ type WriterConfig struct {
 	// a response to a produce request. The default is -1, which means to wait for
 	// all replicas, and a value above 0 is required to indicate how many replicas
 	// should acknowledge a message to be considered successful.
-	//
-	// This version of kafka-go (v0.3) does not support 0 required acks, due to
-	// some internal complexity implementing this with the Kafka protocol. If you
-	// need that functionality specifically, you'll need to upgrade to v0.4.
 	RequiredAcks int
 
 	// Setting this flag to true causes the WriteMessages method to never block.


### PR DESCRIPTION
Developers (at least me) don't always look at which version of the library is currently added to the project. 

I removed outdated parts in the documentation so that the hints in the IDE would not confuse users.


**UPD**: Fixed an inaccuracy in the description of the field for the struct `DescribeConfigsRequest`