### PR TITLE
[DP-1901] - Convert Wurstmeister Kafka image to Bitnami for Kafka-go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,31 +12,41 @@ jobs:
   kafka-010:
     working_directory: &working_directory /go/src/github.com/segmentio/kafka-go
     environment:
-      KAFKA_VERSION: "0.10.1"
+      KAFKA_VERSION: "0.10.2"
     docker:
     - image: circleci/golang
-    - image: wurstmeister/zookeeper
+    - image: bitnami/zookeeper:latest
       ports:
       - 2181:2181
-    - image: wurstmeister/kafka:0.10.1.1
-      ports:
-      - 9092:9092
-      - 9093:9093
       environment:
-        KAFKA_BROKER_ID: '1'
+        ALLOW_ANONYMOUS_LOGIN: yes
+    - image: bitnami/kafka:0.10.2.1
+      ports:
+        - 9092:9092
+        - 9093:9093
+      environment:
+        KAFKA_BROKER_ID: 1
         KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
         KAFKA_DELETE_TOPIC_ENABLE: 'true'
         KAFKA_ADVERTISED_HOST_NAME: 'localhost'
         KAFKA_ADVERTISED_PORT: '9092'
-        KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+        KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
         KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
         KAFKA_MESSAGE_MAX_BYTES: '200000000'
+
         KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
         KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-        KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN'
-        KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-        CUSTOM_INIT_SCRIPT: |-
-          echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+        KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+        KAFKA_AUTHORIZER_CLASS_NAME: 'kafka.security.auth.SimpleAclAuthorizer'
+        KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: 'true'
+
+        KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/bitnami/kafka/config/kafka_server_jaas.conf"
+        ALLOW_PLAINTEXT_LISTENER: yes
+      entrypoint:
+        - "/bin/bash"
+        - "-c"
+        - echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/bitnami/kafka/config/kafka_server_jaas.conf; exec /app-entrypoint.sh /start-kafka.sh
+
     steps: &steps
     - checkout
     - restore_cache:

--- a/README.md
+++ b/README.md
@@ -797,3 +797,8 @@ KAFKA_VERSION=2.3.1 \
   KAFKA_SKIP_NETTEST=1 \
   go test -race ./...
 ```
+
+(or) to clean up the cached test results and run tests:
+```
+go clean -cache && make test
+```

--- a/docker-compose-270.yml
+++ b/docker-compose-270.yml
@@ -12,7 +12,7 @@ services:
 
   kafka:
     container_name: kafka
-    image: bitnami/kafka:2.4.1
+    image: bitnami/kafka:2.7.0
     restart: on-failure:3
     links:
       - zookeeper

--- a/docker-compose.010.yml
+++ b/docker-compose.010.yml
@@ -1,29 +1,43 @@
-version: "3"
+# See https://hub.docker.com/r/bitnami/kafka/tags for the complete list.
+version: '3'
 services:
-  kafka:
-    image: wurstmeister/kafka:0.10.1.1
-    links:
-    - zookeeper
+  zookeeper:
+    container_name: zookeeper
+    hostname: zookeeper
+    image: bitnami/zookeeper:latest
     ports:
-    - 9092:9092
-    - 9093:9093
+      - 2181:2181
     environment:
-      KAFKA_BROKER_ID: '1'
+      ALLOW_ANONYMOUS_LOGIN: yes
+
+  kafka:
+    container_name: kafka
+    image: bitnami/kafka:0.10.2.1
+    restart: on-failure:3
+    links:
+      - zookeeper
+    ports:
+      - 9092:9092
+      - 9093:9093
+    environment:
+      KAFKA_BROKER_ID: 1
       KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
       KAFKA_ADVERTISED_HOST_NAME: 'localhost'
       KAFKA_ADVERTISED_PORT: '9092'
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_MESSAGE_MAX_BYTES: '200000000'
+
       KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN'
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-      CUSTOM_INIT_SCRIPT: |-
-        echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_AUTHORIZER_CLASS_NAME: 'kafka.security.auth.SimpleAclAuthorizer'
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: 'true'
 
-  zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-    - 2181:2181
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/bitnami/kafka/config/kafka_server_jaas.conf"
+      ALLOW_PLAINTEXT_LISTENER: yes
+    entrypoint:
+      - "/bin/bash"
+      - "-c"
+      - echo -e 'KafkaServer {\norg.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/bitnami/kafka/config/kafka_server_jaas.conf; exec /app-entrypoint.sh /start-kafka.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,47 @@
-version: "3"
+# See https://hub.docker.com/r/bitnami/kafka/tags for the complete list.
+# bitnami 2.3.1 reference - https://github.com/bitnami/containers/tree/ae572036b5281456b0086345fec0bdb74f7cf3a3/bitnami/kafka/2
+version: '3'
 services:
+  zookeeper:
+    container_name: zookeeper
+    hostname: zookeeper
+    image: bitnami/zookeeper:latest
+    ports:
+      - 2181:2181
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: yes
+
   kafka:
-    image: wurstmeister/kafka:2.12-2.3.1
+    container_name: kafka
+    image: bitnami/kafka:2.3.1
     restart: on-failure:3
     links:
-    - zookeeper
+      - zookeeper
     ports:
-    - 9092:9092
-    - 9093:9093
+      - 9092:9092
+      - 9093:9093
     environment:
-      KAFKA_VERSION: '2.3.1'
-      KAFKA_BROKER_ID: '1'
-      KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
-      KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_ADVERTISED_HOST_NAME: 'localhost'
-      KAFKA_ADVERTISED_PORT: '9092'
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-      KAFKA_MESSAGE_MAX_BYTES: '200000000'
-      KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
-      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
-      KAFKA_AUTHORIZER_CLASS_NAME: 'kafka.security.auth.SimpleAclAuthorizer'
-      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: 'true'
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
-      CUSTOM_INIT_SCRIPT: |-
-        echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
-        /opt/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
+      KAFKA_CFG_BROKER_ID: 1
+      # KAFKA_CFG_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+      KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
+      KAFKA_CFG_ADVERTISED_HOST_NAME: 'localhost'
+      KAFKA_CFG_ADVERTISED_PORT: '9092'
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_CFG_MESSAGE_MAX_BYTES: '200000000'
+      KAFKA_CFG_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+      KAFKA_CFG_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_CFG_AUTHORIZER_CLASS_NAME: 'kafka.security.auth.SimpleAclAuthorizer'
+      KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: 'true'
 
-  zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-    - 2181:2181
+      KAFKA_INTER_BROKER_USER: adminplain
+      KAFKA_INTER_BROKER_PASSWORD: admin-secret
+      KAFKA_BROKER_USER: adminplain
+      KAFKA_BROKER_PASSWORD: admin-secret
+
+      ALLOW_PLAINTEXT_LISTENER: yes
+    entrypoint:
+      - "/bin/bash"
+      - "-c"
+      - /opt/bitnami/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config "SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]" --entity-type users --entity-name adminscram; exec /entrypoint.sh /run.sh


### PR DESCRIPTION
# Description

This effort is to convert all the wurstmeister kafka, zookeeper images to Bitnami kafka, zookeeper

## NOTE:
bitnami do not have image support for kafka version 0.10.1.1. Hence we will be using kafka version 0.10.2.1 instead of 0.10.1.1.

reference - https://hub.docker.com/r/bitnami/kafka/tags?page=1&name=0.10.