### PR TITLE
Add Chunk Size to RR Balancer (Increased Batching Ability)

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -56,7 +56,8 @@ func (rr *RoundRobin) balance(partitions []int) int {
 }
 
 // ChunkedRoundRobin is a Balancer implementation that equally distributes messages
-// across all available partitions, but in chunks
+// across all available partitions, but puts greater emphasis on batching by a chunk size
+// within a shorter time period than is possible via the regular RoundRobin Balancer.
 type ChunkedRoundRobin struct {
 	chunkSize int
 
@@ -79,8 +80,7 @@ func (rr *ChunkedRoundRobin) Balance(msg Message, partitions ...int) int {
 		rr.chunkSize = 1
 	}
 
-	var choice int
-	choice = (int(atomic.AddUint64(next, 1)) / rr.chunkSize) % len(partitions)
+	choice := (int(atomic.AddUint64(next, 1)) / rr.chunkSize) % len(partitions)
 	return choice
 }
 

--- a/balancer.go
+++ b/balancer.go
@@ -52,7 +52,6 @@ func (rr *RoundRobin) Balance(msg Message, partitions ...int) int {
 }
 
 func (rr *RoundRobin) balance(partitions []int) int {
-
 	if rr.ChunkSize < 1 {
 		rr.ChunkSize = 1
 	}

--- a/balancer.go
+++ b/balancer.go
@@ -75,7 +75,7 @@ func (rr *ChunkedRoundRobin) Balance(msg Message, partitions ...int) int {
 	}
 	var next = rr.counter
 
-	// set default chunk size to 1
+	// set default chunk size to 1.
 	if rr.ChunkSize < 1 {
 		rr.ChunkSize = 1
 	}

--- a/balancer.go
+++ b/balancer.go
@@ -37,7 +37,8 @@ func (f BalancerFunc) Balance(msg Message, partitions ...int) int {
 
 // RoundRobin is an Balancer implementation that equally distributes messages
 // across all available partitions.  It can take an optional chunk size to send
-// ChunkSize messages to the same partition before moving to the next partition
+// ChunkSize messages to the same partition before moving to the next partition.
+// This can be used to improve batch sizes.
 type RoundRobin struct {
 	ChunkSize int
 	mutex     sync.RWMutex

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -473,7 +473,7 @@ func TestChunkedRoundRobin(t *testing.T) {
 	}
 	for label, test := range testCases {
 		t.Run(label, func(t *testing.T) {
-			lb := &ChunkedRoundRobin{chunkSize: test.ChunkSize}
+			lb := &ChunkedRoundRobin{ChunkSize: test.ChunkSize}
 			msg := Message{}
 			var partition int
 			var i int

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -411,3 +411,83 @@ func TestLeastBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestRoundRobin(t *testing.T) {
+	t.Run("test_round_robin", func(t *testing.T) {
+		lb := &RoundRobin{}
+		msg := Message{Key: nil}
+		var partition int
+		var i int
+		for i = 0; i < 50; i++ {
+			partition = lb.Balance(msg, []int{0, 1, 2, 3, 4, 5, 6}...)
+			if partition != i%7 {
+				t.Error("Returned partition", partition, "expecting", i%7)
+			}
+		}
+	})
+}
+
+func TestChunkedRoundRobin(t *testing.T) {
+	testCases := map[string]struct {
+		Partitions []int
+		ChunkSize  int
+	}{
+		"default - odd partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6},
+		},
+		"negative chunk size - odd partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6},
+			ChunkSize:  -1,
+		},
+		"0 chunk size - odd partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6},
+			ChunkSize:  0,
+		},
+		"5 chunk size - odd partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6},
+			ChunkSize:  5,
+		},
+		"12 chunk size - odd partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6},
+			ChunkSize:  12,
+		},
+		"default - even partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6, 7},
+		},
+		"negative chunk size - even partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			ChunkSize:  -1,
+		},
+		"0 chunk size - even partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			ChunkSize:  0,
+		},
+		"5 chunk size - even partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			ChunkSize:  5,
+		},
+		"12 chunk size - even partition count": {
+			Partitions: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			ChunkSize:  12,
+		},
+	}
+	for label, test := range testCases {
+		t.Run(label, func(t *testing.T) {
+			lb := &ChunkedRoundRobin{chunkSize: test.ChunkSize}
+			msg := Message{}
+			var partition int
+			var i int
+			expectedChunkSize := test.ChunkSize
+			if expectedChunkSize < 1 {
+				expectedChunkSize = 1
+			}
+			partitions := test.Partitions
+			for i = 0; i < 50; i++ {
+				partition = lb.Balance(msg, partitions...)
+				if partition != i/expectedChunkSize%len(partitions) {
+					t.Error("Returned partition", partition, "expecting", i/expectedChunkSize%len(partitions))
+				}
+			}
+		})
+	}
+}

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -413,21 +413,6 @@ func TestLeastBytes(t *testing.T) {
 }
 
 func TestRoundRobin(t *testing.T) {
-	t.Run("test_round_robin", func(t *testing.T) {
-		lb := &RoundRobin{}
-		msg := Message{Key: nil}
-		var partition int
-		var i int
-		for i = 0; i < 50; i++ {
-			partition = lb.Balance(msg, []int{0, 1, 2, 3, 4, 5, 6}...)
-			if partition != i%7 {
-				t.Error("Returned partition", partition, "expecting", i%7)
-			}
-		}
-	})
-}
-
-func TestChunkedRoundRobin(t *testing.T) {
 	testCases := map[string]struct {
 		Partitions []int
 		ChunkSize  int
@@ -473,7 +458,7 @@ func TestChunkedRoundRobin(t *testing.T) {
 	}
 	for label, test := range testCases {
 		t.Run(label, func(t *testing.T) {
-			lb := &ChunkedRoundRobin{ChunkSize: test.ChunkSize}
+			lb := &RoundRobin{ChunkSize: test.ChunkSize}
 			msg := Message{}
 			var partition int
 			var i int


### PR DESCRIPTION
The motivation here is to try to get Kafka-Go's RR Balancer to batch more aggressively.  The RR Balancer naively iterates through the available partitions, putting a single message on each of them until the batch timeout.  If it could put x messages on each partition before moving onto the next one, it would still be evenly distributed, but batch better.

The coding approach was to bring in the same chunking mechanism our internal Bulrush library uses, but simplify it and adapt it for the code-style of Kafka-Go.  