### PR TITLE
Allow null replicas in RequestPartition

### DIFF
--- a/alterpartitionreassignments.go
+++ b/alterpartitionreassignments.go
@@ -81,7 +81,7 @@ func (c *Client) AlterPartitionReassignments(
 			apiTopicMap[topic] = apiTopic
 		}
 
-		replicas := []int32{}
+		var replicas []int32
 		for _, brokerID := range assignment.BrokerIDs {
 			replicas = append(replicas, int32(brokerID))
 		}


### PR DESCRIPTION
The `replicas` slice was declared as an empty slice which precludes passing a nil slice in the case of wanting to cancel an ongoing assignment.