### PR TITLE
Fix: consumer's group partition watcher doesn't sees partition number changing

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -497,7 +497,7 @@ func (g *Generation) heartbeatLoop(interval time.Duration) {
 // a bad spot and should rebalance. Commonly you will see an error here if there
 // is a problem with the connection to the coordinator and a rebalance will
 // establish a new connection to the coordinator.
-func (g *Generation) partitionWatcher(interval time.Duration, topic string) {
+func (g *Generation) partitionWatcher(interval time.Duration, topic string, startPartitions int) {
 	g.Start(func(ctx context.Context) {
 		g.log(func(l Logger) {
 			l.Printf("started partition watcher for group, %v, topic %v [%v]", g.GroupID, topic, interval)
@@ -509,14 +509,6 @@ func (g *Generation) partitionWatcher(interval time.Duration, topic string) {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
-		ops, err := g.conn.readPartitions(topic)
-		if err != nil {
-			g.logError(func(l Logger) {
-				l.Printf("Problem getting partitions during startup, %v\n, Returning and setting up nextGeneration", err)
-			})
-			return
-		}
-		oParts := len(ops)
 		for {
 			select {
 			case <-ctx.Done():
@@ -525,7 +517,7 @@ func (g *Generation) partitionWatcher(interval time.Duration, topic string) {
 				ops, err := g.conn.readPartitions(topic)
 				switch {
 				case err == nil, errors.Is(err, UnknownTopicOrPartition):
-					if len(ops) != oParts {
+					if len(ops) != startPartitions {
 						g.log(func(l Logger) {
 							l.Printf("Partition changes found, rebalancing group: %v.", g.GroupID)
 						})
@@ -651,11 +643,17 @@ func NewConsumerGroup(config ConsumerGroupConfig) (*ConsumerGroup, error) {
 	}
 
 	cg := &ConsumerGroup{
-		config: config,
-		next:   make(chan *Generation),
-		errs:   make(chan error),
-		done:   make(chan struct{}),
+		config:             config,
+		partitionsPerTopic: make(map[string]int, len(config.Topics)),
+		next:               make(chan *Generation),
+		errs:               make(chan error),
+		done:               make(chan struct{}),
 	}
+
+	for _, topic := range config.Topics {
+		cg.partitionsPerTopic[topic] = 0
+	}
+
 	cg.wg.Add(1)
 	go func() {
 		cg.run()
@@ -670,9 +668,10 @@ func NewConsumerGroup(config ConsumerGroupConfig) (*ConsumerGroup, error) {
 // Generation is where partition assignments and offset management occur.
 // Callers will use Next to get a handle to the Generation.
 type ConsumerGroup struct {
-	config ConsumerGroupConfig
-	next   chan *Generation
-	errs   chan error
+	config             ConsumerGroupConfig
+	partitionsPerTopic map[string]int
+	next               chan *Generation
+	errs               chan error
 
 	closeOnce sync.Once
 	wg        sync.WaitGroup
@@ -840,8 +839,8 @@ func (cg *ConsumerGroup) nextGeneration(memberID string) (string, error) {
 	// complete.
 	gen.heartbeatLoop(cg.config.HeartbeatInterval)
 	if cg.config.WatchPartitionChanges && iAmLeader {
-		for _, topic := range cg.config.Topics {
-			gen.partitionWatcher(cg.config.PartitionWatchInterval, topic)
+		for topic, startPartitions := range cg.partitionsPerTopic {
+			gen.partitionWatcher(cg.config.PartitionWatchInterval, topic, startPartitions)
 		}
 	}
 
@@ -1032,6 +1031,16 @@ func (cg *ConsumerGroup) assignTopicPartitions(conn coordinator, group joinGroup
 	// a topic watcher can trigger a rebalance when the topic comes into being.
 	if err != nil && !errors.Is(err, UnknownTopicOrPartition) {
 		return nil, err
+	}
+
+	// resetting old values of partitions per topic
+	for topic := range cg.partitionsPerTopic {
+		cg.partitionsPerTopic[topic] = 0
+	}
+
+	// setting new values of partitions per topic
+	for _, partition := range partitions {
+		cg.partitionsPerTopic[partition.Topic] += 1
 	}
 
 	cg.withLogger(func(l Logger) {

--- a/consumergroup_test.go
+++ b/consumergroup_test.go
@@ -637,7 +637,7 @@ func TestGenerationExitsOnPartitionChange(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		gen.partitionWatcher(watchTime, "topic-1")
+		gen.partitionWatcher(watchTime, "topic-1", 1)
 		close(done)
 	}()
 


### PR DESCRIPTION
Suggestion to fix issue https://github.com/segmentio/kafka-go/issues/1314

Steps to reproduce the issue:

1. Create topic
2. Simultaneously connect to this topic with consumer group
3. At some time, if Kafka didn't assigned partitions to topic (so topic is exists, but has zero partitions), you won't receive topic to consumer group because of empty assignment. So Kafka after that assigning partitions to topic
4. At the start of partitionWatcher it scrapes assigned number of partitions and starts loop where monitors number of partitions assigned to topic

After all we have empty consumer group, and partitionWatcher monitoring for changing partition number with non-zero start number of partitions. So we have to increase partitions to receive topic into consumer group.

Solution:
We need to assign partitions number to topic in assignTopicPartitions function. So we run partitionWatcher with assigned in assignTopicPartition function number of partitions and don't scrape it inside partitionWatcher

P.S. In this PR I also changed partitionWatcher. Now it runs only if consumer is leader of consumer group. Kafka says this is correct