### PR TITLE
Fix Heartbeat Response V1+ field ordering

### DIFF
--- a/protocol/heartbeat/heartbeat.go
+++ b/protocol/heartbeat/heartbeat.go
@@ -27,8 +27,8 @@ type Response struct {
 	// type.
 	_ struct{} `kafka:"min=v4,max=v4,tag"`
 
-	ErrorCode      int16 `kafka:"min=v0,max=v4"`
 	ThrottleTimeMs int32 `kafka:"min=v1,max=v4"`
+	ErrorCode      int16 `kafka:"min=v0,max=v4"`
 }
 
 func (r *Response) ApiKey() protocol.ApiKey {


### PR DESCRIPTION
https://kafka.apache.org/11/protocol.html#The_Messages_Heartbeat

The V0 heartbeat response looks like:
```
Heartbeat Response (Version: 0) => error_code 
  error_code => INT16
```

The V1 heartbeat response looks like:
```
Heartbeat Response (Version: 1) => throttle_time_ms error_code 
  throttle_time_ms => INT32
  error_code => INT16
```

This change makes it so that the V1 heartbeat responses no longer have the error code mistakenly reported as a `time.Duration`.