### PR TITLE
Configurable Message.Key and Message.Value bytes allocation functions

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -224,7 +224,7 @@ func (batch *Batch) ReadMessage() (Message, error) {
 				return
 			},
 			func(r *bufio.Reader, size int, nbytes int) (remain int, err error) {
-				msg.Key, remain, err = readIntoAllocatedBytes(r, size, nbytes, batch.makeValBytes)
+				msg.Value, remain, err = readIntoAllocatedBytes(r, size, nbytes, batch.makeValBytes)
 				return
 			},
 		)

--- a/batch.go
+++ b/batch.go
@@ -38,6 +38,11 @@ type Batch struct {
 	// we get an EOF we do not get the lastOffset. So there is a mismatch
 	// between when we receive it and need to use it.
 	lastOffset int64
+
+	// makeKeyBytes is used to create a bytes slice for Message.Key with given length.
+	makeKeyBytes func(length int) []byte
+	// makeValBytes is used to create a bytes slice for Message.Value with given length.
+	makeValBytes func(length int) []byte
 }
 
 // Throttle gives the throttling duration applied by the kafka server on the
@@ -199,11 +204,11 @@ func (batch *Batch) ReadMessage() (Message, error) {
 
 	offset, timestamp, headers, err = batch.readMessage(
 		func(r *bufio.Reader, size int, nbytes int) (remain int, err error) {
-			msg.Key, remain, err = readNewBytes(r, size, nbytes)
+			msg.Key, remain, err = readIntoAllocatedBytes(r, size, nbytes, batch.makeKeyBytes)
 			return
 		},
 		func(r *bufio.Reader, size int, nbytes int) (remain int, err error) {
-			msg.Value, remain, err = readNewBytes(r, size, nbytes)
+			msg.Value, remain, err = readIntoAllocatedBytes(r, size, nbytes, batch.makeValBytes)
 			return
 		},
 	)
@@ -215,11 +220,11 @@ func (batch *Batch) ReadMessage() (Message, error) {
 		}
 		offset, timestamp, headers, err = batch.readMessage(
 			func(r *bufio.Reader, size int, nbytes int) (remain int, err error) {
-				msg.Key, remain, err = readNewBytes(r, size, nbytes)
+				msg.Key, remain, err = readIntoAllocatedBytes(r, size, nbytes, batch.makeKeyBytes)
 				return
 			},
 			func(r *bufio.Reader, size int, nbytes int) (remain int, err error) {
-				msg.Value, remain, err = readNewBytes(r, size, nbytes)
+				msg.Key, remain, err = readIntoAllocatedBytes(r, size, nbytes, batch.makeValBytes)
 				return
 			},
 		)

--- a/conn.go
+++ b/conn.go
@@ -123,6 +123,11 @@ type ReadBatchConfig struct {
 	// For backward compatibility, when this field is left zero, kafka-go will
 	// infer the max wait from the connection's read deadline.
 	MaxWait time.Duration
+
+	// MakeKeyBytes is used to create a bytes slice for Message.Key with given length.
+	MakeKeyBytes func(length int) []byte
+	// MakeValBytes is used to create a bytes slice for Message.Value with given length.
+	MakeValBytes func(length int) []byte
 }
 
 type IsolationLevel int8
@@ -867,6 +872,14 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 	if errors.Is(err, errShortRead) {
 		err = checkTimeoutErr(adjustedDeadline)
 	}
+	makeKeyBytes := cfg.MakeKeyBytes
+	if makeKeyBytes == nil {
+		makeKeyBytes = func(len int) []byte { return make([]byte, len) }
+	}
+	makeValBytes := cfg.MakeValBytes
+	if makeValBytes == nil {
+		makeValBytes = func(len int) []byte { return make([]byte, len) }
+	}
 
 	return &Batch{
 		conn:          c,
@@ -883,6 +896,9 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 		// don't accidentally signal that we successfully reached the end of the
 		// batch.
 		err: dontExpectEOF(err),
+
+		makeKeyBytes: makeKeyBytes,
+		makeValBytes: makeValBytes,
 	}
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -12,11 +12,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/segmentio/kafka-go/compress/gzip"
 	"github.com/segmentio/kafka-go/compress/lz4"
 	"github.com/segmentio/kafka-go/compress/snappy"
 	"github.com/segmentio/kafka-go/compress/zstd"
-	"github.com/stretchr/testify/require"
 )
 
 // This regression test covers reading messages using offsets that

