### PR TITLE
Fixes some flaky tests in the build as well as the case when tests start before kafka is ready

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ jobs:
         paths:
         - /go/pkg/mod
     - run:
+        name: Wait for kafka
+        command: ./scripts/wait-for-kafka.sh
+    - run:
         name: Test kafka-go
         command: go test -race -cover ./...
     - run:

--- a/addoffsetstotxn_test.go
+++ b/addoffsetstotxn_test.go
@@ -22,11 +22,13 @@ func TestClientAddOffsetsToTxn(t *testing.T) {
 	defer shutdown()
 
 	err := clientCreateTopic(client, topic, 3)
+	defer deleteTopic(t, topic)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	waitForTopic(ctx, t, topic)
 	defer cancel()
 	respc, err := waitForCoordinatorIndefinitely(ctx, client, &FindCoordinatorRequest{
 		Addr:    client.Addr,

--- a/scripts/wait-for-kafka.sh
+++ b/scripts/wait-for-kafka.sh
@@ -1,0 +1,20 @@
+#/bin/bash
+
+COUNTER=0; 
+echo foo | nc localhost 9092
+STATUS=$?
+ATTEMPTS=60
+until [ ${STATUS} -eq 0 ] || [ "$COUNTER" -ge "${ATTEMPTS}" ];
+do
+    let COUNTER=$COUNTER+1;
+    sleep 1;
+    echo "[$COUNTER] waiting for 9092 port to be open";
+    echo foo | nc localhost 9092
+    STATUS=$?
+done
+
+if [ "${COUNTER}" -gt "${ATTEMPTS}" ];
+then
+    echo "Kafka is not running, failing"
+    exit 1
+fi

--- a/txnoffsetcommit_test.go
+++ b/txnoffsetcommit_test.go
@@ -21,6 +21,8 @@ func TestClientTxnOffsetCommit(t *testing.T) {
 
 	client, shutdown := newLocalClientWithTopic(topic, 1)
 	defer shutdown()
+	waitForTopic(context.TODO(), t, topic)
+	defer deleteTopic(t, topic)
 
 	now := time.Now()
 


### PR DESCRIPTION
This PR fixes at least 1 flaky test and a scenario when kafka is slow to start and the first tests in the suite just fail.

The cases are various but we have:
- topic creating not waiting before sending and reading
- timeouts
- kafka not started

I don't think this has solved them all, but I managed to get a local build passing as well as in CI, which I could not achieve without these changes.