### PR TITLE
Fix RetentionTime error in documentation default is -1

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -469,9 +469,11 @@ type ReaderConfig struct {
 	JoinGroupBackoff time.Duration
 
 	// RetentionTime optionally sets the length of time the consumer group will be saved
-	// by the broker
+	// by the broker. -1 will disable the setting and leave the
+	// retention up to the broker's offsets.retention.minutes property. By
+	// default, that setting is 1 day for kafka < 2.0 and 7 days for kafka >= 2.0.
 	//
-	// Default: 24h
+	// Default: -1
 	//
 	// Only used when GroupID is set
 	RetentionTime time.Duration


### PR DESCRIPTION
Fix error in documentation for ReaderConfig.RetentionTime. Default value should be -1.

Fix #1244 