### PR TITLE
docker-compose.yml: specify AMD64 platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,18 +6,27 @@ services:
     hostname: zookeeper
     image: bitnami/zookeeper:latest
     ports:
-      - 2181:2181
+    - 2181:2181
     environment:
       ALLOW_ANONYMOUS_LOGIN: yes
+    # If you are on arm64 and experiencing issues with the tests (hangs,
+    # connection reset) then try the following in order:
+
+    # - stopping and removing all downloaded container images
+    # - ensuring you have the latest Docker Desktop version
+    # - factory reset your Docker Desktop settings
+
+    # If you are still running into issues please post in #help-infra-seg.
+    platform: linux/amd64
   kafka:
     container_name: kafka
     image: bitnami/kafka:2.3.1-ol-7-r61
     restart: on-failure:3
     links:
-      - zookeeper
+    - zookeeper
     ports:
-      - 9092:9092
-      - 9093:9093
+    - 9092:9092
+    - 9093:9093
     environment:
       KAFKA_CFG_BROKER_ID: 1
       KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
@@ -37,6 +46,10 @@ services:
       KAFKA_BROKER_PASSWORD: admin-secret
       ALLOW_PLAINTEXT_LISTENER: yes
     entrypoint:
-      - "/bin/bash"
-      - "-c"
-      - /opt/bitnami/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config "SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]" --entity-type users --entity-name adminscram; exec /entrypoint.sh /run.sh
+    - "/bin/bash"
+    - "-c"
+    - /opt/bitnami/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config
+      "SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]"
+      --entity-type users --entity-name adminscram; exec /entrypoint.sh /run.sh
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64


### PR DESCRIPTION
Several Docker images used by Segment do not work reliably on Mac M1 laptops,
which use the arm64 chipset. Commonly, these are images that were built several
years ago, before M1 laptops were in widespread use, and behave unpredictably
when run on an arm64 chipset.

The simplest workaround is to ensure that the Docker environment is always
running on amd64. If this service runs on Graviton instances (which use the
arm64 chipset), then you should close this PR, or reverse the "platform" to
instead specify "linux/arm64".

This change should ensure that employees with Apple M1 laptops will be able to
reliably start and run Docker containers on this repository.

This commit may include some whitespace-only changes, which are an
artifact of the comment-preserving YAML parser that was used to modify the
docker-compose.yml file. To exclude these from the diff, append ?w=1 to the pull
request URL.

This pull request was generated by a script run by Kevin Burke. There are over
300 docker-compose files at Segment and he would appreciate your help testing
and merging this pull request. At this scale, it is not possible to satisfy
every repository's rules for formatting, labeling, and testing pull requests.

If you have questions, please post in #help-infra-seg.
JIRA: https://segment.atlassian.net/browse/IO-2101
