### PR TITLE
Expose Message.totalSize, Message.size, and Message.headerSize

### DIFF
--- a/message.go
+++ b/message.go
@@ -45,19 +45,19 @@ func (msg Message) message(cw *crc32Writer) message {
 
 const timestampSize = 8
 
-func (msg *Message) size() int32 {
+func (msg *Message) Size() int32 {
 	return 4 + 1 + 1 + sizeofBytes(msg.Key) + sizeofBytes(msg.Value) + timestampSize
 }
 
-func (msg *Message) headerSize() int {
+func (msg *Message) HeaderSize() int {
 	return varArrayLen(len(msg.Headers), func(i int) int {
 		h := &msg.Headers[i]
 		return varStringLen(h.Key) + varBytesLen(h.Value)
 	})
 }
 
-func (msg *Message) totalSize() int32 {
-	return int32(msg.headerSize()) + msg.size()
+func (msg *Message) TotalSize() int32 {
+	return int32(msg.HeaderSize()) + msg.Size()
 }
 
 type message struct {

--- a/message_test.go
+++ b/message_test.go
@@ -686,7 +686,7 @@ func TestMessageSize(t *testing.T) {
 				Time:  randate(),
 			}
 			expSize := msg.message(nil).size()
-			gotSize := msg.size()
+			gotSize := msg.Size()
 			if expSize != gotSize {
 				t.Errorf("Expected size %d, but got size %d", expSize, gotSize)
 			}

--- a/writer.go
+++ b/writer.go
@@ -624,7 +624,7 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 	batchBytes := w.batchBytes()
 
 	for i := range msgs {
-		n := int64(msgs[i].totalSize())
+		n := int64(msgs[i].TotalSize())
 		if n > batchBytes {
 			// This error is left for backward compatibility with historical
 			// behavior, but it can yield O(N^2) behaviors. The expectations
@@ -1219,7 +1219,7 @@ func newWriteBatch(now time.Time, timeout time.Duration) *writeBatch {
 }
 
 func (b *writeBatch) add(msg Message, maxSize int, maxBytes int64) bool {
-	bytes := int64(msg.totalSize())
+	bytes := int64(msg.TotalSize())
 
 	if b.size > 0 && (b.bytes+bytes) > maxBytes {
 		return false


### PR DESCRIPTION
This PR makes the 3 functions `Message.totalSize`, `Message.size`, and `Message.headerSize` public. 

This is helpful for applications which may need to add a buffer before calling `WriteMessages`, or for applications that need to compute the size of the payload on the wire for other reasons.

Resolves https://github.com/segmentio/kafka-go/issues/1254

