### PR TITLE
add finalizer to Reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"runtime"
 	"sort"
 	"strconv"
 	"sync"
@@ -741,6 +742,12 @@ func NewReader(config ReaderConfig) *Reader {
 		}
 		go r.run(cg)
 	}
+
+	runtime.SetFinalizer(r, func(r *Reader) {
+		go func() {
+			_ = r.Close()
+		}()
+	})
 
 	return r
 }


### PR DESCRIPTION
we run into issues where users don't call Close() on their readers before creating new ones. This causes issues with the consumer groups as more members are added to the group which can exceed the number of partitions and stop work. This should prevent that from happening in some cases by setting a finalizer which closes the Reader