### PR TITLE
Reuse messages slice to avoid new allocations

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -276,7 +276,7 @@ func testReaderOutOfRangeGetsCanceled(t *testing.T, ctx context.Context, r *Read
 	}
 }
 
-func createTopic(t *testing.T, topic string, partitions int) {
+func createTopic(t testing.TB, topic string, partitions int) {
 	t.Helper()
 
 	t.Logf("createTopic(%s, %d)", topic, partitions)
@@ -326,7 +326,7 @@ func createTopic(t *testing.T, topic string, partitions int) {
 }
 
 // Block until topic exists.
-func waitForTopic(ctx context.Context, t *testing.T, topic string) {
+func waitForTopic(ctx context.Context, t testing.TB, topic string) {
 	t.Helper()
 
 	for {
@@ -370,7 +370,7 @@ func waitForTopic(ctx context.Context, t *testing.T, topic string) {
 	}
 }
 
-func deleteTopic(t *testing.T, topic ...string) {
+func deleteTopic(t testing.TB, topic ...string) {
 	t.Helper()
 	conn, err := Dial("tcp", "localhost:9092")
 	if err != nil {


### PR DESCRIPTION
The service which is writing to kafka is under relatively high load and memory usage and as well as CPU usage was too high under load. One of the reasons of it was allocations and work of GC, that was found with help of pprof. After some investigation I've found that kafka writer produces unexpectedly high load on RAM in terms of allocated space, and its reduction should free some CPU resources and make RAM consumption more predictable. Please try `BenchmarkWriterBatches`, maybe I have wrong understanding, but results on my machine are the following, looks like in long it will be more visible: 
```
go.exe test -benchmem -run=^$ -tags integration,db_backed -bench ^BenchmarkWriterBatches$ github.com/segmentio/kafka-go -benchmem -memprofile memprofile.out -benchtime=100x
```
Before changes:
```
go tool pprof -alloc_space ..\memprofile_before.out
Type: alloc_space
Time: Dec 17, 2022 at 9:38pm (MSK)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 403.95MB, 95.39% of 423.46MB total
Dropped 31 nodes (cum <= 2.12MB)
Showing top 10 nodes out of 41
      flat  flat%   sum%        cum   cum%
  159.01MB 37.55% 37.55%   159.01MB 37.55%  github.com/segmentio/kafka-go.filterMetadataResponse
  126.72MB 29.92% 67.48%   126.72MB 29.92%  github.com/segmentio/kafka-go.(*writeBatch).add (inline)
   48.50MB 11.45% 78.93%   207.51MB 49.00%  github.com/segmentio/kafka-go.(*Writer).partitions
   30.85MB  7.29% 86.21%    30.85MB  7.29%  github.com/segmentio/kafka-go/protocol.newPage
   14.55MB  3.44% 89.65%   365.78MB 86.38%  github.com/segmentio/kafka-go.(*Writer).WriteMessages
       9MB  2.13% 91.78%   142.22MB 33.59%  github.com/segmentio/kafka-go.(*partitionWriter).writeMessages
    5.50MB  1.30% 93.08%        6MB  1.42%  github.com/segmentio/kafka-go.newWriteBatch (inline)
    3.50MB  0.83% 93.90%       15MB  3.54%  github.com/segmentio/kafka-go.(*Writer).produce
    3.32MB  0.78% 94.69%   369.10MB 87.16%  github.com/segmentio/kafka-go.BenchmarkWriterBatches
       3MB  0.71% 95.39%        5MB  1.18%  context.propagateCancel
```
After changes:
```
go tool pprof -alloc_space ..\memprofile_after.out 
Type: alloc_space
Time: Dec 17, 2022 at 9:36pm (MSK)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 266.24MB, 93.67% of 284.24MB total
Dropped 43 nodes (cum <= 1.42MB)
Showing top 10 nodes out of 56
      flat  flat%   sum%        cum   cum%
  158.01MB 55.59% 55.59%   158.01MB 55.59%  github.com/segmentio/kafka-go.filterMetadataResponse
      49MB 17.24% 72.83%   207.01MB 72.83%  github.com/segmentio/kafka-go.(*Writer).partitions
   21.28MB  7.49% 80.32%    21.78MB  7.66%  github.com/segmentio/kafka-go/protocol.newPage
   10.50MB  3.70% 84.01%    22.10MB  7.77%  github.com/segmentio/kafka-go.(*partitionWriter).writeMessages
   10.03MB  3.53% 87.54%   239.64MB 84.31%  github.com/segmentio/kafka-go.(*Writer).WriteMessages
    5.50MB  1.94% 89.48%     6.50MB  2.29%  github.com/segmentio/kafka-go.newWriteBatch (inline)
    5.09MB  1.79% 91.27%     5.09MB  1.79%  github.com/segmentio/kafka-go.(*writeBatch).add
    2.82MB  0.99% 92.26%   242.46MB 85.30%  github.com/segmentio/kafka-go.BenchmarkWriterBatches
       2MB   0.7% 92.96%        2MB   0.7%  runtime.allocm
       2MB   0.7% 93.67%       10MB  3.52%  github.com/segmentio/kafka-go.(*Writer).produce
```

On tested application allocations were also reduced.