### PR TITLE
feat: add ProtocolType to ListGroupsResponseGroup

### DIFF
--- a/listgroups.go
+++ b/listgroups.go
@@ -31,6 +31,9 @@ type ListGroupsResponseGroup struct {
 
 	// Coordinator is the ID of the coordinator broker for the group.
 	Coordinator int
+
+	// The group protocol type (eg "consumer", "connect")
+	ProtocolType string
 }
 
 func (c *Client) ListGroups(
@@ -48,8 +51,9 @@ func (c *Client) ListGroups(
 
 	for _, apiGroupInfo := range apiResp.Groups {
 		resp.Groups = append(resp.Groups, ListGroupsResponseGroup{
-			GroupID:     apiGroupInfo.GroupID,
-			Coordinator: int(apiGroupInfo.BrokerID),
+			GroupID:      apiGroupInfo.GroupID,
+			Coordinator:  int(apiGroupInfo.BrokerID),
+			ProtocolType: apiGroupInfo.ProtocolType,
 		})
 	}
 

--- a/listgroups_test.go
+++ b/listgroups_test.go
@@ -96,14 +96,21 @@ func TestClientListGroups(t *testing.T) {
 		)
 	}
 	hasGroup := false
+	hasProtocol := false
 	for _, group := range resp.Groups {
 		if group.GroupID == gid {
 			hasGroup = true
+			if group.ProtocolType == "consumer" {
+				hasProtocol = true
+			}
 			break
 		}
 	}
 
 	if !hasGroup {
 		t.Error("Group not found in list")
+	}
+	if !hasProtocol {
+		t.Error("Group does not have expected protocol type")
 	}
 }


### PR DESCRIPTION
Currently, the protocol based ListGroups request does not include the [ProtocolType field](https://kafka.apache.org/protocol#The_Messages_ListGroups) in the response object (the deprecated V1 ListGroups response included it). It just returns GroupID and Coordinator.

This PR adds ProtocolType to that response object.