### PR TITLE
add a new metric named `batchQueueTime` to track the batch time cost

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1088,14 +1088,14 @@ func (ptw *partitionWriter) awaitBatch(batch *writeBatch) {
 		// having it leak until it expires.
 		batch.timer.Stop()
 	}
-}
-
-func (ptw *partitionWriter) writeBatch(batch *writeBatch) {
 	stats := ptw.w.stats()
 	stats.batchTime.observe(int64(time.Since(batch.time)))
 	stats.batchSize.observe(int64(len(batch.msgs)))
 	stats.batchSizeBytes.observe(batch.bytes)
+}
 
+func (ptw *partitionWriter) writeBatch(batch *writeBatch) {
+	stats := ptw.w.stats()
 	var res *ProduceResponse
 	var err error
 	key := ptw.meta

--- a/writer.go
+++ b/writer.go
@@ -1100,6 +1100,7 @@ func (ptw *partitionWriter) writeBatch(batch *writeBatch) {
 	stats.batchTime.observe(int64(time.Since(batch.time)))
 	stats.batchSize.observe(int64(len(batch.msgs)))
 	stats.batchSizeBytes.observe(batch.bytes)
+
 	var res *ProduceResponse
 	var err error
 	key := ptw.meta

--- a/writer.go
+++ b/writer.go
@@ -27,29 +27,29 @@ import (
 // by the function and test if it an instance of kafka.WriteErrors in order to
 // identify which messages have succeeded or failed, for example:
 //
-//	// Construct a synchronous writer (the default mode).
-//	w := &kafka.Writer{
-//		Addr:         Addr: kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
-//		Topic:        "topic-A",
-//		RequiredAcks: kafka.RequireAll,
-//	}
-//
-//	...
-//
-//  // Passing a context can prevent the operation from blocking indefinitely.
-//	switch err := w.WriteMessages(ctx, msgs...).(type) {
-//	case nil:
-//	case kafka.WriteErrors:
-//		for i := range msgs {
-//			if err[i] != nil {
-//				// handle the error writing msgs[i]
-//				...
-//			}
+//		// Construct a synchronous writer (the default mode).
+//		w := &kafka.Writer{
+//			Addr:         Addr: kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
+//			Topic:        "topic-A",
+//			RequiredAcks: kafka.RequireAll,
 //		}
-//	default:
-//		// handle other errors
+//
 //		...
-//	}
+//
+//	 // Passing a context can prevent the operation from blocking indefinitely.
+//		switch err := w.WriteMessages(ctx, msgs...).(type) {
+//		case nil:
+//		case kafka.WriteErrors:
+//			for i := range msgs {
+//				if err[i] != nil {
+//					// handle the error writing msgs[i]
+//					...
+//				}
+//			}
+//		default:
+//			// handle other errors
+//			...
+//		}
 //
 // In asynchronous mode, the program may configure a completion handler on the
 // writer to receive notifications of messages being written to kafka:
@@ -348,12 +348,13 @@ type WriterStats struct {
 	Bytes    int64 `metric:"kafka.writer.message.bytes"   type:"counter"`
 	Errors   int64 `metric:"kafka.writer.error.count"     type:"counter"`
 
-	BatchTime  DurationStats `metric:"kafka.writer.batch.seconds"`
-	WriteTime  DurationStats `metric:"kafka.writer.write.seconds"`
-	WaitTime   DurationStats `metric:"kafka.writer.wait.seconds"`
-	Retries    int64         `metric:"kafka.writer.retries.count" type:"counter"`
-	BatchSize  SummaryStats  `metric:"kafka.writer.batch.size"`
-	BatchBytes SummaryStats  `metric:"kafka.writer.batch.bytes"`
+	BatchTime      DurationStats `metric:"kafka.writer.batch.seconds"`
+	BatchQueueTime DurationStats `metric:"kafka.writer.batch.queue.seconds"`
+	WriteTime      DurationStats `metric:"kafka.writer.write.seconds"`
+	WaitTime       DurationStats `metric:"kafka.writer.wait.seconds"`
+	Retries        int64         `metric:"kafka.writer.retries.count" type:"counter"`
+	BatchSize      SummaryStats  `metric:"kafka.writer.batch.size"`
+	BatchBytes     SummaryStats  `metric:"kafka.writer.batch.bytes"`
 
 	MaxAttempts     int64         `metric:"kafka.writer.attempts.max"  type:"gauge"`
 	WriteBackoffMin time.Duration `metric:"kafka.writer.backoff.min"   type:"gauge"`
@@ -398,6 +399,7 @@ type writerStats struct {
 	errors         counter
 	dialTime       summary
 	batchTime      summary
+	batchQueueTime summary
 	writeTime      summary
 	waitTime       summary
 	retries        counter
@@ -880,6 +882,7 @@ func (w *Writer) Stats() WriterStats {
 		Errors:          stats.errors.snapshot(),
 		DialTime:        stats.dialTime.snapshotDuration(),
 		BatchTime:       stats.batchTime.snapshotDuration(),
+		BatchQueueTime:  stats.batchQueueTime.snapshotDuration(),
 		WriteTime:       stats.writeTime.snapshotDuration(),
 		WaitTime:        stats.waitTime.snapshotDuration(),
 		Retries:         stats.retries.snapshot(),
@@ -1089,13 +1092,14 @@ func (ptw *partitionWriter) awaitBatch(batch *writeBatch) {
 		batch.timer.Stop()
 	}
 	stats := ptw.w.stats()
-	stats.batchTime.observe(int64(time.Since(batch.time)))
-	stats.batchSize.observe(int64(len(batch.msgs)))
-	stats.batchSizeBytes.observe(batch.bytes)
+	stats.batchQueueTime.observe(int64(time.Since(batch.time)))
 }
 
 func (ptw *partitionWriter) writeBatch(batch *writeBatch) {
 	stats := ptw.w.stats()
+	stats.batchTime.observe(int64(time.Since(batch.time)))
+	stats.batchSize.observe(int64(len(batch.msgs)))
+	stats.batchSizeBytes.observe(batch.bytes)
 	var res *ProduceResponse
 	var err error
 	key := ptw.meta


### PR DESCRIPTION
close #1101

* After a batch is resolved, record the batch duration immediately.