### PR TITLE
Use buffer pool for decompressed buffer

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -81,6 +81,7 @@ func (batch *Batch) close() (err error) {
 	batch.lock = nil
 	if batch.msgs != nil {
 		batch.msgs.discard()
+		releaseBuffer(batch.msgs.decompressed)
 	}
 
 	if err = batch.err; errors.Is(batch.err, io.EOF) {

--- a/batch.go
+++ b/batch.go
@@ -79,9 +79,14 @@ func (batch *Batch) close() (err error) {
 
 	batch.conn = nil
 	batch.lock = nil
+
 	if batch.msgs != nil {
 		batch.msgs.discard()
+	}
+
+	if batch.msgs != nil && batch.msgs.decompressed != nil {
 		releaseBuffer(batch.msgs.decompressed)
+		batch.msgs.decompressed = nil
 	}
 
 	if err = batch.err; errors.Is(batch.err, io.EOF) {


### PR DESCRIPTION
Directly using batch.Read or through the Reader interface requires creating new batch using `conn.ReadBatchWith`. This causes the decompressed buffer to be allocated fresh and requires repeated calls to Grow and then it is discarded on batch.Close.

To avoid this, this patch acquires new buffer when creating newMessageSetReader and releases it in batch.Close.