### PR TITLE
Add ErrorType method to MessageTooLargeError

### DIFF
--- a/error.go
+++ b/error.go
@@ -636,6 +636,7 @@ func coalesceErrors(errs ...error) error {
 	return nil
 }
 
+// MessageTooLargeError is returned when a message is too large to fit within the allowed size.
 type MessageTooLargeError struct {
 	Message   Message
 	Remaining []Message
@@ -653,6 +654,19 @@ func messageTooLarge(msgs []Message, i int) MessageTooLargeError {
 
 func (e MessageTooLargeError) Error() string {
 	return MessageSizeTooLarge.Error()
+}
+
+// ErrorType returns the specific error type associated with the MessageTooLargeError.
+// This function returns the predefined Error constant MessageSizeTooLarge, indicating
+// that the error occurred due to a message being too large to fit within the allowed size.
+//
+// Example:
+//
+//	err := MessageSizeTooLarge
+//	msgTooLarge := []Message{...}
+//	errors.Is(err, msgTooLarge.ErrorType())
+func (e MessageTooLargeError) ErrorType() Error {
+	return MessageSizeTooLarge
 }
 
 func makeError(code int16, message string) error {

--- a/error.go
+++ b/error.go
@@ -656,7 +656,7 @@ func (e MessageTooLargeError) Error() string {
 	return MessageSizeTooLarge.Error()
 }
 
-func (e MessageTooLargeError) Unwrap() Error {
+func (e MessageTooLargeError) Unwrap() error {
 	return MessageSizeTooLarge
 }
 

--- a/error.go
+++ b/error.go
@@ -656,16 +656,7 @@ func (e MessageTooLargeError) Error() string {
 	return MessageSizeTooLarge.Error()
 }
 
-// ErrorType returns the specific error type associated with the MessageTooLargeError.
-// This function returns the predefined Error constant MessageSizeTooLarge, indicating
-// that the error occurred due to a message being too large to fit within the allowed size.
-//
-// Example:
-//
-//	err := MessageSizeTooLarge
-//	msgTooLarge := []Message{...}
-//	errors.Is(err, msgTooLarge.ErrorType())
-func (e MessageTooLargeError) ErrorType() Error {
+func (e MessageTooLargeError) Unwrap() Error {
 	return MessageSizeTooLarge
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -1,8 +1,11 @@
 package kafka
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestError(t *testing.T) {
@@ -109,5 +112,17 @@ func TestError(t *testing.T) {
 		if s := err.Description(); len(s) != 0 {
 			t.Error("non-empty description:", s)
 		}
+	})
+
+	t.Run("MessageTooLargeError error.Is satisfaction", func(t *testing.T) {
+		err := MessageSizeTooLarge
+		msg := []Message{
+			{Key: []byte("key"), Value: []byte("value")},
+			{Key: []byte("key"), Value: make([]byte, 1024*1024)},
+		}
+		msgTooLarge := messageTooLarge(msg, 1)
+		assert.False(t, errors.Is(err, msgTooLarge))
+		assert.Equal(t, err.Error(), msgTooLarge.Error())
+		assert.True(t, errors.Is(err, msgTooLarge.ErrorType()))
 	})
 }

--- a/error_test.go
+++ b/error_test.go
@@ -117,7 +117,7 @@ func TestError(t *testing.T) {
 		err := MessageSizeTooLarge
 		msg := []Message{
 			{Key: []byte("key"), Value: []byte("value")},
-			{Key: []byte("key"), Value: make([]byte, 1024*1024)},
+			{Key: []byte("key"), Value: make([]byte, 8)},
 		}
 		msgTooLarge := messageTooLarge(msg, 1)
 		assert.NotErrorIs(t, err, msgTooLarge)

--- a/error_test.go
+++ b/error_test.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -121,8 +120,8 @@ func TestError(t *testing.T) {
 			{Key: []byte("key"), Value: make([]byte, 1024*1024)},
 		}
 		msgTooLarge := messageTooLarge(msg, 1)
-		assert.False(t, errors.Is(err, msgTooLarge))
-		assert.Equal(t, err.Error(), msgTooLarge.Error())
-		assert.True(t, errors.Is(err, msgTooLarge.ErrorType()))
+		assert.NotErrorIs(t, err, msgTooLarge)
+		assert.Contains(t, msgTooLarge.Error(), MessageSizeTooLarge.Error())
+		assert.ErrorIs(t, msgTooLarge, MessageSizeTooLarge)
 	})
 }


### PR DESCRIPTION
## Description
When someone is trying to check an errors.Is comparison of the struct MessageTooLargeError there is no good way to check that the underlying error `MessageSizeTooLarge`. By exposing the underlying error with this new method it allows end users to be able to make a comparison using errors.Is().

Add ErrorType method to MessageTooLargeError struct to support functionality with the errors.Is function.

closes #1293

