### PR TITLE
Do not commit offsets for past generations if partition not owned

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -232,7 +232,9 @@ func (batch *Batch) ReadMessage() (Message, error) {
 	msg.HighWaterMark = batch.highWaterMark
 	msg.Time = makeTime(timestamp)
 	msg.Headers = headers
-	msg.GenerationId = batch.conn.generationId
+	if batch.conn != nil {
+		msg.GenerationId = batch.conn.generationId
+	}
 
 	return msg, err
 }

--- a/batch.go
+++ b/batch.go
@@ -232,6 +232,7 @@ func (batch *Batch) ReadMessage() (Message, error) {
 	msg.HighWaterMark = batch.highWaterMark
 	msg.Time = makeTime(timestamp)
 	msg.Headers = headers
+	msg.GenerationId = batch.conn.generationId
 
 	return msg, err
 }

--- a/commit.go
+++ b/commit.go
@@ -3,18 +3,20 @@ package kafka
 // A commit represents the instruction of publishing an update of the last
 // offset read by a program for a topic and partition.
 type commit struct {
-	topic     string
-	partition int
-	offset    int64
+	topic        string
+	partition    int
+	offset       int64
+	generationId int32
 }
 
 // makeCommit builds a commit value from a message, the resulting commit takes
 // its topic, partition, and offset from the message.
 func makeCommit(msg Message) commit {
 	return commit{
-		topic:     msg.Topic,
-		partition: msg.Partition,
-		offset:    msg.Offset + 1,
+		topic:        msg.Topic,
+		partition:    msg.Partition,
+		offset:       msg.Offset + 1,
+		generationId: msg.GenerationId,
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -65,6 +65,8 @@ type Conn struct {
 	apiVersions atomic.Value // apiVersionMap
 
 	transactionalID *string
+
+	generationId int32
 }
 
 type apiVersionMap map[apiKey]ApiVersion
@@ -182,6 +184,7 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 		offset:          FirstOffset,
 		requiredAcks:    -1,
 		transactionalID: emptyToNullable(config.TransactionalID),
+		generationId:    -1,
 	}
 
 	c.wb.w = &c.wbuf
@@ -388,6 +391,7 @@ func (c *Conn) joinGroup(request joinGroupRequestV1) (joinGroupResponseV1, error
 		return joinGroupResponseV1{}, Error(response.ErrorCode)
 	}
 
+	c.generationId = response.GenerationID
 	return response, nil
 }
 

