### PR TITLE
Remove runtime.Gosched

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1419,7 +1418,6 @@ func (c *Conn) waitResponse(d *connDeadline, id int32) (deadline time.Time, size
 		// Optimistically release the read lock if a response has already
 		// been received but the current operation is not the target for it.
 		c.rlock.Unlock()
-		runtime.Gosched()
 	}
 
 	c.leave()


### PR DESCRIPTION
After [go 1.14](https://go.dev/doc/go1.14), go scheduler can interrupt without function call and can ensure that goroutines get fair access to the processor.  Moreover, it could decrease performance because of intentional goroutine switching.