### PR TITLE
offsetfetch request topics are now nullable

### DIFF
--- a/offsetfetch.go
+++ b/offsetfetch.go
@@ -84,6 +84,11 @@ func (c *Client) OffsetFetch(ctx context.Context, req *OffsetFetchRequest) (*Off
 	var offsetFetchReq *offsetfetch.Request
 
 	if len(req.Topics) < 1 {
+		// Kafka version 0.10.2.x and above allow null Topics map for OffsetFetch API
+		// which will return the result for all topics with the desired consumer group:
+		// https://kafka.apache.org/0102/protocol.html#The_Messages_OffsetFetch
+		// For Kafka version below 0.10.2.x this call will result in an error
+
 		offsetFetchReq = &offsetfetch.Request{
 			GroupID: req.GroupID,
 		}

--- a/offsetfetch.go
+++ b/offsetfetch.go
@@ -81,10 +81,20 @@ func (c *Client) OffsetFetch(ctx context.Context, req *OffsetFetchRequest) (*Off
 		})
 	}
 
-	m, err := c.roundTrip(ctx, req.Addr, &offsetfetch.Request{
-		GroupID: req.GroupID,
-		Topics:  topics,
-	})
+	var offsetFetchReq *offsetfetch.Request
+
+	if len(req.Topics) < 1 {
+		offsetFetchReq = &offsetfetch.Request{
+			GroupID: req.GroupID,
+		}
+	} else {
+		offsetFetchReq = &offsetfetch.Request{
+			GroupID: req.GroupID,
+			Topics:  topics,
+		}
+	}
+
+	m, err := c.roundTrip(ctx, req.Addr, offsetFetchReq)
 
 	if err != nil {
 		return nil, fmt.Errorf("kafka.(*Client).OffsetFetch: %w", err)

--- a/offsetfetch.go
+++ b/offsetfetch.go
@@ -66,40 +66,34 @@ type OffsetFetchPartition struct {
 // OffsetFetch sends an offset fetch request to a kafka broker and returns the
 // response.
 func (c *Client) OffsetFetch(ctx context.Context, req *OffsetFetchRequest) (*OffsetFetchResponse, error) {
-	topics := make([]offsetfetch.RequestTopic, 0, len(req.Topics))
 
-	for topicName, partitions := range req.Topics {
-		indexes := make([]int32, len(partitions))
+	// Kafka version 0.10.2.x and above allow null Topics map for OffsetFetch API
+	// which will return the result for all topics with the desired consumer group:
+	// https://kafka.apache.org/0102/protocol.html#The_Messages_OffsetFetch
+	// For Kafka version below 0.10.2.x this call will result in an error
+	var topics []offsetfetch.RequestTopic
 
-		for i, p := range partitions {
-			indexes[i] = int32(p)
-		}
+	if len(req.Topics) > 0 {
+		topics = make([]offsetfetch.RequestTopic, 0, len(req.Topics))
 
-		topics = append(topics, offsetfetch.RequestTopic{
-			Name:             topicName,
-			PartitionIndexes: indexes,
-		})
-	}
+		for topicName, partitions := range req.Topics {
+			indexes := make([]int32, len(partitions))
 
-	var offsetFetchReq *offsetfetch.Request
+			for i, p := range partitions {
+				indexes[i] = int32(p)
+			}
 
-	if len(req.Topics) < 1 {
-		// Kafka version 0.10.2.x and above allow null Topics map for OffsetFetch API
-		// which will return the result for all topics with the desired consumer group:
-		// https://kafka.apache.org/0102/protocol.html#The_Messages_OffsetFetch
-		// For Kafka version below 0.10.2.x this call will result in an error
-
-		offsetFetchReq = &offsetfetch.Request{
-			GroupID: req.GroupID,
-		}
-	} else {
-		offsetFetchReq = &offsetfetch.Request{
-			GroupID: req.GroupID,
-			Topics:  topics,
+			topics = append(topics, offsetfetch.RequestTopic{
+				Name:             topicName,
+				PartitionIndexes: indexes,
+			})
 		}
 	}
 
-	m, err := c.roundTrip(ctx, req.Addr, offsetFetchReq)
+	m, err := c.roundTrip(ctx, req.Addr, &offsetfetch.Request{
+		GroupID: req.GroupID,
+		Topics:  topics,
+	})
 
 	if err != nil {
 		return nil, fmt.Errorf("kafka.(*Client).OffsetFetch: %w", err)

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -3,8 +3,10 @@ package kafka
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestOffsetFetchResponseV1(t *testing.T) {
@@ -40,6 +42,114 @@ func TestOffsetFetchResponseV1(t *testing.T) {
 	}
 	if !reflect.DeepEqual(item, found) {
 		t.Error("expected item and found to be the same")
+		t.FailNow()
+	}
+}
+
+func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	topic1 := "t1"
+	topic2 := "t2"
+	consumeGroup := "cg"
+	numMsgs := 50
+	defer cancel()
+	r1 := NewReader(ReaderConfig{
+		Brokers:  []string{"localhost:9092"},
+		Topic:    topic1,
+		GroupID:  consumeGroup,
+		MinBytes: 1,
+		MaxBytes: 100,
+		MaxWait:  100 * time.Millisecond,
+	})
+	defer r1.Close()
+	prepareReader(t, ctx, r1, makeTestSequence(numMsgs)...)
+	r2 := NewReader(ReaderConfig{
+		Brokers:  []string{"localhost:9092"},
+		Topic:    topic2,
+		GroupID:  consumeGroup,
+		MinBytes: 1,
+		MaxBytes: 100,
+		MaxWait:  100 * time.Millisecond,
+	})
+	defer r2.Close()
+	prepareReader(t, ctx, r2, makeTestSequence(numMsgs)...)
+
+	for i := 0; i < numMsgs/2; i++ {
+		if _, err := r1.ReadMessage(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < numMsgs/2; i++ {
+		if _, err := r2.ReadMessage(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := Client{Addr: TCP("localhost:9092")}
+	topicOffsets, err := client.OffsetFetch(ctx, &OffsetFetchRequest{GroupID: "cg"})
+
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	if len(topicOffsets.Topics) != 2 {
+		t.Error(err)
+		t.FailNow()
+	}
+}
+
+func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	topic1 := "t1"
+	topic2 := "t2"
+	consumeGroup := "cg"
+	numMsgs := 50
+	defer cancel()
+	r1 := NewReader(ReaderConfig{
+		Brokers:  []string{"localhost:9092"},
+		Topic:    topic1,
+		GroupID:  consumeGroup,
+		MinBytes: 1,
+		MaxBytes: 100,
+		MaxWait:  100 * time.Millisecond,
+	})
+	defer r1.Close()
+	prepareReader(t, ctx, r1, makeTestSequence(numMsgs)...)
+	r2 := NewReader(ReaderConfig{
+		Brokers:  []string{"localhost:9092"},
+		Topic:    topic2,
+		GroupID:  consumeGroup,
+		MinBytes: 1,
+		MaxBytes: 100,
+		MaxWait:  100 * time.Millisecond,
+	})
+	defer r2.Close()
+	prepareReader(t, ctx, r2, makeTestSequence(numMsgs)...)
+
+	for i := 0; i < numMsgs/2; i++ {
+		if _, err := r1.ReadMessage(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < numMsgs/2; i++ {
+		if _, err := r2.ReadMessage(ctx); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client := Client{Addr: TCP("localhost:9092")}
+	topicOffsets, err := client.OffsetFetch(ctx, &OffsetFetchRequest{GroupID: "cg", Topics: map[string][]int{
+		topic1: {1},
+	}})
+
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	if len(topicOffsets.Topics) != 1 {
+		t.Error(err)
 		t.FailNow()
 	}
 }

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -101,44 +101,52 @@ func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
 
 func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	topic1 := "t1"
-	topic2 := "t2"
-	consumeGroup := "cg"
+	topic1 := makeTopic()
+	createTopic(t, topic1, 1)
+	defer deleteTopic(t, topic1)
+	consumeGroup := makeGroupID()
 	numMsgs := 50
 	defer cancel()
 	r1 := NewReader(ReaderConfig{
-		Brokers:  []string{"localhost:9092"},
-		Topic:    topic1,
-		GroupID:  consumeGroup,
-		MinBytes: 1,
-		MaxBytes: 100,
-		MaxWait:  100 * time.Millisecond,
+		Brokers:           []string{"localhost:9092"},
+		Topic:             topic1,
+		GroupID:           consumeGroup,
+		HeartbeatInterval: 2 * time.Second,
+		RebalanceTimeout:  2 * time.Second,
+		RetentionTime:     time.Hour,
+		MinBytes:          1,
+		MaxBytes:          1e6,
 	})
 	defer r1.Close()
 	prepareReader(t, ctx, r1, makeTestSequence(numMsgs)...)
+	client, topic2, shutdown := newLocalClientAndTopic()
+	defer deleteTopic(t, topic2)
+	defer shutdown()
 	r2 := NewReader(ReaderConfig{
-		Brokers:  []string{"localhost:9092"},
-		Topic:    topic2,
-		GroupID:  consumeGroup,
-		MinBytes: 1,
-		MaxBytes: 100,
-		MaxWait:  100 * time.Millisecond,
+		Brokers:           []string{"localhost:9092"},
+		Topic:             topic2,
+		GroupID:           r1.config.GroupID,
+		HeartbeatInterval: r1.config.HeartbeatInterval,
+		SessionTimeout:    r1.config.SessionTimeout,
+		RetentionTime:     r1.config.RetentionTime,
+		MinBytes:          r1.config.MinBytes,
+		MaxBytes:          r1.config.MaxBytes,
+		Logger:            r1.config.Logger,
 	})
 	defer r2.Close()
 	prepareReader(t, ctx, r2, makeTestSequence(numMsgs)...)
 
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r1.ReadMessage(ctx); err != nil {
+		if _, err := r1.FetchMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r2.ReadMessage(ctx); err != nil {
+		if _, err := r2.FetchMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	client := Client{Addr: TCP("localhost:9092")}
 	topicOffsets, err := client.OffsetFetch(ctx, &OffsetFetchRequest{GroupID: "cg", Topics: map[string][]int{
 		topic1: {1},
 	}})

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -75,12 +75,12 @@ func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
 	prepareReader(t, ctx, r2, makeTestSequence(numMsgs)...)
 
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r1.FetchMessage(ctx); err != nil {
+		if _, err := r1.ReadMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r2.FetchMessage(ctx); err != nil {
+		if _, err := r2.ReadMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -128,12 +128,12 @@ func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	prepareReader(t, ctx, r2, makeTestSequence(numMsgs)...)
 
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r1.FetchMessage(ctx); err != nil {
+		if _, err := r1.ReadMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r2.FetchMessage(ctx); err != nil {
+		if _, err := r2.ReadMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -148,7 +148,7 @@ func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	}
 
 	topicOffsets, err := client.OffsetFetch(ctx, &OffsetFetchRequest{GroupID: "cg", Topics: map[string][]int{
-		topic1: {1},
+		topic1: {0},
 	}})
 
 	if err != nil {

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -98,6 +98,7 @@ func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
 	for _, apiVersion := range apiVersions.ApiKeys {
 		if apiVersion.ApiKey == 9 && apiVersion.MaxVersion < 2 {
 			// skipping this test for clusters not supporting version >= 2 of OffsetFetch API
+			t.Logf("Test %s is not supported for OffsetFetch API versions below 2", t.Name())
 			t.SkipNow()
 		}
 	}
@@ -113,6 +114,7 @@ func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
+
 }
 
 func TestOffsetFetchRequestWithOneTopic(t *testing.T) {

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -102,7 +102,7 @@ func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
 func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	topic1 := makeTopic()
-	createTopic(t, topic1, 3)
+	createTopic(t, topic1, 1)
 	defer deleteTopic(t, topic1)
 	consumeGroup := makeGroupID()
 	numMsgs := 50
@@ -120,7 +120,7 @@ func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	defer r1.Close()
 	prepareReader(t, ctx, r1, makeTestSequence(numMsgs)...)
 	topic2 := makeTopic()
-	client, shutdown := newLocalClientWithTopic(topic2, 3)
+	client, shutdown := newLocalClientWithTopic(topic2, 1)
 	defer deleteTopic(t, topic2)
 	defer shutdown()
 	r2 := NewReader(ReaderConfig{
@@ -149,7 +149,7 @@ func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	}
 
 	topicOffsets, err := client.OffsetFetch(ctx, &OffsetFetchRequest{GroupID: "cg", Topics: map[string][]int{
-		topic1: {1},
+		topic1: {0},
 	}})
 
 	if err != nil {

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -102,7 +102,7 @@ func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
 func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	topic1 := makeTopic()
-	createTopic(t, topic1, 1)
+	createTopic(t, topic1, 3)
 	defer deleteTopic(t, topic1)
 	consumeGroup := makeGroupID()
 	numMsgs := 50
@@ -119,7 +119,8 @@ func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	})
 	defer r1.Close()
 	prepareReader(t, ctx, r1, makeTestSequence(numMsgs)...)
-	client, topic2, shutdown := newLocalClientAndTopic()
+	topic2 := makeTopic()
+	client, shutdown := newLocalClientWithTopic(topic2, 3)
 	defer deleteTopic(t, topic2)
 	defer shutdown()
 	r2 := NewReader(ReaderConfig{
@@ -148,7 +149,7 @@ func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	}
 
 	topicOffsets, err := client.OffsetFetch(ctx, &OffsetFetchRequest{GroupID: "cg", Topics: map[string][]int{
-		topic1: {0},
+		topic1: {1},
 	}})
 
 	if err != nil {

--- a/offsetfetch_test.go
+++ b/offsetfetch_test.go
@@ -75,12 +75,12 @@ func TestOffsetFetchRequestWithNoTopic(t *testing.T) {
 	prepareReader(t, ctx, r2, makeTestSequence(numMsgs)...)
 
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r1.ReadMessage(ctx); err != nil {
+		if _, err := r1.FetchMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r2.ReadMessage(ctx); err != nil {
+		if _, err := r2.FetchMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -128,12 +128,12 @@ func TestOffsetFetchRequestWithOneTopic(t *testing.T) {
 	prepareReader(t, ctx, r2, makeTestSequence(numMsgs)...)
 
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r1.ReadMessage(ctx); err != nil {
+		if _, err := r1.FetchMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for i := 0; i < numMsgs/2; i++ {
-		if _, err := r2.ReadMessage(ctx); err != nil {
+		if _, err := r2.FetchMessage(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/protocol/offsetfetch/offsetfetch.go
+++ b/protocol/offsetfetch/offsetfetch.go
@@ -8,7 +8,7 @@ func init() {
 
 type Request struct {
 	GroupID string         `kafka:"min=v0,max=v5"`
-	Topics  []RequestTopic `kafka:"min=v0,max=v5"`
+	Topics  []RequestTopic `kafka:"min=v0,max=v5,nullable"`
 }
 
 func (r *Request) ApiKey() protocol.ApiKey { return protocol.OffsetFetch }


### PR DESCRIPTION

### Issue
#1115 


### Fix 
made the "Topics" filed of offsetfetch's Request (https://github.com/segmentio/kafka-go/blob/main/protocol/offsetfetch/offsetfetch.go#L11)  nullable in order to make it compliant with Kafka API specs



### Testing

Setup: 

P1 ------> [T1] ------> {CG1} -------> C1
P12------> [T2] ------> {CG1} -------> C2


![offset-test-setup](https://github.com/segmentio/kafka-go/assets/106259585/96483f11-3ece-4060-896b-965548ed3585)

Test 1 driver

```package main

import (
	"context"
	"fmt"

	"github.com/segmentio/kafka-go"
)

func main() {
	fmt.Printf("START\n")
	ctx := context.Background()
	client := kafka.Client{Addr: kafka.TCP("localhost:9092")}
	topicOffsets, err := client.OffsetFetch(ctx, &kafka.OffsetFetchRequest{GroupID: "cg1"})
	if err != nil {
		fmt.Printf("ERROR: %s\n", err.Error())
	}
	fmt.Printf("number of topics %d\n", len(topicOffsets.Topics))
	for topic, offsets := range topicOffsets.Topics {
		fmt.Printf("###########################\n")
		fmt.Printf("offset for topic %s\n", topic)
		for _, offset := range offsets {
			fmt.Printf("\t###########################\n")
			fmt.Printf("\toffset.Partition=%d\n", offset.Partition)
			fmt.Printf("\toffset.CommittedOffset=%d\n", offset.CommittedOffset)
			fmt.Printf("\toffset.Metadata=%s\n", offset.Metadata)
		}
	}

}
```
output:

```
START
number of topics 2
###########################
offset for topic topic-secondary
	###########################
	offset.Partition=5
	offset.CommittedOffset=1349
	offset.Metadata=
	###########################
	offset.Partition=2
	offset.CommittedOffset=912
	offset.Metadata=
	###########################
	offset.Partition=4
	offset.CommittedOffset=228
	offset.Metadata=
	###########################
	offset.Partition=1
	offset.CommittedOffset=685
	offset.Metadata=
	###########################
	offset.Partition=0
	offset.CommittedOffset=687
	offset.Metadata=
	###########################
	offset.Partition=3
	offset.CommittedOffset=686
	offset.Metadata=
###########################
offset for topic topic-primary
	###########################
	offset.Partition=2
	offset.CommittedOffset=525
	offset.Metadata=
	###########################
	offset.Partition=5
	offset.CommittedOffset=1143
	offset.Metadata=
	###########################
	offset.Partition=3
	offset.CommittedOffset=684
	offset.Metadata=
	###########################
	offset.Partition=4
	offset.CommittedOffset=457
	offset.Metadata=
	###########################
	offset.Partition=1
	offset.CommittedOffset=913
	offset.Metadata=
	###########################
	offset.Partition=0
	offset.CommittedOffset=1502
	offset.Metadata=
```

Test 2 driver

```
package main

import (
	"context"
	"fmt"

	"github.com/segmentio/kafka-go"
)

func main() {
	fmt.Printf("START\n")
	ctx := context.Background()
	client := kafka.Client{Addr: kafka.TCP("localhost:9092")}
	topics := map[string][]int{
		"topic-primary": {1, 2, 3},
	}
	topicOffsets, err := client.OffsetFetch(ctx, &kafka.OffsetFetchRequest{GroupID: "cg1", Topics: topics})
	if err != nil {
		fmt.Printf("ERROR: %s\n", err.Error())
	}
	fmt.Printf("number of topics %d\n", len(topicOffsets.Topics))
	for topic, offsets := range topicOffsets.Topics {
		fmt.Printf("###########################\n")
		fmt.Printf("offset for topic %s\n", topic)
		for _, offset := range offsets {
			fmt.Printf("\t###########################\n")
			fmt.Printf("\toffset.Partition=%d\n", offset.Partition)
			fmt.Printf("\toffset.CommittedOffset=%d\n", offset.CommittedOffset)
			fmt.Printf("\toffset.Metadata=%s\n", offset.Metadata)
		}
	}

}
```

output:

```
START
number of topics 1
###########################
offset for topic topic-primary
	###########################
	offset.Partition=1
	offset.CommittedOffset=1360
	offset.Metadata=
	###########################
	offset.Partition=2
	offset.CommittedOffset=525
	offset.Metadata=
	###########################
	offset.Partition=3
	offset.CommittedOffset=912
	offset.Metadata=
```