--- a/message.go
+++ b/message.go
@@ -20,6 +20,10 @@ type Message struct {
 	Value         []byte
 	Headers       []Header
 
+	// If the message has been sent by a consumer group, it contains the
+	// generation's id. Value is -1 if not using consumer groups.
+	GenerationId int32
+
 	// This field is used to hold arbitrary data you wish to include, so it
 	// will be available when handle it on the Writer's `Completion` method,
 	// this support the application can do any post operation on each message.

--- a/reader.go
+++ b/reader.go
@@ -121,7 +121,7 @@ func (r *Reader) unsubscribe() {
 	// another consumer to avoid such a race.
 }
 
-func (r *Reader) subscribe(allAssignments map[string][]PartitionAssignment) {
+func (r *Reader) subscribe(generationId int32, allAssignments map[string][]PartitionAssignment) {
 	offsets := make(map[topicPartition]int64)
 	for topic, assignments := range allAssignments {
 		for _, assignment := range assignments {
@@ -134,7 +134,7 @@ func (r *Reader) subscribe(allAssignments map[string][]PartitionAssignment) {
 	}
 
 	r.mutex.Lock()
-	r.start(offsets)
+	r.start(generationId, offsets)
 	r.mutex.Unlock()
 
 	r.withLogger(func(l Logger) {
@@ -152,9 +152,31 @@ func (r *Reader) commitOffsetsWithRetry(gen *Generation, offsetStash offsetStash
 
 	messagesToSend := make(map[string]map[int]int64)
 	for topic, partitionsInfo := range offsetStash {
-		messagesToSend[topic] = make(map[int]int64)
+		msgsForTopic := make(map[int]int64)
 		for partition, commitInfo := range partitionsInfo {
-			messagesToSend[topic][partition] = commitInfo.offset
+			// if there is a generation and it is different than the current
+			// it means there was a rebalance
+			if commitInfo.generationId != -1 {
+				if gen.ID == commitInfo.generationId {
+					msgsForTopic[partition] = commitInfo.offset
+				} else {
+					if assignments, ok := gen.Assignments[topic]; ok {
+						for _, assignment := range assignments {
+							if assignment.ID == partition && commitInfo.generationId > gen.ID {
+								msgsForTopic[partition] = commitInfo.offset
+							}
+						}
+					}
+					r.withErrorLogger(func(l Logger) {
+						l.Printf("Discarding commint for %s - %d: %d . Current generation is %d, commit generation is %d", topic, partition, commitInfo.offset, gen.ID, commitInfo.generationId)
+					})
+				}
+			} else {
+				msgsForTopic[partition] = commitInfo.offset
+			}
+		}
+		if len(msgsForTopic) > 0 {
+			messagesToSend[topic] = msgsForTopic
 		}
 	}
 	for attempt := 0; attempt < retries; attempt++ {
@@ -343,7 +365,7 @@ func (r *Reader) run(cg *ConsumerGroup) {
 
 		r.stats.rebalances.observe(1)
 
-		r.subscribe(gen.Assignments)
+		r.subscribe(gen.ID, gen.Assignments)
 
 		gen.Start(func(ctx context.Context) {
 			r.commitLoop(ctx, gen)
@@ -833,7 +855,7 @@ func (r *Reader) FetchMessage(ctx context.Context) (Message, error) {
 		r.mutex.Lock()
 
 		if !r.closed && r.version == 0 {
-			r.start(r.getTopicPartitionOffset())
+			r.start(-1, r.getTopicPartitionOffset())
 		}
 
 		version := r.version
@@ -1054,7 +1076,7 @@ func (r *Reader) SetOffset(offset int64) error {
 		r.offset = offset
 
 		if r.version != 0 {
-			r.start(r.getTopicPartitionOffset())
+			r.start(-1, r.getTopicPartitionOffset())
 		}
 
 		r.activateReadLag()
@@ -1192,7 +1214,7 @@ func (r *Reader) readLag(ctx context.Context) {
 	}
 }
 
-func (r *Reader) start(offsetsByPartition map[topicPartition]int64) {
+func (r *Reader) start(generationId int32, offsetsByPartition map[topicPartition]int64) {
 	if r.closed {
 		// don't start child reader if parent Reader is closed
 		return
@@ -1230,7 +1252,7 @@ func (r *Reader) start(offsetsByPartition map[topicPartition]int64) {
 
 				// backwards-compatibility flags
 				offsetOutOfRangeError: r.config.OffsetOutOfRangeError,
-			}).run(ctx, offset)
+			}).run(ctx, generationId, offset)
 		}(ctx, key, offset, &r.join)
 	}
 }
@@ -1267,7 +1289,7 @@ type readerMessage struct {
 	error     error
 }
 
-func (r *reader) run(ctx context.Context, offset int64) {
+func (r *reader) run(ctx context.Context, generationId int32, offset int64) {
 	// This is the reader's main loop, it only ends if the context is canceled
 	// and will keep attempting to reader messages otherwise.
 	//
@@ -1320,6 +1342,7 @@ func (r *reader) run(ctx context.Context, offset int64) {
 			}
 			continue
 		}
+		conn.generationId = generationId
 
 		// Resetting the attempt counter ensures that if a failure occurs after
 		// a successful initialization we don't keep increasing the backoff


### PR DESCRIPTION
This is a skeleton PR aiming for discussion related to https://github.com/segmentio/kafka-go/issues/1308

In that issue, I describe how rebalances can lead to a situation where the consumer receiving the partition does not read messages in spite of lag existing (because conn's offset is > than the broker's current offset and there's no new messages coming).

I was aiming to fix it by avoiding commits for past generations, to do so, I add the generation id to the message and when committing, I log an error instead of adding it to the stash if it belongs to a generation < than current.

This has the risk of losing valid commits when the new generation comes (as its associated generation < latest generation.id), however it works because a new generation ends up creating new connections which means uncommitted events are duplicated. It is not that I love it because it works incidentally but it does work as my test shows.

If you have a different / better approach I am happy to explore it if you do explain it a bit.