--- a/read.go
+++ b/read.go
@@ -141,7 +141,7 @@ func readBytesWith(r *bufio.Reader, sz int, cb func(*bufio.Reader, int, int) (in
 	return cb(r, sz, n)
 }
 
-// readIntoAllocatedBytes reads n bytes from r into a slice provided by makeBytes, which should should provide a slice with the required length.
+// readIntoAllocatedBytes reads n bytes from r into a slice provided by makeBytes, which should provide a slice with the required length.
 // This slice is then returned, as well as the number of bytes remaining and an error, if any.
 func readIntoAllocatedBytes(r *bufio.Reader, sz int, n int, makeBytes func(length int) []byte) ([]byte, int, error) {
 	var err error

--- a/read.go
+++ b/read.go
@@ -141,7 +141,9 @@ func readBytesWith(r *bufio.Reader, sz int, cb func(*bufio.Reader, int, int) (in
 	return cb(r, sz, n)
 }
 
-func readNewBytes(r *bufio.Reader, sz int, n int) ([]byte, int, error) {
+// readIntoAllocatedBytes reads n bytes from r into a slice provided by makeBytes, which should should provide a slice with the required length.
+// This slice is then returned, as well as the number of bytes remaining and an error, if any.
+func readIntoAllocatedBytes(r *bufio.Reader, sz int, n int, makeBytes func(length int) []byte) ([]byte, int, error) {
 	var err error
 	var b []byte
 	var shortRead bool
@@ -152,7 +154,7 @@ func readNewBytes(r *bufio.Reader, sz int, n int) ([]byte, int, error) {
 			shortRead = true
 		}
 
-		b = make([]byte, n)
+		b = makeBytes(n)
 		n, err = io.ReadFull(r, b)
 		b = b[:n]
 		sz -= n
@@ -163,6 +165,10 @@ func readNewBytes(r *bufio.Reader, sz int, n int) ([]byte, int, error) {
 	}
 
 	return b, sz, err
+}
+
+func readNewBytes(r *bufio.Reader, sz int, n int) ([]byte, int, error) {
+	return readIntoAllocatedBytes(r, sz, n, func(length int) []byte { return make([]byte, length) })
 }
 
 func readArrayLen(r *bufio.Reader, sz int, n *int) (int, error) {

--- a/reader.go
+++ b/reader.go
@@ -520,6 +520,11 @@ type ReaderConfig struct {
 	// This flag is being added to retain backwards-compatibility, so it will be
 	// removed in a future version of kafka-go.
 	OffsetOutOfRangeError bool
+
+	// MakeKeyBytes is used to create a bytes slice for Message.Key with given length.
+	MakeKeyBytes func(length int) []byte
+	// MakeValBytes is used to create a bytes slice for Message.Value with given length.
+	MakeValBytes func(length int) []byte
 }
 
 // Validate method validates ReaderConfig properties.
@@ -1211,6 +1216,8 @@ func (r *Reader) start(offsetsByPartition map[topicPartition]int64) {
 				stats:            r.stats,
 				isolationLevel:   r.config.IsolationLevel,
 				maxAttempts:      r.config.MaxAttempts,
+				makeKeyBytes:     r.config.MakeKeyBytes,
+				makeValBytes:     r.config.MakeValBytes,
 
 				// backwards-compatibility flags
 				offsetOutOfRangeError: r.config.OffsetOutOfRangeError,
@@ -1240,6 +1247,8 @@ type reader struct {
 	stats            *readerStats
 	isolationLevel   IsolationLevel
 	maxAttempts      int
+	makeKeyBytes     func(length int) []byte
+	makeValBytes     func(length int) []byte
 
 	offsetOutOfRangeError bool
 }
@@ -1496,6 +1505,8 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 		MinBytes:       r.minBytes,
 		MaxBytes:       r.maxBytes,
 		IsolationLevel: r.isolationLevel,
+		MakeKeyBytes:   r.makeKeyBytes,
+		MakeValBytes:   r.makeValBytes,
 	})
 	highWaterMark := batch.HighWaterMark()
 


### PR DESCRIPTION
I've seen in the profiles that a big amount of allocations come from creating the slices for `Key` and `Value` fields of `Message` through `readNewBytes`.

I can understand that we don't want to make clients accountable for properly releasing those slices by default, as that can be an unnecessary toil for many. However, in high performance applications it would be nice to have control over this.