### PR TITLE
Makefile: use docker compose not docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ test:
 	go test -race -cover ./...
 
 docker:
-	docker-compose up -d
+	docker compose up -d


### PR DESCRIPTION
As part of the Docker binary this will be updated more often and has
better support and newer features than the separate "docker-compose"
binary.
