### PR TITLE
Report errors on writer close.

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -576,6 +577,10 @@ func (w *Writer) Close() error {
 		w.transport.CloseIdleConnections()
 	}
 
+	errorsCount := w.stats().errors.snapshot()
+	if errorsCount > 0 {
+		return fmt.Errorf("failed to close gracefully, %d errors occurred", errorsCount)
+	}
 	return nil
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -107,6 +107,11 @@ func TestWriter(t *testing.T) {
 		},
 
 		{
+			scenario: "closing a writer with errors should return error",
+			function: testWriterCloseWithErrors,
+		},
+
+		{
 			scenario: "writing 1 message through a writer using round-robin balancing produces 1 message to the first partition",
 			function: testWriterRoundRobin1,
 		},
@@ -220,6 +225,15 @@ func testWriterClose(t *testing.T) {
 
 	if err := w.Close(); err != nil {
 		t.Error(err)
+	}
+}
+
+func testWriterCloseWithErrors(t *testing.T) {
+	w := newTestWriter(WriterConfig{})
+	w.stats().errors.observe(1)
+
+	if err := w.Close(); err == nil {
+		t.Error("expected error, but got nil")
 	}
 }
 


### PR DESCRIPTION
Currently, errors (at least in async mode) will only go to logs (if configured). With this change, the Close function will return an error that will fail the caller side in a "loud" way. This helps to identify the issue sooner.