### PR TITLE
Fix redundant nil check of allocated address

### DIFF
--- a/protocol/request.go
+++ b/protocol/request.go
@@ -77,10 +77,6 @@ func WriteRequest(w io.Writer, apiVersion int16, correlationID int32, clientID s
 	}
 
 	t := &apiTypes[apiKey]
-	if t == nil {
-		return fmt.Errorf("unsupported api: %s", apiNames[apiKey])
-	}
-
 	if typedMessage, ok := msg.(OverrideTypeMessage); ok {
 		typeKey := typedMessage.TypeKey()
 		overrideType := overrideApiTypes[apiKey][typeKey]

--- a/reader_test.go
+++ b/reader_test.go
@@ -858,6 +858,7 @@ func TestReaderConsumerGroup(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.scenario, func(t *testing.T) {
 			// It appears that some of the tests depend on all these tests being
 			// run concurrently to pass... this is brittle and should be fixed


### PR DESCRIPTION
Apparently, any elements in array variable apiTypes has been allocated, the nil check is redundant.