### PR TITLE
Changed AlterPartitionReassignments request to support multiple topics

### DIFF
--- a/alterpartitionreassignments_test.go
+++ b/alterpartitionreassignments_test.go
@@ -16,34 +16,23 @@ func TestClientAlterPartitionReassignments(t *testing.T) {
 	client, shutdown := newLocalClient()
 	defer shutdown()
 
-	topic1 := makeTopic()
-	topic2 := makeTopic()
-	createTopic(t, topic1, 2)
-	createTopic(t, topic2, 2)
-	defer func() {
-		deleteTopic(t, topic1)
-		deleteTopic(t, topic2)
-	}()
+	topic := makeTopic()
+	createTopic(t, topic, 2)
+	defer deleteTopic(t, topic)
 
 	// Local kafka only has 1 broker, so any partition reassignments are really no-ops.
 	resp, err := client.AlterPartitionReassignments(
 		ctx,
 		&AlterPartitionReassignmentsRequest{
-			Topics: map[string][]AlterPartitionReassignmentsRequestAssignment{
-				topic1: {
-					{
-						PartitionID: 0,
-						BrokerIDs:   []int{1},
-					},
-					{
-						PartitionID: 1,
-						BrokerIDs:   []int{1},
-					},
+			Topic: topic,
+			Assignments: []AlterPartitionReassignmentsRequestAssignment{
+				{
+					PartitionID: 0,
+					BrokerIDs:   []int{1},
 				},
-				topic2: {
-					{
-						PartitionID: 0,
-					},
+				{
+					PartitionID: 1,
+					BrokerIDs:   []int{1},
 				},
 			},
 		},
@@ -59,25 +48,72 @@ func TestClientAlterPartitionReassignments(t *testing.T) {
 			"got", resp.Error,
 		)
 	}
-	if len(resp.Topics) != 2 {
-		t.Error(
-			"Unexpected length of topic results",
-			"expected", 2,
-			"got", len(resp.Topics),
-		)
-	}
-	if len(resp.Topics[topic1]) != 2 {
+	if len(resp.PartitionResults) != 2 {
 		t.Error(
 			"Unexpected length of partition results",
 			"expected", 2,
-			"got", len(resp.Topics[topic1]),
+			"got", len(resp.PartitionResults),
 		)
 	}
-	if len(resp.Topics[topic2]) != 1 {
+}
+
+func TestClientAlterPartitionReassignmentsMultiTopics(t *testing.T) {
+	if !ktesting.KafkaIsAtLeast("2.4.0") {
+		return
+	}
+
+	ctx := context.Background()
+	client, shutdown := newLocalClient()
+	defer shutdown()
+
+	topic1 := makeTopic()
+	topic2 := makeTopic()
+	createTopic(t, topic1, 2)
+	createTopic(t, topic2, 2)
+	defer func() {
+		deleteTopic(t, topic1)
+		deleteTopic(t, topic2)
+	}()
+
+	// Local kafka only has 1 broker, so any partition reassignments are really no-ops.
+	resp, err := client.AlterPartitionReassignments(
+		ctx,
+		&AlterPartitionReassignmentsRequest{
+			Assignments: []AlterPartitionReassignmentsRequestAssignment{
+				{
+					Topic:       topic1,
+					PartitionID: 0,
+					BrokerIDs:   []int{1},
+				},
+				{
+					Topic:       topic1,
+					PartitionID: 1,
+					BrokerIDs:   []int{1},
+				},
+				{
+					Topic:       topic2,
+					PartitionID: 0,
+					BrokerIDs:   []int{1},
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Error(
+			"Unexpected error in response",
+			"expected", nil,
+			"got", resp.Error,
+		)
+	}
+	if len(resp.PartitionResults) != 3 {
 		t.Error(
 			"Unexpected length of partition results",
-			"expected", 1,
-			"got", len(resp.Topics[topic2]),
+			"expected", 3,
+			"got", len(resp.PartitionResults),
 		)
 	}
 }

--- a/protocol/alterpartitionreassignments/alterpartitionreassignments.go
+++ b/protocol/alterpartitionreassignments/alterpartitionreassignments.go
@@ -23,7 +23,7 @@ type RequestTopic struct {
 
 type RequestPartition struct {
 	PartitionIndex int32   `kafka:"min=v0,max=v0"`
-	Replicas       []int32 `kafka:"min=v0,max=v0"`
+	Replicas       []int32 `kafka:"min=v0,max=v0,nullable"`
 }
 
 func (r *Request) ApiKey() protocol.ApiKey {

--- a/protocol/alterpartitionreassignments/alterpartitionreassignments_test.go
+++ b/protocol/alterpartitionreassignments/alterpartitionreassignments_test.go
@@ -1,0 +1,55 @@
+package alterpartitionreassignments_test
+
+import (
+	"testing"
+
+	"github.com/segmentio/kafka-go/protocol/alterpartitionreassignments"
+	"github.com/segmentio/kafka-go/protocol/prototest"
+)
+
+const (
+	v0 = 0
+)
+
+func TestAlterPartitionReassignmentsRequest(t *testing.T) {
+	prototest.TestRequest(t, v0, &alterpartitionreassignments.Request{
+		TimeoutMs: 1,
+		Topics: []alterpartitionreassignments.RequestTopic{
+			{
+				Name: "topic-1",
+				Partitions: []alterpartitionreassignments.RequestPartition{
+					{
+						PartitionIndex: 1,
+						Replicas:       []int32{1, 2, 3},
+					},
+					{
+						PartitionIndex: 2,
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAlterPartitionReassignmentsResponse(t *testing.T) {
+	prototest.TestResponse(t, v0, &alterpartitionreassignments.Response{
+		ErrorCode:      1,
+		ErrorMessage:   "error",
+		ThrottleTimeMs: 1,
+		Results: []alterpartitionreassignments.ResponseResult{
+			{
+				Name: "topic-1",
+				Partitions: []alterpartitionreassignments.ResponsePartition{
+					{
+						PartitionIndex: 1,
+						ErrorMessage:   "error",
+						ErrorCode:      1,
+					},
+					{
+						PartitionIndex: 2,
+					},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
- Allowed assigning to multiple topics with AlterPartitionReassignments
- Make BrokerIds in AlterPartitionReassignments nullable to support canceling ongoing partition reassignments