### PR TITLE
docs: fix typos and comments

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -46,7 +46,7 @@ func (batch *Batch) Throttle() time.Duration {
 	return batch.throttle
 }
 
-// Watermark returns the current highest watermark in a partition.
+// HighWaterMark returns the current highest watermark in a partition.
 func (batch *Batch) HighWaterMark() int64 {
 	return batch.highWaterMark
 }

--- a/createtopics.go
+++ b/createtopics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/segmentio/kafka-go/protocol/createtopics"
 )
 
-// CreateTopicRequests represents a request sent to a kafka broker to create
+// CreateTopicsRequest represents a request sent to a kafka broker to create
 // new topics.
 type CreateTopicsRequest struct {
 	// Address of the kafka broker to send the request to.
@@ -27,7 +27,7 @@ type CreateTopicsRequest struct {
 	ValidateOnly bool
 }
 
-// CreateTopicResponse represents a response from a kafka broker to a topic
+// CreateTopicsResponse represents a response from a kafka broker to a topic
 // creation request.
 type CreateTopicsResponse struct {
 	// The amount of time that the broker throttled the request.

--- a/describeclientquotas.go
+++ b/describeclientquotas.go
@@ -35,7 +35,7 @@ type DescribeClientQuotasRequestComponent struct {
 	Match string
 }
 
-// DescribeClientQuotasReesponse represents a response from a kafka broker to a describe client quota request.
+// DescribeClientQuotasResponse represents a response from a kafka broker to a describe client quota request.
 type DescribeClientQuotasResponse struct {
 	// The amount of time that the broker throttled the request.
 	Throttle time.Duration

--- a/listoffset.go
+++ b/listoffset.go
@@ -17,7 +17,7 @@ type OffsetRequest struct {
 }
 
 // FirstOffsetOf constructs an OffsetRequest which asks for the first offset of
-// the parition given as argument.
+// the partition given as argument.
 func FirstOffsetOf(partition int) OffsetRequest {
 	return OffsetRequest{Partition: partition, Timestamp: FirstOffset}
 }

--- a/metadata.go
+++ b/metadata.go
@@ -19,7 +19,7 @@ type MetadataRequest struct {
 	Topics []string
 }
 
-// MetadatResponse represents a response from a kafka broker to a metadata
+// MetadataResponse represents a response from a kafka broker to a metadata
 // request.
 type MetadataResponse struct {
 	// The amount of time that the broker throttled the request.

--- a/protocol/record.go
+++ b/protocol/record.go
@@ -191,7 +191,7 @@ func (rs *RecordSet) ReadFrom(r io.Reader) (int64, error) {
 			// Reconstruct the prefix that we had to read to determine the version
 			// of the record set from the magic byte.
 			//
-			// Technically this may recurisvely stack readers when consuming all
+			// Technically this may recursively stack readers when consuming all
 			// items of the batch, which could hurt performance. In practice this
 			// path should not be taken tho, since the decoder would read from a
 			// *bufio.Reader which implements the bufferedReader interface.
@@ -304,7 +304,7 @@ type RawRecordSet struct {
 // then writes/encodes the RecordSet to a buffer referenced by the RawRecordSet.
 //
 // Note: re-using the RecordSet.ReadFrom implementation makes this suboptimal from a
-// performance standpoint as it require an extra copy of the record bytes. Holding off
+// performance standpoint as it requires an extra copy of the record bytes. Holding off
 // on optimizing, as this code path is only invoked in tests.
 func (rrs *RawRecordSet) ReadFrom(r io.Reader) (int64, error) {
 	rs := &RecordSet{}

--- a/record.go
+++ b/record.go
@@ -35,7 +35,7 @@ type Record = protocol.Record
 // RecordReader values are not safe to use concurrently from multiple goroutines.
 type RecordReader = protocol.RecordReader
 
-// NewRecordReade reconstructs a RecordSet which exposes the sequence of records
+// NewRecordReader reconstructs a RecordSet which exposes the sequence of records
 // passed as arguments.
 func NewRecordReader(records ...Record) RecordReader {
 	return protocol.NewRecordReader(records...)


### PR DESCRIPTION
This PR fixes typos and improves comments across various types and functions in the codebase.