### PR TITLE
add methods for parsing and stringifying acl related resources

### DIFF
--- a/createacls.go
+++ b/createacls.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/segmentio/kafka-go/protocol/createacls"
@@ -42,6 +43,42 @@ const (
 	ACLPermissionTypeAllow   ACLPermissionType = 3
 )
 
+func (apt ACLPermissionType) String() string {
+	mapping := map[ACLPermissionType]string{
+		ACLPermissionTypeUnknown: "Unknown",
+		ACLPermissionTypeAny:     "Any",
+		ACLPermissionTypeDeny:    "Deny",
+		ACLPermissionTypeAllow:   "Allow",
+	}
+	s, ok := mapping[apt]
+	if !ok {
+		s = mapping[ACLPermissionTypeUnknown]
+	}
+	return s
+}
+
+// UnmarshalText takes a string representation of the resource type and converts it to an ACLPermissionType.
+func (apt *ACLPermissionType) UnmarshalText(text []byte) error {
+	normalized := strings.ToLower(string(text))
+	mapping := map[string]ACLPermissionType{
+		"unknown": ACLPermissionTypeUnknown,
+		"any":     ACLPermissionTypeAny,
+		"deny":    ACLPermissionTypeDeny,
+		"allow":   ACLPermissionTypeAllow,
+	}
+	parsed, ok := mapping[normalized]
+	if !ok {
+		return fmt.Errorf("cannot parse %s as an ACLPermissionType", normalized)
+	}
+	*apt = parsed
+	return nil
+}
+
+// MarshalText transforms an ACLPermissionType into its string representation.
+func (apt ACLPermissionType) MarshalText() ([]byte, error) {
+	return []byte(apt.String()), nil
+}
+
 type ACLOperationType int8
 
 const (
@@ -59,6 +96,61 @@ const (
 	ACLOperationTypeAlterConfigs    ACLOperationType = 11
 	ACLOperationTypeIdempotentWrite ACLOperationType = 12
 )
+
+func (aot ACLOperationType) String() string {
+	mapping := map[ACLOperationType]string{
+		ACLOperationTypeUnknown:         "Unknown",
+		ACLOperationTypeAny:             "Any",
+		ACLOperationTypeAll:             "All",
+		ACLOperationTypeRead:            "Read",
+		ACLOperationTypeWrite:           "Write",
+		ACLOperationTypeCreate:          "Create",
+		ACLOperationTypeDelete:          "Delete",
+		ACLOperationTypeAlter:           "Alter",
+		ACLOperationTypeDescribe:        "Describe",
+		ACLOperationTypeClusterAction:   "ClusterAction",
+		ACLOperationTypeDescribeConfigs: "DescribeConfigs",
+		ACLOperationTypeAlterConfigs:    "AlterConfigs",
+		ACLOperationTypeIdempotentWrite: "IdempotentWrite",
+	}
+	s, ok := mapping[aot]
+	if !ok {
+		s = mapping[ACLOperationTypeUnknown]
+	}
+	return s
+}
+
+// UnmarshalText takes a string representation of the resource type and converts it to an ACLPermissionType.
+func (aot *ACLOperationType) UnmarshalText(text []byte) error {
+	normalized := strings.ToLower(string(text))
+	mapping := map[string]ACLOperationType{
+		"unknown":         ACLOperationTypeUnknown,
+		"any":             ACLOperationTypeAny,
+		"all":             ACLOperationTypeAll,
+		"read":            ACLOperationTypeRead,
+		"write":           ACLOperationTypeWrite,
+		"create":          ACLOperationTypeCreate,
+		"delete":          ACLOperationTypeDelete,
+		"alter":           ACLOperationTypeAlter,
+		"describe":        ACLOperationTypeDescribe,
+		"clusteraction":   ACLOperationTypeClusterAction,
+		"describeconfigs": ACLOperationTypeDescribeConfigs,
+		"alterconfigs":    ACLOperationTypeAlterConfigs,
+		"idempotentwrite": ACLOperationTypeIdempotentWrite,
+	}
+	parsed, ok := mapping[normalized]
+	if !ok {
+		return fmt.Errorf("cannot parse %s as an ACLOperationType", normalized)
+	}
+	*aot = parsed
+	return nil
+
+}
+
+// MarshalText transforms an ACLOperationType into its string representation.
+func (aot ACLOperationType) MarshalText() ([]byte, error) {
+	return []byte(aot.String()), nil
+}
 
 type ACLEntry struct {
 	ResourceType        ResourceType

--- a/createacls.go
+++ b/createacls.go
@@ -57,6 +57,11 @@ func (apt ACLPermissionType) String() string {
 	return s
 }
 
+// MarshalText transforms an ACLPermissionType into its string representation.
+func (apt ACLPermissionType) MarshalText() ([]byte, error) {
+	return []byte(apt.String()), nil
+}
+
 // UnmarshalText takes a string representation of the resource type and converts it to an ACLPermissionType.
 func (apt *ACLPermissionType) UnmarshalText(text []byte) error {
 	normalized := strings.ToLower(string(text))
@@ -73,11 +78,6 @@ func (apt *ACLPermissionType) UnmarshalText(text []byte) error {
 	}
 	*apt = parsed
 	return nil
-}
-
-// MarshalText transforms an ACLPermissionType into its string representation.
-func (apt ACLPermissionType) MarshalText() ([]byte, error) {
-	return []byte(apt.String()), nil
 }
 
 type ACLOperationType int8
@@ -121,6 +121,11 @@ func (aot ACLOperationType) String() string {
 	return s
 }
 
+// MarshalText transforms an ACLOperationType into its string representation.
+func (aot ACLOperationType) MarshalText() ([]byte, error) {
+	return []byte(aot.String()), nil
+}
+
 // UnmarshalText takes a string representation of the resource type and converts it to an ACLPermissionType.
 func (aot *ACLOperationType) UnmarshalText(text []byte) error {
 	normalized := strings.ToLower(string(text))
@@ -147,11 +152,6 @@ func (aot *ACLOperationType) UnmarshalText(text []byte) error {
 	*aot = parsed
 	return nil
 
-}
-
-// MarshalText transforms an ACLOperationType into its string representation.
-func (aot ACLOperationType) MarshalText() ([]byte, error) {
-	return []byte(aot.String()), nil
 }
 
 type ACLEntry struct {

--- a/createacls.go
+++ b/createacls.go
@@ -68,6 +68,7 @@ func (apt *ACLPermissionType) UnmarshalText(text []byte) error {
 	}
 	parsed, ok := mapping[normalized]
 	if !ok {
+		*apt = ACLPermissionTypeUnknown
 		return fmt.Errorf("cannot parse %s as an ACLPermissionType", normalized)
 	}
 	*apt = parsed
@@ -140,6 +141,7 @@ func (aot *ACLOperationType) UnmarshalText(text []byte) error {
 	}
 	parsed, ok := mapping[normalized]
 	if !ok {
+		*aot = ACLOperationTypeUnknown
 		return fmt.Errorf("cannot parse %s as an ACLOperationType", normalized)
 	}
 	*aot = parsed

--- a/createacls_test.go
+++ b/createacls_test.go
@@ -50,3 +50,37 @@ func TestClientCreateACLs(t *testing.T) {
 		}
 	}
 }
+
+func TestACLPermissionTypeMarshal(t *testing.T) {
+	for i := ACLPermissionTypeUnknown; i <= ACLPermissionTypeAllow; i++ {
+		text, err := i.MarshalText()
+		if err != nil {
+			t.Errorf("couldn't marshal %d to text: %s", i, err)
+		}
+		var got ACLPermissionType
+		err = got.UnmarshalText(text)
+		if err != nil {
+			t.Errorf("couldn't unmarshal %s to ACLPermissionType: %s", text, err)
+		}
+		if got != i {
+			t.Errorf("got %d, want %d", got, i)
+		}
+	}
+}
+
+func TestACLOperationTypeMarshal(t *testing.T) {
+	for i := ACLOperationTypeUnknown; i <= ACLOperationTypeIdempotentWrite; i++ {
+		text, err := i.MarshalText()
+		if err != nil {
+			t.Errorf("couldn't marshal %d to text: %s", i, err)
+		}
+		var got ACLOperationType
+		err = got.UnmarshalText(text)
+		if err != nil {
+			t.Errorf("couldn't unmarshal %s to ACLOperationType: %s", text, err)
+		}
+		if got != i {
+			t.Errorf("got %d, want %d", got, i)
+		}
+	}
+}

--- a/resource.go
+++ b/resource.go
@@ -1,5 +1,10 @@
 package kafka
 
+import (
+	"fmt"
+	"strings"
+)
+
 // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
 type ResourceType int8
 
@@ -14,6 +19,44 @@ const (
 	ResourceTypeTransactionalID ResourceType = 5
 	ResourceTypeDelegationToken ResourceType = 6
 )
+
+func (rt ResourceType) String() string {
+	mapping := map[ResourceType]string{
+		ResourceTypeUnknown:         "unknown",
+		ResourceTypeAny:             "any",
+		ResourceTypeTopic:           "topic",
+		ResourceTypeGroup:           "group",
+		ResourceTypeCluster:         "cluster",
+		ResourceTypeTransactionalID: "transactionalid",
+		ResourceTypeDelegationToken: "delegationtoken",
+	}
+	s, ok := mapping[rt]
+	if !ok {
+		s = mapping[ResourceTypeUnknown]
+	}
+	return s
+}
+
+func (rt *ResourceType) UnmarshalText(text []byte) error {
+	normalized := strings.ToLower(string(text))
+	mapping := map[string]ResourceType{
+		"unknown":         ResourceTypeUnknown,
+		"any":             ResourceTypeAny,
+		"topic":           ResourceTypeTopic,
+		"group":           ResourceTypeGroup,
+		"broker":          ResourceTypeBroker,
+		"cluster":         ResourceTypeCluster,
+		"transactionalid": ResourceTypeTransactionalID,
+		"delegationtoken": ResourceTypeDelegationToken,
+	}
+	parsed, ok := mapping[normalized]
+	if !ok {
+		*rt = ResourceTypeUnknown
+		return fmt.Errorf("cannot parse %s as a ResourceType", normalized)
+	}
+	*rt = parsed
+	return nil
+}
 
 // https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/resource/PatternType.java
 type PatternType int8

--- a/resource.go
+++ b/resource.go
@@ -22,10 +22,12 @@ const (
 
 func (rt ResourceType) String() string {
 	mapping := map[ResourceType]string{
-		ResourceTypeUnknown:         "Unknown",
-		ResourceTypeAny:             "Any",
-		ResourceTypeTopic:           "Topic",
-		ResourceTypeGroup:           "Group",
+		ResourceTypeUnknown: "Unknown",
+		ResourceTypeAny:     "Any",
+		ResourceTypeTopic:   "Topic",
+		ResourceTypeGroup:   "Group",
+		// Note that ResourceTypeBroker and ResourceTypeCluster have the same value.
+		// A map cannot have duplicate values so we just use the same value for both.
 		ResourceTypeCluster:         "Cluster",
 		ResourceTypeTransactionalID: "Transactionalid",
 		ResourceTypeDelegationToken: "Delegationtoken",

--- a/resource.go
+++ b/resource.go
@@ -22,13 +22,13 @@ const (
 
 func (rt ResourceType) String() string {
 	mapping := map[ResourceType]string{
-		ResourceTypeUnknown:         "unknown",
-		ResourceTypeAny:             "any",
-		ResourceTypeTopic:           "topic",
-		ResourceTypeGroup:           "group",
-		ResourceTypeCluster:         "cluster",
-		ResourceTypeTransactionalID: "transactionalid",
-		ResourceTypeDelegationToken: "delegationtoken",
+		ResourceTypeUnknown:         "Unknown",
+		ResourceTypeAny:             "Any",
+		ResourceTypeTopic:           "Topic",
+		ResourceTypeGroup:           "Group",
+		ResourceTypeCluster:         "Cluster",
+		ResourceTypeTransactionalID: "Transactionalid",
+		ResourceTypeDelegationToken: "Delegationtoken",
 	}
 	s, ok := mapping[rt]
 	if !ok {
@@ -85,11 +85,11 @@ const (
 
 func (pt PatternType) String() string {
 	mapping := map[PatternType]string{
-		PatternTypeUnknown:  "unknown",
-		PatternTypeAny:      "any",
-		PatternTypeMatch:    "match",
-		PatternTypeLiteral:  "literal",
-		PatternTypePrefixed: "prefixed",
+		PatternTypeUnknown:  "Unknown",
+		PatternTypeAny:      "Any",
+		PatternTypeMatch:    "Match",
+		PatternTypeLiteral:  "Literal",
+		PatternTypePrefixed: "Prefixed",
 	}
 	s, ok := mapping[pt]
 	if !ok {

--- a/resource.go
+++ b/resource.go
@@ -37,6 +37,10 @@ func (rt ResourceType) String() string {
 	return s
 }
 
+func (rt ResourceType) MarshalText() ([]byte, error) {
+	return []byte(rt.String()), nil
+}
+
 func (rt *ResourceType) UnmarshalText(text []byte) error {
 	normalized := strings.ToLower(string(text))
 	mapping := map[string]ResourceType{
@@ -78,3 +82,40 @@ const (
 	// that start with 'foo'.
 	PatternTypePrefixed PatternType = 4
 )
+
+func (pt PatternType) String() string {
+	mapping := map[PatternType]string{
+		PatternTypeUnknown:  "unknown",
+		PatternTypeAny:      "any",
+		PatternTypeMatch:    "match",
+		PatternTypeLiteral:  "literal",
+		PatternTypePrefixed: "prefixed",
+	}
+	s, ok := mapping[pt]
+	if !ok {
+		s = mapping[PatternTypeUnknown]
+	}
+	return s
+}
+
+func (pt PatternType) MarshalText() ([]byte, error) {
+	return []byte(pt.String()), nil
+}
+
+func (pt *PatternType) UnmarshalText(text []byte) error {
+	normalized := strings.ToLower(string(text))
+	mapping := map[string]PatternType{
+		"unknown":  PatternTypeUnknown,
+		"any":      PatternTypeAny,
+		"match":    PatternTypeMatch,
+		"literal":  PatternTypeLiteral,
+		"prefixed": PatternTypePrefixed,
+	}
+	parsed, ok := mapping[normalized]
+	if !ok {
+		*pt = PatternTypeUnknown
+		return fmt.Errorf("cannot parse %s as a PatternType", normalized)
+	}
+	*pt = parsed
+	return nil
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -19,6 +19,27 @@ func TestResourceTypeMarshal(t *testing.T) {
 	}
 }
 
+// Verify that the text version of ResourceTypeBroker is "Cluster".
+// This is added since ResourceTypeBroker and ResourceTypeCluster
+// have the same value.
+func TestResourceTypeBroker(t *testing.T) {
+	text, err := ResourceTypeBroker.MarshalText()
+	if err != nil {
+		t.Errorf("couldn't marshal %d to text: %s", ResourceTypeBroker, err)
+	}
+	if string(text) != "Cluster" {
+		t.Errorf("got %s, want %s", string(text), "Cluster")
+	}
+	var got ResourceType
+	err = got.UnmarshalText(text)
+	if err != nil {
+		t.Errorf("couldn't unmarshal %s to ResourceType: %s", text, err)
+	}
+	if got != ResourceTypeBroker {
+		t.Errorf("got %d, want %d", got, ResourceTypeBroker)
+	}
+}
+
 func TestPatternTypeMarshal(t *testing.T) {
 	for i := PatternTypeUnknown; i <= PatternTypePrefixed; i++ {
 		text, err := i.MarshalText()

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,37 @@
+package kafka
+
+import "testing"
+
+func TestResourceTypeMarshal(t *testing.T) {
+	for i := ResourceTypeUnknown; i <= ResourceTypeDelegationToken; i++ {
+		text, err := i.MarshalText()
+		if err != nil {
+			t.Errorf("couldn't marshal %d to text: %s", i, err)
+		}
+		var got ResourceType
+		err = got.UnmarshalText(text)
+		if err != nil {
+			t.Errorf("couldn't unmarshal %s to ResourceType: %s", text, err)
+		}
+		if got != i {
+			t.Errorf("got %d, want %d", got, i)
+		}
+	}
+}
+
+func TestPatternTypeMarshal(t *testing.T) {
+	for i := PatternTypeUnknown; i <= PatternTypePrefixed; i++ {
+		text, err := i.MarshalText()
+		if err != nil {
+			t.Errorf("couldn't marshal %d to text: %s", i, err)
+		}
+		var got PatternType
+		err = got.UnmarshalText(text)
+		if err != nil {
+			t.Errorf("couldn't unmarshal %s to PatternType: %s", text, err)
+		}
+		if got != i {
+			t.Errorf("got %d, want %d", got, i)
+		}
+	}
+}


### PR DESCRIPTION
Add methods for parsing ACL related resources and converting them between their kafka-go and human readable versions

This is taken from Sarama https://github.com/IBM/sarama/blob/3ca69a884964f10c228a382d184b0d5005c342e1/acl_types.go#L35
