### PR TITLE
check remaining bytes when marking batch as empty

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -868,7 +868,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var msgs *messageSetReader
 	if err == nil {
-		if highWaterMark == offset {
+		if highWaterMark == offset && remain == 0 {
 			msgs = &messageSetReader{empty: true}
 		} else {
 			msgs, err = newMessageSetReader(&c.rbuf, remain)


### PR DESCRIPTION
Fixes [issue-1188](https://github.com/segmentio/kafka-go/issues/1188) and drastically reduce the number of reader errors and dials.