### PR TITLE
Avoid unnecessary string allocation while decoding

### DIFF
--- a/protocol/reflect.go
+++ b/protocol/reflect.go
@@ -5,6 +5,7 @@ package protocol
 
 import (
 	"reflect"
+	"unsafe"
 )
 
 type index []int
@@ -95,4 +96,4 @@ func (a array) isNil() bool { return a.val.IsNil() }
 
 func indexOf(s reflect.StructField) index { return index(s.Index) }
 
-func bytesToString(b []byte) string { return string(b) }
+func bytesToString(b []byte) string { return *(*string)(unsafe.Pointer(&b)) }


### PR DESCRIPTION
https://github.com/segmentio/kafka-go/issues/1061

I realized memory increase in our application and I dumped the heap usage and saw that kafka-go library allocates a lot of heap memory. 

I found a solution for bytesToString memory leak, by using the unsafe package we can convert byte to string or string to byte without extra allocation.