### PR TITLE
Optimize the murmur2 hash function

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -333,14 +333,14 @@ func murmur2(data []byte) uint32 {
 	}
 
 	// Handle the last few bytes of the input array
-	extra := length % 4
-	if extra >= 3 {
+	switch length % 4 {
+	case 3:
 		h ^= (uint32(data[(length & ^3)+2]) & 0xff) << 16
-	}
-	if extra >= 2 {
+		fallthrough
+	case 2:
 		h ^= (uint32(data[(length & ^3)+1]) & 0xff) << 8
-	}
-	if extra >= 1 {
+		fallthrough
+	case 1:
 		h ^= uint32(data[length & ^3]) & 0xff
 		h *= m
 	}


### PR DESCRIPTION
Use the same method as the Java code to process the remaining bytes. The new code uses Duff's device which only needs one branch. Here's benchmark highlights:

```text
cpu: Intel(R) Core(TM) i5-10200H CPU @ 2.40GHz
                   │     old     │                new                 │
                   │   sec/op    │   sec/op     vs base               │
Murmur2/8-bytes-8    7.446n ± 1%   7.191n ± 1%  -3.41% (p=0.000 n=10)
Murmur2/16-bytes-8   12.21n ± 1%   12.12n ± 1%  -0.74% (p=0.026 n=10)
Murmur2/32-bytes-8   22.71n ± 1%   22.70n ± 1%       ~ (p=0.696 n=10)
Murmur2/64-bytes-8   44.15n ± 1%   44.04n ± 0%       ~ (p=0.093 n=10)
geomean              17.37n        17.18n       -1.12%
```