### PR TITLE
Add count/sum to SummaryStats and DurationStats.

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -6,19 +6,21 @@ import (
 )
 
 // SummaryStats is a data structure that carries a summary of observed values.
-// The average, minimum, and maximum are reported.
 type SummaryStats struct {
-	Avg int64 `metric:"avg" type:"gauge"`
-	Min int64 `metric:"min" type:"gauge"`
-	Max int64 `metric:"max" type:"gauge"`
+	Avg   int64 `metric:"avg" type:"gauge"`
+	Min   int64 `metric:"min" type:"gauge"`
+	Max   int64 `metric:"max" type:"gauge"`
+	Count int64 `metric:"count" type:"counter"`
+	Sum   int64 `metric:"sum" type:"counter"`
 }
 
-// DurationStats is a data structure that carries a summary of observed duration
-// values. The average, minimum, and maximum are reported.
+// DurationStats is a data structure that carries a summary of observed duration values.
 type DurationStats struct {
-	Avg time.Duration `metric:"avg" type:"gauge"`
-	Min time.Duration `metric:"min" type:"gauge"`
-	Max time.Duration `metric:"max" type:"gauge"`
+	Avg   time.Duration `metric:"avg" type:"gauge"`
+	Min   time.Duration `metric:"min" type:"gauge"`
+	Max   time.Duration `metric:"max" type:"gauge"`
+	Count int64         `metric:"count" type:"counter"`
+	Sum   time.Duration `metric:"sum" type:"counter"`
 }
 
 // counter is an atomic incrementing counter which gets reset on snapshot.
@@ -167,17 +169,21 @@ func (s *summary) snapshot() SummaryStats {
 	}
 
 	return SummaryStats{
-		Avg: avg,
-		Min: min,
-		Max: max,
+		Avg:   avg,
+		Min:   min,
+		Max:   max,
+		Count: count,
+		Sum:   sum,
 	}
 }
 
 func (s *summary) snapshotDuration() DurationStats {
 	summary := s.snapshot()
 	return DurationStats{
-		Avg: time.Duration(summary.Avg),
-		Min: time.Duration(summary.Min),
-		Max: time.Duration(summary.Max),
+		Avg:   time.Duration(summary.Avg),
+		Min:   time.Duration(summary.Min),
+		Max:   time.Duration(summary.Max),
+		Count: summary.Count,
+		Sum:   time.Duration(summary.Sum),
 	}
 }


### PR DESCRIPTION
This PR adds `Count` and `Sum` fields into `SummaryStats` and `DurationStats`. These fields are useful when converting stats into Prometheus counters or summaries. Here is how we use them in our code:

```go

type writerMetrics struct {
	writer *kafka.Writer

	// ignoring other metrics in this example
	batchTime, batchBytes *summary
}

func (wm *writerMetrics) updateStats() {
	ws := wm.writer.Stats()

	// ignoring other metrics in this example
	wm.batchTime.add(ws.BatchTime.Count, ws.BatchTime.Sum.Seconds()) // here we use new Count and Sum fields.
	wm.batchBytes.add(ws.BatchBytes.Count, float64(ws.BatchBytes.Sum))
}

// summary is registered into Prometheus registrerer, see newSummary below.
type summary struct {
	desc *prometheus.Desc

	mu    sync.Mutex
	count uint64
	sum   float64
}

func newSummary(name, help string, reg prometheus.Registerer) *summary {
	s := &summary{
		desc: prometheus.NewDesc(name, help, nil, nil),
	}
	if reg != nil {
		reg.MustRegister(s)
	}
	return s
}

func (s *summary) add(count int64, sum float64) {
	s.mu.Lock()
	s.count += uint64(count)
	s.sum += sum
	s.mu.Unlock()
}

func (s *summary) Describe(descs chan<- *prometheus.Desc) {
	descs <- s.desc
}

func (s *summary) Collect(metrics chan<- prometheus.Metric) {
	s.mu.Lock()
	count, sum := s.count, s.sum
	s.mu.Unlock()

	metrics <- prometheus.MustNewConstSummary(s.desc, count, sum, nil)
}
```