### PR TITLE
Implementation of session timeout in V1 SASL Authentication

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1492,6 +1492,13 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 	t0 := time.Now()
 	conn.SetReadDeadline(t0.Add(r.maxWait))
 
+	if conn.sessionExpiresAt != nil && t0.After(*conn.sessionExpiresAt) {
+		err := r.dialer.authenticateSASL(ctx, conn)
+		if err != nil {
+			return -1, err
+		}
+	}
+
 	batch := conn.ReadBatchWith(ReadBatchConfig{
 		MinBytes:       r.minBytes,
 		MaxBytes:       r.maxBytes,

--- a/saslauthenticate.go
+++ b/saslauthenticate.go
@@ -4,43 +4,46 @@ import (
 	"bufio"
 )
 
-type saslAuthenticateRequestV0 struct {
+type saslAuthenticateRequestV1 struct {
 	// Data holds the SASL payload
 	Data []byte
 }
 
-func (t saslAuthenticateRequestV0) size() int32 {
+func (t saslAuthenticateRequestV1) size() int32 {
 	return sizeofBytes(t.Data)
 }
 
-func (t *saslAuthenticateRequestV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+func (t *saslAuthenticateRequestV1) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
 	return readBytes(r, sz, &t.Data)
 }
 
-func (t saslAuthenticateRequestV0) writeTo(wb *writeBuffer) {
+func (t saslAuthenticateRequestV1) writeTo(wb *writeBuffer) {
 	wb.writeBytes(t.Data)
 }
 
-type saslAuthenticateResponseV0 struct {
+type saslAuthenticateResponseV1 struct {
 	// ErrorCode holds response error code
 	ErrorCode int16
 
 	ErrorMessage string
 
 	Data []byte
+
+	SessionLifetimeMillis int64
 }
 
-func (t saslAuthenticateResponseV0) size() int32 {
-	return sizeofInt16(t.ErrorCode) + sizeofString(t.ErrorMessage) + sizeofBytes(t.Data)
+func (t saslAuthenticateResponseV1) size() int32 {
+	return sizeofInt16(t.ErrorCode) + sizeofString(t.ErrorMessage) + sizeofBytes(t.Data) + sizeofInt64(t.SessionLifetimeMillis)
 }
 
-func (t saslAuthenticateResponseV0) writeTo(wb *writeBuffer) {
+func (t saslAuthenticateResponseV1) writeTo(wb *writeBuffer) {
 	wb.writeInt16(t.ErrorCode)
 	wb.writeString(t.ErrorMessage)
 	wb.writeBytes(t.Data)
+	wb.writeInt64(t.SessionLifetimeMillis)
 }
 
-func (t *saslAuthenticateResponseV0) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
+func (t *saslAuthenticateResponseV1) readFrom(r *bufio.Reader, sz int) (remain int, err error) {
 	if remain, err = readInt16(r, sz, &t.ErrorCode); err != nil {
 		return
 	}
@@ -50,5 +53,9 @@ func (t *saslAuthenticateResponseV0) readFrom(r *bufio.Reader, sz int) (remain i
 	if remain, err = readBytes(r, remain, &t.Data); err != nil {
 		return
 	}
+	if remain, err = readInt64(r, remain, &t.SessionLifetimeMillis); err != nil {
+		return
+	}
+
 	return
 }

--- a/saslauthenticate_test.go
+++ b/saslauthenticate_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 )
 
-func TestSASLAuthenticateRequestV0(t *testing.T) {
-	item := saslAuthenticateRequestV0{
+func TestSASLAuthenticateRequestV1(t *testing.T) {
+	item := saslAuthenticateRequestV1{
 		Data: []byte("\x00user\x00pass"),
 	}
 
@@ -16,7 +16,7 @@ func TestSASLAuthenticateRequestV0(t *testing.T) {
 	w := &writeBuffer{w: b}
 	item.writeTo(w)
 
-	var found saslAuthenticateRequestV0
+	var found saslAuthenticateRequestV1
 	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)
@@ -32,18 +32,19 @@ func TestSASLAuthenticateRequestV0(t *testing.T) {
 	}
 }
 
-func TestSASLAuthenticateResponseV0(t *testing.T) {
-	item := saslAuthenticateResponseV0{
-		ErrorCode:    2,
-		ErrorMessage: "Message",
-		Data:         []byte("bytes"),
+func TestSASLAuthenticateResponseV1(t *testing.T) {
+	item := saslAuthenticateResponseV1{
+		ErrorCode:             2,
+		ErrorMessage:          "Message",
+		Data:                  []byte("bytes"),
+		SessionLifetimeMillis: 1000,
 	}
 
 	b := bytes.NewBuffer(nil)
 	w := &writeBuffer{w: b}
 	item.writeTo(w)
 
-	var found saslAuthenticateResponseV0
+	var found saslAuthenticateResponseV1
 	remain, err := (&found).readFrom(bufio.NewReader(b), b.Len())
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Fixes https://github.com/segmentio/kafka-go/issues/1093

This PR aims to interpret the session timeout in the SaslAuthenticate V1 Response. Considering that both `saslAuthenticateRequestV0` and `saslAuthenticateResponseV0` are only used in when we're working with V1 requests, i've decided to rename these to `saslAuthenticateRequestV1` and `saslAuthenticateResponseV1` and bring in the addition of `session_lifetime_ms`

V1 Response:
```
SaslAuthenticate Response (Version: 1) => error_code error_message auth_bytes session_lifetime_ms 
  error_code => INT16
  error_message => NULLABLE_STRING
  auth_bytes => BYTES
  session_lifetime_ms => INT64
```

https://kafka.apache.org/protocol.html#The_Messages_SaslAuthenticate

I've also taken inspiration from https://github.com/twmb/franz-go/blob/a1a2a452c33e53c177792b251c523786c4d9fa27/pkg/kgo/broker.go#L373 to check the expiry on read, at a staggered interval at around 90-90% of the session_lifetime_ms