### PR TITLE
Fixes #874

### DIFF
--- a/message_reader.go
+++ b/message_reader.go
@@ -135,6 +135,11 @@ func (r *messageSetReader) readMessage(min int64, key readBytesFunc, val readByt
 		// Set an invalid value so that it can be ignored
 		lastOffset = -1
 	case 2:
+		for ; r.count == 0; err = r.readHeader() {
+			if err != nil {
+				return
+			}
+		}
 		offset, lastOffset, timestamp, headers, err = r.readMessageV2(min, key, val)
 	default:
 		err = r.header.badMagic()


### PR DESCRIPTION
I stumbled across #874 and dug in.

The issue seems to be caused by the fact readMessageV2 expects a message to be present on the wire, but a compacted topic may return a "RecordBatch" with no records (when an offset gets compacted out).

The proposed fix loops reading additional headers when both RecordBatch is used ( [i.e. magic number 2](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Messagesets) ) and when the returned RecordBatch has zero records.

If the maintainers request any additional work, I'm happy to let someone else complete the work as I don't know when I'd be able to come back to this.