### PR TITLE
Adds attempt number to log message when failing to write messages

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1156,7 +1156,7 @@ func (ptw *partitionWriter) writeBatch(batch *writeBatch) {
 		stats.errors.observe(1)
 
 		ptw.w.withErrorLogger(func(log Logger) {
-			log.Printf("error writing messages to %s (partition %d): %s", key.topic, key.partition, err)
+			log.Printf("error writing messages to %s (partition %d, attempt %d): %s", key.topic, key.partition, attempt, err)
 		})
 
 		if !isTemporary(err) && !isTransientNetworkError(err) {


### PR DESCRIPTION
This is done to make it easier to write better error logger implementations. For instance, when using IAM auth for MSK, the first write will fail after credentials rotate. The connection is re-negotiated and the retry is successful, but the logs are filled with errors. This lets us ignore the error of the first attempt, but log subsequent ones.