### PR TITLE
correct lengthRemain handling into message_read.readMessageV2

### DIFF
--- a/message_reader.go
+++ b/message_reader.go
@@ -292,6 +292,10 @@ func (r *messageSetReader) readMessageV2(_ int64, key readBytesFunc, val readByt
 			// stack. here we set the parent count to 0 so that when the child set is exhausted, the
 			// reader will then try to read the header of the next message set
 			r.readerStack.parent.count = 0
+			// lengthRemain has to be adjusted to length of decompressed data
+			// otherwise we can end up with negative lengthRemain that will fail the check into batch.go:readMessage (https://github.com/segmentio/kafka-go/blob/3f6808045dfce56553562afa2ede13fabd640603/batch.go#L283),
+			// that leads to endlessly reading the same compacted batch
+			r.lengthRemain = r.remain
 		}
 	}
 	remainBefore := r.remain


### PR DESCRIPTION
In topic with log compaction the incorrect handling of lengthRemain into readMessageV2 lead to endlessly reading of the same compacted batch. It is happens because skipping offset to batch.lastOffset assumes that lengthRemain ==0 but without this correction lengthRemain became negative and comparison with zero doesn't work.