### PR TITLE
fix: A lot of unexpected EOF error when reading from partition

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -858,7 +858,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 
 	var msgs *messageSetReader
 	if err == nil {
-		if highWaterMark == offset {
+		if highWaterMark == offset || remain == 0 {
 			msgs = &messageSetReader{empty: true}
 		} else {
 			msgs, err = newMessageSetReader(&c.rbuf, remain)


### PR DESCRIPTION
error log like: 
> no messages received from kafka within the allocated time for partition 0 of cysj2-UpdateUsername at offset 472919: [7] Request Timed Out: the request exceeded the user-specified time limit in the request