### PR TITLE
example groupID case fix

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       collectionName: example_coll
       kafkaURL: kafka:9092
       topic: topic1
-      GroupID: mongo-group
+      groupID: mongo-group
     depends_on: 
     - kafka
     - mongo-db
@@ -61,7 +61,7 @@ services:
     environment:
       kafkaURL: kafka:9092
       topic: topic1
-      GroupID: logger-group
+      groupID: logger-group
     depends_on: 
     - kafka
     restart: always


### PR DESCRIPTION
In consumer code we use `groupID` env but in docker-compose `GroupID` passed.