### PR TITLE
Remove trailing newlines from log messages

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -467,7 +467,7 @@ func (g *Generation) heartbeatLoop(interval time.Duration) {
 			l.Printf("started heartbeat for group, %v [%v]", g.GroupID, interval)
 		})
 		defer g.log(func(l Logger) {
-			l.Printf("stopped heartbeat for group %s\n", g.GroupID)
+			l.Printf("stopped heartbeat for group %s", g.GroupID)
 		})
 
 		ticker := time.NewTicker(interval)
@@ -1009,7 +1009,7 @@ func (cg *ConsumerGroup) makeJoinGroupRequestV1(memberID string) (joinGroupReque
 // their various partitions.
 func (cg *ConsumerGroup) assignTopicPartitions(conn coordinator, group joinGroupResponseV1) (GroupMemberAssignments, error) {
 	cg.withLogger(func(l Logger) {
-		l.Printf("selected as leader for group, %s\n", cg.config.ID)
+		l.Printf("selected as leader for group, %s", cg.config.ID)
 	})
 
 	balancer, ok := findGroupBalancer(group.GroupProtocol, cg.config.GroupBalancers)

--- a/reader.go
+++ b/reader.go
@@ -271,10 +271,10 @@ func (r *Reader) commitLoopInterval(ctx context.Context, gen *Generation) {
 // commitLoop processes commits off the commit chan.
 func (r *Reader) commitLoop(ctx context.Context, gen *Generation) {
 	r.withLogger(func(l Logger) {
-		l.Printf("started commit for group %s\n", r.config.GroupID)
+		l.Printf("started commit for group %s", r.config.GroupID)
 	})
 	defer r.withLogger(func(l Logger) {
-		l.Printf("stopped commit for group %s\n", r.config.GroupID)
+		l.Printf("stopped commit for group %s", r.config.GroupID)
 	})
 
 	if r.useSyncCommits() {
@@ -293,7 +293,7 @@ func (r *Reader) run(cg *ConsumerGroup) {
 	defer cg.Close()
 
 	r.withLogger(func(l Logger) {
-		l.Printf("entering loop for consumer group, %v\n", r.config.GroupID)
+		l.Printf("entering loop for consumer group, %v", r.config.GroupID)
 	})
 
 	for {


### PR DESCRIPTION
The majority of logged messages don't have newlines at the end - this PR makes the rest of the logged messages consistent.