### PR TITLE
Fix: Ignoring error UnknownTopicOrPartition in partitionWatcher

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -510,10 +510,11 @@ func (g *Generation) partitionWatcher(interval time.Duration, topic string) {
 		defer ticker.Stop()
 
 		ops, err := g.conn.readPartitions(topic)
-		if err != nil {
+		if err != nil && !errors.Is(err, UnknownTopicOrPartition) {
 			g.logError(func(l Logger) {
 				l.Printf("Problem getting partitions during startup, %v\n, Returning and setting up nextGeneration", err)
 			})
+
 			return
 		}
 		oParts := len(ops)


### PR DESCRIPTION
Second suggestion to fix issue https://github.com/segmentio/kafka-go/issues/1314 with no rebalance after consumer in consumer group receives empty assignment

https://github.com/segmentio/kafka-go/issues/1314

Cause of the issue:

1. Topic is not created
2. assignPartitions not fail with error
3. Topic created
4. partitionWatcher receives count of partitions from topic and fall through in loop
5. Group never rebalances

Solution:
partitionWatcher should ignore UnknownTopicOrPartition error and fall to loop with 0 start partitions count