### PR TITLE
retract v0.4.36-v0.4.37

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.0.0-20220706163947-c90051bbdb60
 )
+
+retract (
+	[v0.4.36, v0.4.37]
+)


### PR DESCRIPTION
those two versions contained the conversion of the ConsumerGroup to the Client type. That conversion contained numerous bugs and had to be reverted