### PR TITLE
support userscramcredentials apis

### DIFF
--- a/alteruserscramcredentials.go
+++ b/alteruserscramcredentials.go
@@ -1,0 +1,115 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol/alteruserscramcredentials"
+)
+
+// AlterUserScramCredentialsRequest represents a request sent to a kafka broker to
+// alter user scram credentials.
+type AlterUserScramCredentialsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	// List of credentials to delete.
+	Deletions []UserScramCredentialsDeletion
+
+	// List of credentials to upsert.
+	Upsertions []UserScramCredentialsUpsertion
+}
+
+type ScramMechanism int8
+
+const (
+	ScramMechanismUnknown ScramMechanism = iota // 0
+	ScramMechanismSha256                        // 1
+	ScramMechanismSha512                        // 2
+)
+
+type UserScramCredentialsDeletion struct {
+	Name      string
+	Mechanism ScramMechanism
+}
+
+type UserScramCredentialsUpsertion struct {
+	Name           string
+	Mechanism      ScramMechanism
+	Iterations     int32
+	Salt           []byte
+	SaltedPassword []byte
+}
+
+// AlterUserScramCredentialsResponse represents a response from a kafka broker to an alter user
+// credentials request.
+type AlterUserScramCredentialsResponse struct {
+	// The amount of time that the broker throttled the request.
+	Throttle time.Duration
+
+	// List of errors that occurred while attempting to alter
+	// the user scram credentials.
+	//
+	// The errors contain the kafka error code. Programs may use the standard
+	// errors.Is function to test the error against kafka error codes.
+	Errors []error
+
+	// List of altered user scram credentials.
+	Results []AlterUserScramCredentialsResponseUsers
+}
+
+type AlterUserScramCredentialsResponseUsers struct {
+	User string
+}
+
+// AlterUserScramCredentials sends user scram credentials alteration request to a kafka broker and returns
+// the response.
+func (c *Client) AlterUserScramCredentials(ctx context.Context, req *AlterUserScramCredentialsRequest) (*AlterUserScramCredentialsResponse, error) {
+	deletions := make([]alteruserscramcredentials.RequestUserScramCredentialsDeletion, len(req.Deletions))
+	upsertions := make([]alteruserscramcredentials.RequestUserScramCredentialsUpsertion, len(req.Upsertions))
+
+	for deletionIdx, deletion := range req.Deletions {
+		deletions[deletionIdx] = alteruserscramcredentials.RequestUserScramCredentialsDeletion{
+			Name:      deletion.Name,
+			Mechanism: int8(deletion.Mechanism),
+		}
+	}
+
+	for upsertionIdx, upsertion := range req.Upsertions {
+		upsertions[upsertionIdx] = alteruserscramcredentials.RequestUserScramCredentialsUpsertion{
+			Name:           upsertion.Name,
+			Mechanism:      int8(upsertion.Mechanism),
+			Iterations:     upsertion.Iterations,
+			Salt:           upsertion.Salt,
+			SaltedPassword: upsertion.SaltedPassword,
+		}
+	}
+
+	m, err := c.roundTrip(ctx, req.Addr, &alteruserscramcredentials.Request{
+		Deletions:  deletions,
+		Upsertions: upsertions,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kafka.(*Client).AlterUserScramCredentials: %w", err)
+	}
+
+	res := m.(*alteruserscramcredentials.Response)
+	responseEntries := make([]AlterUserScramCredentialsResponseUsers, len(res.Results))
+	responseErrors := make([]error, len(res.Results))
+
+	for responseIdx, responseResult := range res.Results {
+		responseEntries[responseIdx] = AlterUserScramCredentialsResponseUsers{
+			User: responseResult.User,
+		}
+		responseErrors[responseIdx] = makeError(responseResult.ErrorCode, responseResult.ErrorMessage)
+	}
+	ret := &AlterUserScramCredentialsResponse{
+		Throttle: makeDuration(res.ThrottleTimeMs),
+		Errors:   responseErrors,
+		Results:  responseEntries,
+	}
+
+	return ret, nil
+}

--- a/alteruserscramcredentials.go
+++ b/alteruserscramcredentials.go
@@ -57,10 +57,10 @@ type AlterUserScramCredentialsResponse struct {
 	Errors []error
 
 	// List of altered user scram credentials.
-	Results []AlterUserScramCredentialsResponseUsers
+	Results []AlterUserScramCredentialsResponseUser
 }
 
-type AlterUserScramCredentialsResponseUsers struct {
+type AlterUserScramCredentialsResponseUser struct {
 	User string
 }
 
@@ -96,11 +96,11 @@ func (c *Client) AlterUserScramCredentials(ctx context.Context, req *AlterUserSc
 	}
 
 	res := m.(*alteruserscramcredentials.Response)
-	responseEntries := make([]AlterUserScramCredentialsResponseUsers, len(res.Results))
+	responseEntries := make([]AlterUserScramCredentialsResponseUser, len(res.Results))
 	responseErrors := make([]error, len(res.Results))
 
 	for responseIdx, responseResult := range res.Results {
-		responseEntries[responseIdx] = AlterUserScramCredentialsResponseUsers{
+		responseEntries[responseIdx] = AlterUserScramCredentialsResponseUser{
 			User: responseResult.User,
 		}
 		responseErrors[responseIdx] = makeError(responseResult.ErrorCode, responseResult.ErrorMessage)

--- a/alteruserscramcredentials.go
+++ b/alteruserscramcredentials.go
@@ -38,7 +38,7 @@ type UserScramCredentialsDeletion struct {
 type UserScramCredentialsUpsertion struct {
 	Name           string
 	Mechanism      ScramMechanism
-	Iterations     int32
+	Iterations     int
 	Salt           []byte
 	SaltedPassword []byte
 }

--- a/alteruserscramcredentials_test.go
+++ b/alteruserscramcredentials_test.go
@@ -19,7 +19,7 @@ func TestAlterUserScramCredentials(t *testing.T) {
 
 	createRes, err := client.AlterUserScramCredentials(context.Background(), &AlterUserScramCredentialsRequest{
 		Upsertions: []UserScramCredentialsUpsertion{
-			UserScramCredentialsUpsertion{
+			{
 				Name:           "alice",
 				Mechanism:      ScramMechanismSha512,
 				Iterations:     15000,
@@ -49,7 +49,7 @@ func TestAlterUserScramCredentials(t *testing.T) {
 
 	describeRes, err := client.DescribeUserScramCredentials(context.Background(), &DescribeUserScramCredentialsRequest{
 		Users: []UserScramCredentialsUser{
-			UserScramCredentialsUser{
+			{
 				Name: "alice",
 			},
 		},
@@ -63,10 +63,10 @@ func TestAlterUserScramCredentials(t *testing.T) {
 		Throttle: makeDuration(0),
 		Error:    makeError(0, ""),
 		Results: []DescribeUserScramCredentialsResponseResult{
-			DescribeUserScramCredentialsResponseResult{
+			{
 				User: "alice",
 				CredentialInfos: []DescribeUserScramCredentialsCredentialInfo{
-					DescribeUserScramCredentialsCredentialInfo{
+					{
 						Mechanism:  ScramMechanismSha512,
 						Iterations: 15000,
 					},

--- a/alteruserscramcredentials_test.go
+++ b/alteruserscramcredentials_test.go
@@ -1,0 +1,48 @@
+package kafka
+
+import (
+	"context"
+	"testing"
+
+	ktesting "github.com/segmentio/kafka-go/testing"
+)
+
+func TestAlterUserScramCredentials(t *testing.T) {
+	// https://issues.apache.org/jira/browse/KAFKA-10259
+	if !ktesting.KafkaIsAtLeast("2.7.0") {
+		return
+	}
+
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
+	res, err := client.AlterUserScramCredentials(context.Background(), &AlterUserScramCredentialsRequest{
+		Upsertions: []UserScramCredentialsUpsertion{
+			UserScramCredentialsUpsertion{
+				Name:           "alice",
+				Mechanism:      ScramMechanismSha512,
+				Iterations:     15000,
+				Salt:           []byte("my-salt"),
+				SaltedPassword: []byte("my-salted-password"),
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range res.Errors {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	if len(res.Results) != 1 {
+		t.Fatalf("expected 1 result; got %d", len(res.Results))
+	}
+
+	if res.Results[0].User != "alice" {
+		t.Fatalf("expected result with user alice, got %s", res.Results[0].User)
+	}
+}

--- a/alteruserscramcredentials_test.go
+++ b/alteruserscramcredentials_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	ktesting "github.com/segmentio/kafka-go/testing"
@@ -117,7 +118,7 @@ func TestAlterUserScramCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if describeDeletionRes.Error != makeError(0, "") {
+	if !errors.Is(describeDeletionRes.Error, makeError(0, "")) {
 		t.Fatalf("didn't expect a top level error on describe results after deletion, got %v", describeDeletionRes.Error)
 	}
 
@@ -133,5 +134,9 @@ func TestAlterUserScramCredentials(t *testing.T) {
 
 	if len(result.CredentialInfos) != 0 {
 		t.Fatalf("didn't expect describeResult credential infos, got %v", result.CredentialInfos)
+	}
+
+	if !errors.Is(result.Error, ResourceNotFound) {
+		t.Fatalf("expected describeResult resourcenotfound error, got %s", result.Error)
 	}
 }

--- a/alteruserscramcredentials_test.go
+++ b/alteruserscramcredentials_test.go
@@ -80,7 +80,7 @@ func TestAlterUserScramCredentials(t *testing.T) {
 
 	deleteRes, err := client.AlterUserScramCredentials(context.Background(), &AlterUserScramCredentialsRequest{
 		Deletions: []UserScramCredentialsDeletion{
-			UserScramCredentialsDeletion{
+			{
 				Name:      "alice",
 				Mechanism: ScramMechanismSha512,
 			},

--- a/alteruserscramcredentials_test.go
+++ b/alteruserscramcredentials_test.go
@@ -34,18 +34,16 @@ func TestAlterUserScramCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, err := range createRes.Errors {
-		if err != nil {
-			t.Error(err)
-		}
-	}
-
 	if len(createRes.Results) != 1 {
 		t.Fatalf("expected 1 createResult; got %d", len(createRes.Results))
 	}
 
 	if createRes.Results[0].User != name {
 		t.Fatalf("expected createResult with user: %s, got %s", name, createRes.Results[0].User)
+	}
+
+	if createRes.Results[0].Error != nil {
+		t.Fatalf("didn't expect an error in createResult, got %v", createRes.Results[0].Error)
 	}
 
 	deleteRes, err := client.AlterUserScramCredentials(context.Background(), &AlterUserScramCredentialsRequest{
@@ -61,17 +59,15 @@ func TestAlterUserScramCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, err := range deleteRes.Errors {
-		if err != nil {
-			t.Error(err)
-		}
-	}
-
 	if len(deleteRes.Results) != 1 {
 		t.Fatalf("expected 1 deleteResult; got %d", len(deleteRes.Results))
 	}
 
 	if deleteRes.Results[0].User != name {
 		t.Fatalf("expected deleteResult with user: %s, got %s", name, deleteRes.Results[0].User)
+	}
+
+	if deleteRes.Results[0].Error != nil {
+		t.Fatalf("didn't expect an error in deleteResult, got %v", deleteRes.Results[0].Error)
 	}
 }

--- a/describeuserscramcredentials.go
+++ b/describeuserscramcredentials.go
@@ -1,0 +1,97 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/segmentio/kafka-go/protocol/describeuserscramcredentials"
+)
+
+// DescribeUserScramCredentialsRequest represents a request sent to a kafka broker to
+// describe user scram credentials.
+type DescribeUserScramCredentialsRequest struct {
+	// Address of the kafka broker to send the request to.
+	Addr net.Addr
+
+	// List of Scram users to describe
+	Users []UserScramCredentialsUser
+}
+
+type UserScramCredentialsUser struct {
+	Name string
+}
+
+// DescribeUserScramCredentialsResponse represents a response from a kafka broker to a describe user
+// credentials request.
+type DescribeUserScramCredentialsResponse struct {
+	// The amount of time that the broker throttled the request.
+	Throttle time.Duration
+
+	// Top level error that occurred while attempting to describe
+	// the user scram credentials.
+	//
+	// The errors contain the kafka error code. Programs may use the standard
+	// errors.Is function to test the error against kafka error codes.
+	Error error
+
+	// List of describeed user scram credentials.
+	Results []DescribeUserScramCredentialsResponseResult
+}
+
+type DescribeUserScramCredentialsResponseResult struct {
+	User            string
+	CredentialInfos []DescribeUserScramCredentialsCredentialInfo
+	Error           error
+}
+
+type DescribeUserScramCredentialsCredentialInfo struct {
+	Mechanism  ScramMechanism
+	Iterations int32
+}
+
+// DescribeUserScramCredentials sends a user scram credentials describe request to a kafka broker and returns
+// the response.
+func (c *Client) DescribeUserScramCredentials(ctx context.Context, req *DescribeUserScramCredentialsRequest) (*DescribeUserScramCredentialsResponse, error) {
+	users := make([]describeuserscramcredentials.RequestUser, len(req.Users))
+
+	for userIdx, user := range req.Users {
+		users[userIdx] = describeuserscramcredentials.RequestUser{
+			Name: user.Name,
+		}
+	}
+
+	m, err := c.roundTrip(ctx, req.Addr, &describeuserscramcredentials.Request{
+		Users: users,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kafka.(*Client).DescribeUserScramCredentials: %w", err)
+	}
+
+	res := m.(*describeuserscramcredentials.Response)
+	responseResults := make([]DescribeUserScramCredentialsResponseResult, len(res.Results))
+
+	for responseIdx, responseResult := range res.Results {
+		credentialInfos := make([]DescribeUserScramCredentialsCredentialInfo, len(responseResult.CredentialInfos))
+
+		for credentialInfoIdx, credentialInfo := range responseResult.CredentialInfos {
+			credentialInfos[credentialInfoIdx] = DescribeUserScramCredentialsCredentialInfo{
+				Mechanism:  ScramMechanism(credentialInfo.Mechanism),
+				Iterations: credentialInfo.Iterations,
+			}
+		}
+		responseResults[responseIdx] = DescribeUserScramCredentialsResponseResult{
+			User:            responseResult.User,
+			CredentialInfos: credentialInfos,
+			Error:           makeError(responseResult.ErrorCode, responseResult.ErrorMessage),
+		}
+	}
+	ret := &DescribeUserScramCredentialsResponse{
+		Throttle: makeDuration(res.ThrottleTimeMs),
+		Error:    makeError(res.ErrorCode, res.ErrorMessage),
+		Results:  responseResults,
+	}
+
+	return ret, nil
+}

--- a/describeuserscramcredentials.go
+++ b/describeuserscramcredentials.go
@@ -36,7 +36,7 @@ type DescribeUserScramCredentialsResponse struct {
 	// errors.Is function to test the error against kafka error codes.
 	Error error
 
-	// List of describeed user scram credentials.
+	// List of described user scram credentials.
 	Results []DescribeUserScramCredentialsResponseResult
 }
 

--- a/describeuserscramcredentials.go
+++ b/describeuserscramcredentials.go
@@ -48,7 +48,7 @@ type DescribeUserScramCredentialsResponseResult struct {
 
 type DescribeUserScramCredentialsCredentialInfo struct {
 	Mechanism  ScramMechanism
-	Iterations int32
+	Iterations int
 }
 
 // DescribeUserScramCredentials sends a user scram credentials describe request to a kafka broker and returns

--- a/describeuserscramcredentials.go
+++ b/describeuserscramcredentials.go
@@ -78,7 +78,7 @@ func (c *Client) DescribeUserScramCredentials(ctx context.Context, req *Describe
 		for credentialInfoIdx, credentialInfo := range responseResult.CredentialInfos {
 			credentialInfos[credentialInfoIdx] = DescribeUserScramCredentialsCredentialInfo{
 				Mechanism:  ScramMechanism(credentialInfo.Mechanism),
-				Iterations: credentialInfo.Iterations,
+				Iterations: int(credentialInfo.Iterations),
 			}
 		}
 		responseResults[responseIdx] = DescribeUserScramCredentialsResponseResult{

--- a/describeuserscramcredentials_test.go
+++ b/describeuserscramcredentials_test.go
@@ -36,18 +36,16 @@ func TestDescribeUserScramCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, err := range createRes.Errors {
-		if err != nil {
-			t.Error(err)
-		}
-	}
-
 	if len(createRes.Results) != 1 {
 		t.Fatalf("expected 1 createResult; got %d", len(createRes.Results))
 	}
 
 	if createRes.Results[0].User != name {
 		t.Fatalf("expected createResult with user: %s, got %s", name, createRes.Results[0].User)
+	}
+
+	if createRes.Results[0].Error != nil {
+		t.Fatalf("didn't expect an error in createResult, got %v", createRes.Results[0].Error)
 	}
 
 	describeCreationRes, err := client.DescribeUserScramCredentials(context.Background(), &DescribeUserScramCredentialsRequest{
@@ -94,18 +92,16 @@ func TestDescribeUserScramCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, err := range deleteRes.Errors {
-		if err != nil {
-			t.Error(err)
-		}
-	}
-
 	if len(deleteRes.Results) != 1 {
 		t.Fatalf("expected 1 deleteResult; got %d", len(deleteRes.Results))
 	}
 
 	if deleteRes.Results[0].User != name {
 		t.Fatalf("expected deleteResult with user: %s, got %s", name, deleteRes.Results[0].User)
+	}
+
+	if deleteRes.Results[0].Error != nil {
+		t.Fatalf("didn't expect an error in deleteResult, got %v", deleteRes.Results[0].Error)
 	}
 
 	describeDeletionRes, err := client.DescribeUserScramCredentials(context.Background(), &DescribeUserScramCredentialsRequest{

--- a/describeuserscramcredentials_test.go
+++ b/describeuserscramcredentials_test.go
@@ -1,0 +1,144 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	ktesting "github.com/segmentio/kafka-go/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescribeUserScramCredentials(t *testing.T) {
+	// https://issues.apache.org/jira/browse/KAFKA-10259
+	if !ktesting.KafkaIsAtLeast("2.7.0") {
+		return
+	}
+
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
+	name := makeTopic()
+
+	createRes, err := client.AlterUserScramCredentials(context.Background(), &AlterUserScramCredentialsRequest{
+		Upsertions: []UserScramCredentialsUpsertion{
+			{
+				Name:           name,
+				Mechanism:      ScramMechanismSha512,
+				Iterations:     15000,
+				Salt:           []byte("my-salt"),
+				SaltedPassword: []byte("my-salted-password"),
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range createRes.Errors {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	if len(createRes.Results) != 1 {
+		t.Fatalf("expected 1 createResult; got %d", len(createRes.Results))
+	}
+
+	if createRes.Results[0].User != name {
+		t.Fatalf("expected createResult with user: %s, got %s", name, createRes.Results[0].User)
+	}
+
+	describeCreationRes, err := client.DescribeUserScramCredentials(context.Background(), &DescribeUserScramCredentialsRequest{
+		Users: []UserScramCredentialsUser{
+			{
+				Name: name,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCreation := DescribeUserScramCredentialsResponse{
+		Throttle: makeDuration(0),
+		Error:    makeError(0, ""),
+		Results: []DescribeUserScramCredentialsResponseResult{
+			{
+				User: name,
+				CredentialInfos: []DescribeUserScramCredentialsCredentialInfo{
+					{
+						Mechanism:  ScramMechanismSha512,
+						Iterations: 15000,
+					},
+				},
+				Error: makeError(0, ""),
+			},
+		},
+	}
+
+	assert.Equal(t, expectedCreation, *describeCreationRes)
+
+	deleteRes, err := client.AlterUserScramCredentials(context.Background(), &AlterUserScramCredentialsRequest{
+		Deletions: []UserScramCredentialsDeletion{
+			{
+				Name:      name,
+				Mechanism: ScramMechanismSha512,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, err := range deleteRes.Errors {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	if len(deleteRes.Results) != 1 {
+		t.Fatalf("expected 1 deleteResult; got %d", len(deleteRes.Results))
+	}
+
+	if deleteRes.Results[0].User != name {
+		t.Fatalf("expected deleteResult with user: %s, got %s", name, deleteRes.Results[0].User)
+	}
+
+	describeDeletionRes, err := client.DescribeUserScramCredentials(context.Background(), &DescribeUserScramCredentialsRequest{
+		Users: []UserScramCredentialsUser{
+			{
+				Name: name,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !errors.Is(describeDeletionRes.Error, makeError(0, "")) {
+		t.Fatalf("didn't expect a top level error on describe results after deletion, got %v", describeDeletionRes.Error)
+	}
+
+	if len(describeDeletionRes.Results) != 1 {
+		t.Fatalf("expected one describe results after deletion, got %d describe results", len(describeDeletionRes.Results))
+	}
+
+	result := describeDeletionRes.Results[0]
+
+	if result.User != name {
+		t.Fatalf("expected describeResult with user: %s, got %s", name, result.User)
+	}
+
+	if len(result.CredentialInfos) != 0 {
+		t.Fatalf("didn't expect describeResult credential infos, got %v", result.CredentialInfos)
+	}
+
+	if !errors.Is(result.Error, ResourceNotFound) {
+		t.Fatalf("expected describeResult resourcenotfound error, got %s", result.Error)
+	}
+}

--- a/protocol/alteruserscramcredentials/alteruserscramcredentials.go
+++ b/protocol/alteruserscramcredentials/alteruserscramcredentials.go
@@ -1,0 +1,66 @@
+package alteruserscramcredentials
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	Deletions  []RequestUserScramCredentialDeletions  `kafka:"min=v0,max=v0"`
+	Upsertions []RequestUserScramCredentialUpsertions `kafka:"min=v0,max=v0"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.AlterUserScramCredentials }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type RequestUserScramCredentialsDeletions struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	Name      string `kafka:"min=v0,max=v0,compact"`
+	Mechanism int8   `kafka:"min=v0,max=v0"`
+}
+
+type RequestUserScramCredentialsUpsertions struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	Name           string `kafka:"min=v0,max=v0,compact"`
+	Mechanism      int8   `kafka:"min=v0,max=v0"`
+	Iterations     int32  `kafka:"min=v0,max=v0"`
+	Salt           []byte `kafka:"min=v0,max=v0,compact"`
+	SaltedPassword []byte `kafka:"min=v0,max=v0,compact"`
+}
+
+type Response struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	ThrottleTimeMs int32                          `kafka:"min=v0,max=v0"`
+	Results        []ResponseUserScramCredentials `kafka:"min=v0,max=v0"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.AlterUserScramCredentials }
+
+type ResponseUserScramCredentials struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	User         string `kafka:"min=v0,max=v0,compact"`
+	ErrorCode    int16  `kafka:"min=v0,max=v0"`
+	ErrorMessage string `kafka:"min=v0,max=v0,nullable"`
+}
+
+var _ protocol.BrokerMessage = (*Request)(nil)

--- a/protocol/alteruserscramcredentials/alteruserscramcredentials.go
+++ b/protocol/alteruserscramcredentials/alteruserscramcredentials.go
@@ -11,8 +11,8 @@ type Request struct {
 	// messages.
 	_ struct{} `kafka:"min=v0,max=v0,tag"`
 
-	Deletions  []RequestUserScramCredentialDeletions  `kafka:"min=v0,max=v0"`
-	Upsertions []RequestUserScramCredentialUpsertions `kafka:"min=v0,max=v0"`
+	Deletions  []RequestUserScramCredentialsDeletion  `kafka:"min=v0,max=v0"`
+	Upsertions []RequestUserScramCredentialsUpsertion `kafka:"min=v0,max=v0"`
 }
 
 func (r *Request) ApiKey() protocol.ApiKey { return protocol.AlterUserScramCredentials }
@@ -21,7 +21,7 @@ func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
 	return cluster.Brokers[cluster.Controller], nil
 }
 
-type RequestUserScramCredentialsDeletions struct {
+type RequestUserScramCredentialsDeletion struct {
 	// We need at least one tagged field to indicate that v2+ uses "flexible"
 	// messages.
 	_ struct{} `kafka:"min=v0,max=v0,tag"`
@@ -30,7 +30,7 @@ type RequestUserScramCredentialsDeletions struct {
 	Mechanism int8   `kafka:"min=v0,max=v0"`
 }
 
-type RequestUserScramCredentialsUpsertions struct {
+type RequestUserScramCredentialsUpsertion struct {
 	// We need at least one tagged field to indicate that v2+ uses "flexible"
 	// messages.
 	_ struct{} `kafka:"min=v0,max=v0,tag"`

--- a/protocol/alteruserscramcredentials/alteruserscramcredentials_test.go
+++ b/protocol/alteruserscramcredentials/alteruserscramcredentials_test.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	v0 = 0
-	v1 = 1
 )
 
 func TestAlterUserScramCredentialsRequest(t *testing.T) {

--- a/protocol/alteruserscramcredentials/alteruserscramcredentials_test.go
+++ b/protocol/alteruserscramcredentials/alteruserscramcredentials_test.go
@@ -1,0 +1,46 @@
+package alteruserscramcredentials_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go/protocol/alteruserscramcredentials"
+	"github.com/segmentio/kafka-go/protocol/prototest"
+)
+
+const (
+	v0 = 0
+	v1 = 1
+)
+
+func TestAlterUserScramCredentialsRequest(t *testing.T) {
+	prototest.TestRequest(t, v0, &alteruserscramcredentials.Request{
+		Deletions: []alteruserscramcredentials.RequestUserScramCredentialsDeletion{
+			{
+				Name:      "foo-1",
+				Mechanism: 1,
+			},
+		},
+		Upsertions: []alteruserscramcredentials.RequestUserScramCredentialsUpsertion{
+			{
+				Name:           "foo-2",
+				Mechanism:      2,
+				Iterations:     15000,
+				Salt:           []byte("my-salt"),
+				SaltedPassword: []byte("my-salted-password"),
+			},
+		},
+	})
+}
+
+func TestAlterUserScramCredentialsResponse(t *testing.T) {
+	prototest.TestResponse(t, v0, &alteruserscramcredentials.Response{
+		ThrottleTimeMs: 500,
+		Results: []alteruserscramcredentials.ResponseUserScramCredentials{
+			{
+				User:         "foo",
+				ErrorCode:    1,
+				ErrorMessage: "foo-error",
+			},
+		},
+	})
+}

--- a/protocol/describeuserscramcredentials/describeuserscramcredentials.go
+++ b/protocol/describeuserscramcredentials/describeuserscramcredentials.go
@@ -1,0 +1,64 @@
+package describeuserscramcredentials
+
+import "github.com/segmentio/kafka-go/protocol"
+
+func init() {
+	protocol.Register(&Request{}, &Response{})
+}
+
+type Request struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	Users []RequestUser `kafka:"min=v0,max=v0"`
+}
+
+func (r *Request) ApiKey() protocol.ApiKey { return protocol.DescribeUserScramCredentials }
+
+func (r *Request) Broker(cluster protocol.Cluster) (protocol.Broker, error) {
+	return cluster.Brokers[cluster.Controller], nil
+}
+
+type RequestUser struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	Name string `kafka:"min=v0,max=v0,compact"`
+}
+
+type Response struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	ThrottleTimeMs int32            `kafka:"min=v0,max=v0"`
+	ErrorCode      int16            `kafka:"min=v0,max=v0"`
+	ErrorMessage   string           `kafka:"min=v0,max=v0,nullable"`
+	Results        []ResponseResult `kafka:"min=v0,max=v0"`
+}
+
+func (r *Response) ApiKey() protocol.ApiKey { return protocol.DescribeUserScramCredentials }
+
+type ResponseResult struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	User            string           `kafka:"min=v0,max=v0,compact"`
+	ErrorCode       int16            `kafka:"min=v0,max=v0"`
+	ErrorMessage    string           `kafka:"min=v0,max=v0,nullable"`
+	CredentialInfos []CredentialInfo `kafka:"min=v0,max=v0"`
+}
+
+type CredentialInfo struct {
+	// We need at least one tagged field to indicate that v2+ uses "flexible"
+	// messages.
+	_ struct{} `kafka:"min=v0,max=v0,tag"`
+
+	Mechanism  int8  `kafka:"min=v0,max=v0"`
+	Iterations int32 `kafka:"min=v0,max=v0"`
+}
+
+var _ protocol.BrokerMessage = (*Request)(nil)

--- a/protocol/describeuserscramcredentials/describeuserscramcredentials_test.go
+++ b/protocol/describeuserscramcredentials/describeuserscramcredentials_test.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	v0 = 0
-	v1 = 1
 )
 
 func TestDescribeUserScramCredentialsRequest(t *testing.T) {

--- a/protocol/describeuserscramcredentials/describeuserscramcredentials_test.go
+++ b/protocol/describeuserscramcredentials/describeuserscramcredentials_test.go
@@ -1,0 +1,42 @@
+package describeuserscramcredentials_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go/protocol/describeuserscramcredentials"
+	"github.com/segmentio/kafka-go/protocol/prototest"
+)
+
+const (
+	v0 = 0
+	v1 = 1
+)
+
+func TestDescribeUserScramCredentialsRequest(t *testing.T) {
+	prototest.TestRequest(t, v0, &describeuserscramcredentials.Request{
+		Users: []describeuserscramcredentials.RequestUser{
+			{
+				Name: "foo-1",
+			},
+		},
+	})
+}
+
+func TestDescribeUserScramCredentialsResponse(t *testing.T) {
+	prototest.TestResponse(t, v0, &describeuserscramcredentials.Response{
+		ThrottleTimeMs: 500,
+		Results: []describeuserscramcredentials.ResponseResult{
+			{
+				User:         "foo",
+				ErrorCode:    1,
+				ErrorMessage: "foo-error",
+				CredentialInfos: []describeuserscramcredentials.CredentialInfo{
+					{
+						Mechanism:  2,
+						Iterations: 15000,
+					},
+				},
+			},
+		},
+	})
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -53,111 +53,115 @@ func (k ApiKey) apiType() apiType {
 }
 
 const (
-	Produce                     ApiKey = 0
-	Fetch                       ApiKey = 1
-	ListOffsets                 ApiKey = 2
-	Metadata                    ApiKey = 3
-	LeaderAndIsr                ApiKey = 4
-	StopReplica                 ApiKey = 5
-	UpdateMetadata              ApiKey = 6
-	ControlledShutdown          ApiKey = 7
-	OffsetCommit                ApiKey = 8
-	OffsetFetch                 ApiKey = 9
-	FindCoordinator             ApiKey = 10
-	JoinGroup                   ApiKey = 11
-	Heartbeat                   ApiKey = 12
-	LeaveGroup                  ApiKey = 13
-	SyncGroup                   ApiKey = 14
-	DescribeGroups              ApiKey = 15
-	ListGroups                  ApiKey = 16
-	SaslHandshake               ApiKey = 17
-	ApiVersions                 ApiKey = 18
-	CreateTopics                ApiKey = 19
-	DeleteTopics                ApiKey = 20
-	DeleteRecords               ApiKey = 21
-	InitProducerId              ApiKey = 22
-	OffsetForLeaderEpoch        ApiKey = 23
-	AddPartitionsToTxn          ApiKey = 24
-	AddOffsetsToTxn             ApiKey = 25
-	EndTxn                      ApiKey = 26
-	WriteTxnMarkers             ApiKey = 27
-	TxnOffsetCommit             ApiKey = 28
-	DescribeAcls                ApiKey = 29
-	CreateAcls                  ApiKey = 30
-	DeleteAcls                  ApiKey = 31
-	DescribeConfigs             ApiKey = 32
-	AlterConfigs                ApiKey = 33
-	AlterReplicaLogDirs         ApiKey = 34
-	DescribeLogDirs             ApiKey = 35
-	SaslAuthenticate            ApiKey = 36
-	CreatePartitions            ApiKey = 37
-	CreateDelegationToken       ApiKey = 38
-	RenewDelegationToken        ApiKey = 39
-	ExpireDelegationToken       ApiKey = 40
-	DescribeDelegationToken     ApiKey = 41
-	DeleteGroups                ApiKey = 42
-	ElectLeaders                ApiKey = 43
-	IncrementalAlterConfigs     ApiKey = 44
-	AlterPartitionReassignments ApiKey = 45
-	ListPartitionReassignments  ApiKey = 46
-	OffsetDelete                ApiKey = 47
-	DescribeClientQuotas        ApiKey = 48
-	AlterClientQuotas           ApiKey = 49
+	Produce                      ApiKey = 0
+	Fetch                        ApiKey = 1
+	ListOffsets                  ApiKey = 2
+	Metadata                     ApiKey = 3
+	LeaderAndIsr                 ApiKey = 4
+	StopReplica                  ApiKey = 5
+	UpdateMetadata               ApiKey = 6
+	ControlledShutdown           ApiKey = 7
+	OffsetCommit                 ApiKey = 8
+	OffsetFetch                  ApiKey = 9
+	FindCoordinator              ApiKey = 10
+	JoinGroup                    ApiKey = 11
+	Heartbeat                    ApiKey = 12
+	LeaveGroup                   ApiKey = 13
+	SyncGroup                    ApiKey = 14
+	DescribeGroups               ApiKey = 15
+	ListGroups                   ApiKey = 16
+	SaslHandshake                ApiKey = 17
+	ApiVersions                  ApiKey = 18
+	CreateTopics                 ApiKey = 19
+	DeleteTopics                 ApiKey = 20
+	DeleteRecords                ApiKey = 21
+	InitProducerId               ApiKey = 22
+	OffsetForLeaderEpoch         ApiKey = 23
+	AddPartitionsToTxn           ApiKey = 24
+	AddOffsetsToTxn              ApiKey = 25
+	EndTxn                       ApiKey = 26
+	WriteTxnMarkers              ApiKey = 27
+	TxnOffsetCommit              ApiKey = 28
+	DescribeAcls                 ApiKey = 29
+	CreateAcls                   ApiKey = 30
+	DeleteAcls                   ApiKey = 31
+	DescribeConfigs              ApiKey = 32
+	AlterConfigs                 ApiKey = 33
+	AlterReplicaLogDirs          ApiKey = 34
+	DescribeLogDirs              ApiKey = 35
+	SaslAuthenticate             ApiKey = 36
+	CreatePartitions             ApiKey = 37
+	CreateDelegationToken        ApiKey = 38
+	RenewDelegationToken         ApiKey = 39
+	ExpireDelegationToken        ApiKey = 40
+	DescribeDelegationToken      ApiKey = 41
+	DeleteGroups                 ApiKey = 42
+	ElectLeaders                 ApiKey = 43
+	IncrementalAlterConfigs      ApiKey = 44
+	AlterPartitionReassignments  ApiKey = 45
+	ListPartitionReassignments   ApiKey = 46
+	OffsetDelete                 ApiKey = 47
+	DescribeClientQuotas         ApiKey = 48
+	AlterClientQuotas            ApiKey = 49
+	DescribeUserScramCredentials ApiKey = 50
+	AlterUserScramCredentials    ApiKey = 51
 
-	numApis = 50
+	numApis = 52
 )
 
 var apiNames = [numApis]string{
-	Produce:                     "Produce",
-	Fetch:                       "Fetch",
-	ListOffsets:                 "ListOffsets",
-	Metadata:                    "Metadata",
-	LeaderAndIsr:                "LeaderAndIsr",
-	StopReplica:                 "StopReplica",
-	UpdateMetadata:              "UpdateMetadata",
-	ControlledShutdown:          "ControlledShutdown",
-	OffsetCommit:                "OffsetCommit",
-	OffsetFetch:                 "OffsetFetch",
-	FindCoordinator:             "FindCoordinator",
-	JoinGroup:                   "JoinGroup",
-	Heartbeat:                   "Heartbeat",
-	LeaveGroup:                  "LeaveGroup",
-	SyncGroup:                   "SyncGroup",
-	DescribeGroups:              "DescribeGroups",
-	ListGroups:                  "ListGroups",
-	SaslHandshake:               "SaslHandshake",
-	ApiVersions:                 "ApiVersions",
-	CreateTopics:                "CreateTopics",
-	DeleteTopics:                "DeleteTopics",
-	DeleteRecords:               "DeleteRecords",
-	InitProducerId:              "InitProducerId",
-	OffsetForLeaderEpoch:        "OffsetForLeaderEpoch",
-	AddPartitionsToTxn:          "AddPartitionsToTxn",
-	AddOffsetsToTxn:             "AddOffsetsToTxn",
-	EndTxn:                      "EndTxn",
-	WriteTxnMarkers:             "WriteTxnMarkers",
-	TxnOffsetCommit:             "TxnOffsetCommit",
-	DescribeAcls:                "DescribeAcls",
-	CreateAcls:                  "CreateAcls",
-	DeleteAcls:                  "DeleteAcls",
-	DescribeConfigs:             "DescribeConfigs",
-	AlterConfigs:                "AlterConfigs",
-	AlterReplicaLogDirs:         "AlterReplicaLogDirs",
-	DescribeLogDirs:             "DescribeLogDirs",
-	SaslAuthenticate:            "SaslAuthenticate",
-	CreatePartitions:            "CreatePartitions",
-	CreateDelegationToken:       "CreateDelegationToken",
-	RenewDelegationToken:        "RenewDelegationToken",
-	ExpireDelegationToken:       "ExpireDelegationToken",
-	DescribeDelegationToken:     "DescribeDelegationToken",
-	DeleteGroups:                "DeleteGroups",
-	ElectLeaders:                "ElectLeaders",
-	IncrementalAlterConfigs:     "IncrementalAlterConfigs",
-	AlterPartitionReassignments: "AlterPartitionReassignments",
-	ListPartitionReassignments:  "ListPartitionReassignments",
-	OffsetDelete:                "OffsetDelete",
-	DescribeClientQuotas:        "DescribeClientQuotas",
-	AlterClientQuotas:           "AlterClientQuotas",
+	Produce:                      "Produce",
+	Fetch:                        "Fetch",
+	ListOffsets:                  "ListOffsets",
+	Metadata:                     "Metadata",
+	LeaderAndIsr:                 "LeaderAndIsr",
+	StopReplica:                  "StopReplica",
+	UpdateMetadata:               "UpdateMetadata",
+	ControlledShutdown:           "ControlledShutdown",
+	OffsetCommit:                 "OffsetCommit",
+	OffsetFetch:                  "OffsetFetch",
+	FindCoordinator:              "FindCoordinator",
+	JoinGroup:                    "JoinGroup",
+	Heartbeat:                    "Heartbeat",
+	LeaveGroup:                   "LeaveGroup",
+	SyncGroup:                    "SyncGroup",
+	DescribeGroups:               "DescribeGroups",
+	ListGroups:                   "ListGroups",
+	SaslHandshake:                "SaslHandshake",
+	ApiVersions:                  "ApiVersions",
+	CreateTopics:                 "CreateTopics",
+	DeleteTopics:                 "DeleteTopics",
+	DeleteRecords:                "DeleteRecords",
+	InitProducerId:               "InitProducerId",
+	OffsetForLeaderEpoch:         "OffsetForLeaderEpoch",
+	AddPartitionsToTxn:           "AddPartitionsToTxn",
+	AddOffsetsToTxn:              "AddOffsetsToTxn",
+	EndTxn:                       "EndTxn",
+	WriteTxnMarkers:              "WriteTxnMarkers",
+	TxnOffsetCommit:              "TxnOffsetCommit",
+	DescribeAcls:                 "DescribeAcls",
+	CreateAcls:                   "CreateAcls",
+	DeleteAcls:                   "DeleteAcls",
+	DescribeConfigs:              "DescribeConfigs",
+	AlterConfigs:                 "AlterConfigs",
+	AlterReplicaLogDirs:          "AlterReplicaLogDirs",
+	DescribeLogDirs:              "DescribeLogDirs",
+	SaslAuthenticate:             "SaslAuthenticate",
+	CreatePartitions:             "CreatePartitions",
+	CreateDelegationToken:        "CreateDelegationToken",
+	RenewDelegationToken:         "RenewDelegationToken",
+	ExpireDelegationToken:        "ExpireDelegationToken",
+	DescribeDelegationToken:      "DescribeDelegationToken",
+	DeleteGroups:                 "DeleteGroups",
+	ElectLeaders:                 "ElectLeaders",
+	IncrementalAlterConfigs:      "IncrementalAlterConfigs",
+	AlterPartitionReassignments:  "AlterPartitionReassignments",
+	ListPartitionReassignments:   "ListPartitionReassignments",
+	OffsetDelete:                 "OffsetDelete",
+	DescribeClientQuotas:         "DescribeClientQuotas",
+	AlterClientQuotas:            "AlterClientQuotas",
+	DescribeUserScramCredentials: "DescribeUserScramCredentials",
+	AlterUserScramCredentials:    "AlterUserScramCredentials",
 }
 
 type messageType struct {


### PR DESCRIPTION
Support userscramcredentials APIs

[DescribeUserScramCredentials API Docs](https://kafka.apache.org/protocol#The_Messages_DescribeUserScramCredentials)

[AlterUserScramCredentials API Docs](https://kafka.apache.org/protocol#The_Messages_AlterUserScramCredentials)

I based this PR on similar work done here https://github.com/segmentio/kafka-go/pull/1119
