### PR TITLE
Fix: Returning error if received UnknownTopicOrPartition from readPartitions

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -1027,12 +1027,7 @@ func (cg *ConsumerGroup) assignTopicPartitions(conn coordinator, group joinGroup
 
 	topics := extractTopics(members)
 	partitions, err := conn.readPartitions(topics...)
-
-	// it's not a failure if the topic doesn't exist yet.  it results in no
-	// assignments for the topic.  this matches the behavior of the official
-	// clients: java, python, and librdkafka.
-	// a topic watcher can trigger a rebalance when the topic comes into being.
-	if err != nil && !errors.Is(err, UnknownTopicOrPartition) {
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
First suggestion to fix issue https://github.com/segmentio/kafka-go/issues/1314 with no rebalance after consumer in consumer group receives empty assignment

https://github.com/segmentio/kafka-go/issues/1314

Cause of the issue:

1. assignTopicToPartition ignores error UnknownTopicOrPartition
2. Topic in Kafka creates after p.1
3. partitionWatcher receives num of partition from created topic and fall through in loop
4. If partitions will never be added to a topic, the group will never rebalance
5. Consumers never consume their messages

Solution:
assignTopicToPartition should fail with error if receives UnknownTopicOrPartition and start next generation.