### PR TITLE
add WriterData field to the message struct

### DIFF
--- a/message.go
+++ b/message.go
@@ -23,7 +23,6 @@ type Message struct {
 	// This field is used to hold arbitrary data you wish to include, so it
 	// will be available when handle it on the Writer's `Completion` method,
 	// this support the application can do any post operation on each message.
-	// notion: this won't be sent to kafka broker.
 	WriterData interface{}
 
 	// If not set at the creation, Time will be automatically set when

--- a/message.go
+++ b/message.go
@@ -20,6 +20,10 @@ type Message struct {
 	Value         []byte
 	Headers       []Header
 
+	// This field is used to hold arbitrary data you wish to include so it
+	// will be available when handle it on the Writer's `Completion` method
+	Metadata interface{}
+
 	// If not set at the creation, Time will be automatically set when
 	// writing the message.
 	Time time.Time

--- a/message.go
+++ b/message.go
@@ -20,9 +20,11 @@ type Message struct {
 	Value         []byte
 	Headers       []Header
 
-	// This field is used to hold arbitrary data you wish to include so it
-	// will be available when handle it on the Writer's `Completion` method
-	Metadata interface{}
+	// This field is used to hold arbitrary data you wish to include, so it
+	// will be available when handle it on the Writer's `Completion` method,
+	// this support the application can do any post operation on each message.
+	// notion: this won't be sent to kafka broker.
+	WriterData interface{}
 
 	// If not set at the creation, Time will be automatically set when
 	// writing the message.

--- a/writer_test.go
+++ b/writer_test.go
@@ -744,7 +744,7 @@ func testWriteMessageWithWriterData(t *testing.T) {
 		for _, msg := range messages {
 			meta := msg.WriterData.(int)
 			if index != meta {
-				t.Errorf("metadata is not correct, index = %d, meta = %d", index, meta)
+				t.Errorf("metadata is not correct, index = %d, writerData = %d", index, meta)
 			}
 			index += 1
 		}

--- a/writer_test.go
+++ b/writer_test.go
@@ -746,7 +746,7 @@ func testWriteMessageWithMetadata(t *testing.T) {
 
 	}
 
-	msg := Message{Key: []byte("key"), Value: []byte("Hello World")}
+	msg := Message{Topic: topic, Key: []byte("key"), Value: []byte("Hello World")}
 
 	const retries = 5
 	for i := 0; i < retries; i++ {

--- a/writer_test.go
+++ b/writer_test.go
@@ -733,24 +733,27 @@ func testWriteMessageWithMetadata(t *testing.T) {
 	})
 	defer w.Close()
 
+	const count = 5
+	expected := 10
+	result := 0
 	w.Completion = func(messages []Message, err error) {
 		if err != nil {
 			t.Errorf("unexpected error %v", err)
 		}
 
-		for i, msg := range messages {
+		for _, msg := range messages {
 			meta := msg.Metadata.(int)
-			if i != meta {
-				t.Errorf("metadata is not correct, i = %d, meta = %d", i, meta)
-			}
+			result += meta
 		}
 
+		if expected != result {
+			t.Errorf("metadata is not correct, expected = %d, result = %d", expected, result)
+		}
 	}
 
 	msg := Message{Key: []byte("key"), Value: []byte("Hello World")}
 
-	const retries = 5
-	for i := 0; i < retries; i++ {
+	for i := 0; i < count; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -175,8 +175,8 @@ func TestWriter(t *testing.T) {
 			function: testWriterDefaults,
 		},
 		{
-			scenario: "test write message with metadata",
-			function: testWriteMessageWithMetadata,
+			scenario: "test write message with writer data",
+			function: testWriteMessageWithWriterData,
 		},
 	}
 
@@ -723,7 +723,7 @@ func testWriterUnexpectedMessageTopic(t *testing.T) {
 	}
 }
 
-func testWriteMessageWithMetadata(t *testing.T) {
+func testWriteMessageWithWriterData(t *testing.T) {
 	topic := makeTopic()
 	createTopic(t, topic, 1)
 	defer deleteTopic(t, topic)
@@ -742,7 +742,7 @@ func testWriteMessageWithMetadata(t *testing.T) {
 		}
 
 		for _, msg := range messages {
-			meta := msg.Metadata.(int)
+			meta := msg.WriterData.(int)
 			if index != meta {
 				t.Errorf("metadata is not correct, index = %d, meta = %d", index, meta)
 			}
@@ -756,7 +756,7 @@ func testWriteMessageWithMetadata(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		msg.Metadata = i
+		msg.WriterData = i
 		err := w.WriteMessages(ctx, msg)
 		if err != nil {
 			t.Errorf("unexpected error %v", err)

--- a/writer_test.go
+++ b/writer_test.go
@@ -747,7 +747,7 @@ func testWriteMessageWithMetadata(t *testing.T) {
 
 	}
 
-	msg := Message{Topic: topic, Key: []byte("key"), Value: []byte("Hello World")}
+	msg := Message{Key: []byte("key"), Value: []byte("Hello World")}
 
 	const retries = 5
 	for i := 0; i < retries; i++ {

--- a/writer_test.go
+++ b/writer_test.go
@@ -733,8 +733,6 @@ func testWriteMessageWithWriterData(t *testing.T) {
 	})
 	defer w.Close()
 
-	const count = 5
-
 	index := 0
 	w.Completion = func(messages []Message, err error) {
 		if err != nil {
@@ -751,8 +749,7 @@ func testWriteMessageWithWriterData(t *testing.T) {
 	}
 
 	msg := Message{Key: []byte("key"), Value: []byte("Hello World")}
-
-	for i := 0; i < count; i++ {
+	for i := 0; i < 5; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -725,6 +725,7 @@ func testWriterUnexpectedMessageTopic(t *testing.T) {
 
 func testWriteMessageWithMetadata(t *testing.T) {
 	topic := makeTopic()
+	createTopic(t, topic, 1)
 	defer deleteTopic(t, topic)
 	w := newTestWriter(WriterConfig{
 		Topic:    topic,

--- a/writer_test.go
+++ b/writer_test.go
@@ -734,8 +734,8 @@ func testWriteMessageWithMetadata(t *testing.T) {
 	defer w.Close()
 
 	const count = 5
-	expected := 10
-	result := 0
+
+	index := 0
 	w.Completion = func(messages []Message, err error) {
 		if err != nil {
 			t.Errorf("unexpected error %v", err)
@@ -743,11 +743,10 @@ func testWriteMessageWithMetadata(t *testing.T) {
 
 		for _, msg := range messages {
 			meta := msg.Metadata.(int)
-			result += meta
-		}
-
-		if expected != result {
-			t.Errorf("metadata is not correct, expected = %d, result = %d", expected, result)
+			if index != meta {
+				t.Errorf("metadata is not correct, index = %d, meta = %d", index, meta)
+			}
+			index += 1
 		}
 	}
 


### PR DESCRIPTION
close #1054 

This PR adds a new field `metadata interface{}` into the `message` struct, which can be used to hold any information, this can be helpful for the application to do post work after confirming the message is delivered.

