### PR TITLE
do not initialize message slice in writer with max capacity

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1015,7 +1015,7 @@ func (b *writeBatch) add(msg Message, maxSize int, maxBytes int64) bool {
 	}
 
 	if cap(b.msgs) == 0 {
-		b.msgs = make([]Message, 0, maxSize)
+		b.msgs = make([]Message, 0)
 	}
 
 	b.msgs = append(b.msgs, msg)


### PR DESCRIPTION
The benefit of initializing the slice with max batch size as the capacity is minimum compared to the downside - in applications that uses large max batch size but writes frequent small batches. We saw memory allocation dropped from 30GiB per minute to 100MB after this change. 