### PR TITLE
feat(sasl): add OAUTHBEARER mechanism (RFC 7628)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     ports:
       - 9092:9092
       - 9093:9093
+      - 9094:9094
     environment:
       KAFKA_CFG_BROKER_ID: 1
       KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
@@ -26,9 +27,14 @@ services:
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_CFG_MESSAGE_MAX_BYTES: '200000000'
-      KAFKA_CFG_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
-      KAFKA_CFG_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+      KAFKA_CFG_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093,OAUTHBEARER://:9094'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093,OAUTHBEARER://localhost:9094'
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'PLAINTEXT:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT,OAUTHBEARER:SASL_PLAINTEXT'
       KAFKA_CFG_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_CFG_LISTENER_NAME_OAUTHBEARER_SASL_ENABLED_MECHANISMS: 'OAUTHBEARER'
+      KAFKA_CFG_LISTENER_NAME_OAUTHBEARER_OAUTHBEARER_SASL_JAAS_CONFIG: 'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required unsecuredLoginStringClaim_sub="admin";'
+      KAFKA_CFG_LISTENER_NAME_OAUTHBEARER_OAUTHBEARER_SASL_SERVER_CALLBACK_HANDLER_CLASS: 'org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler'
+      KAFKA_CFG_LISTENER_NAME_OAUTHBEARER_OAUTHBEARER_SASL_LOGIN_CALLBACK_HANDLER_CLASS: 'org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredLoginCallbackHandler'
       KAFKA_CFG_AUTHORIZER_CLASS_NAME: 'kafka.security.authorizer.AclAuthorizer'
       KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND: 'true'
       KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/bitnami/kafka/config/kafka_jaas.conf"
@@ -36,4 +42,17 @@ services:
     entrypoint:
       - "/bin/bash"
       - "-c"
-      - echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/bitnami/kafka/config/kafka_jaas.conf; /opt/bitnami/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config "SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]" --entity-type users --entity-name adminscram; exec /entrypoint.sh /run.sh
+      - |
+        cat > /opt/bitnami/kafka/config/kafka_jaas.conf << 'EOF'
+        KafkaServer {
+          org.apache.kafka.common.security.scram.ScramLoginModule required
+            username="adminscram"
+            password="admin-secret";
+          org.apache.kafka.common.security.plain.PlainLoginModule required
+            username="adminplain"
+            password="admin-secret"
+            user_adminplain="admin-secret";
+        };
+        EOF
+        /opt/bitnami/kafka/bin/kafka-configs.sh --zookeeper zookeeper:2181 --alter --add-config "SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]" --entity-type users --entity-name adminscram 2>/dev/null || true
+        exec /entrypoint.sh /run.sh

--- a/sasl/oauthbearer/oauthbearer.go
+++ b/sasl/oauthbearer/oauthbearer.go
@@ -1,0 +1,78 @@
+package oauthbearer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/segmentio/kafka-go/sasl"
+)
+
+var ErrOAuthBearerAuth = errors.New("oauthbearer: authentication failed")
+
+// Error represents an RFC 7628 authentication error from the server.
+type Error struct {
+	Status              string `json:"status"`
+	Scope               string `json:"scope,omitempty"`
+	OpenIDConfiguration string `json:"openid-configuration,omitempty"`
+	Raw                 []byte `json:"-"`
+}
+
+func (e *Error) Error() string {
+	if e.Status != "" && e.Scope != "" {
+		return fmt.Sprintf("oauthbearer: status=%s scope=%s", e.Status, e.Scope)
+	}
+	if e.Status != "" {
+		return fmt.Sprintf("oauthbearer: status=%s", e.Status)
+	}
+	if len(e.Raw) > 0 {
+		return fmt.Sprintf("oauthbearer: %s", string(e.Raw))
+	}
+	return "oauthbearer: authentication failed"
+}
+
+func (e *Error) Unwrap() error             { return ErrOAuthBearerAuth }
+func (e *Error) IsInvalidToken() bool      { return e.Status == "invalid_token" }
+func (e *Error) IsInsufficientScope() bool { return e.Status == "insufficient_scope" }
+
+// Mechanism implements the OAUTHBEARER SASL mechanism (RFC 7628).
+type Mechanism struct {
+	TokenFunc  func(ctx context.Context) (token string, err error)
+	Extensions map[string]string
+}
+
+func (m *Mechanism) Name() string { return "OAUTHBEARER" }
+
+func (m *Mechanism) Start(ctx context.Context) (sasl.StateMachine, []byte, error) {
+	if m.TokenFunc == nil {
+		return nil, nil, errors.New("oauthbearer: TokenFunc is required")
+	}
+	token, err := m.TokenFunc(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("oauthbearer: failed to get token: %w", err)
+	}
+	if token == "" {
+		return nil, nil, errors.New("oauthbearer: token cannot be empty")
+	}
+	// RFC 7628: n,,^Aauth=Bearer <token>^A^A
+	response := "n,,\x01auth=Bearer " + token
+	for k, v := range m.Extensions {
+		response += "\x01" + k + "=" + v
+	}
+	response += "\x01\x01"
+	return m, []byte(response), nil
+}
+
+func (m *Mechanism) Next(ctx context.Context, challenge []byte) (bool, []byte, error) {
+	if len(challenge) == 0 {
+		return true, nil, nil
+	}
+	return false, []byte{0x01}, parseError(challenge)
+}
+
+func parseError(challenge []byte) *Error {
+	oauthErr := &Error{Raw: challenge}
+	_ = json.Unmarshal(challenge, oauthErr) // ignore parse errors, Raw is fallback
+	return oauthErr
+}

--- a/sasl/oauthbearer/oauthbearer_integration_test.go
+++ b/sasl/oauthbearer/oauthbearer_integration_test.go
@@ -1,0 +1,103 @@
+package oauthbearer_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl"
+	"github.com/segmentio/kafka-go/sasl/oauthbearer"
+)
+
+const (
+	oauthbearerTestConnect = "localhost:9094"
+	oauthbearerTestTopic   = "test-writer-0"
+)
+
+// unsecuredToken generates a test token compatible with Kafka's
+// OAuthBearerUnsecuredValidatorCallbackHandler.
+func unsecuredToken(subject string) func(context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+		now := time.Now().Unix()
+		payload := fmt.Sprintf(`{"sub":"%s","iat":%d,"exp":%d}`, subject, now, now+3600)
+		payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+		return header + "." + payloadB64 + ".", nil
+	}
+}
+
+// expiredToken generates an already-expired test token (invalid credentials equivalent).
+func expiredToken(subject string) func(context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+		past := time.Now().Add(-1 * time.Hour).Unix()
+		payload := fmt.Sprintf(`{"sub":"%s","iat":%d,"exp":%d}`, subject, past, past+1)
+		payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+		return header + "." + payloadB64 + ".", nil
+	}
+}
+
+func TestOAUTHBEARER(t *testing.T) {
+	// Integration tests require Kafka with OAUTHBEARER listener on port 9094.
+	// See docker-compose.yml for the required configuration.
+	if os.Getenv("KAFKA_OAUTHBEARER_TEST") == "" {
+		t.Skip("KAFKA_OAUTHBEARER_TEST not set; skipping integration test")
+	}
+
+	tests := []struct {
+		valid   func() sasl.Mechanism
+		invalid func() sasl.Mechanism
+	}{
+		{
+			valid: func() sasl.Mechanism {
+				return &oauthbearer.Mechanism{
+					TokenFunc: unsecuredToken("testuser"),
+				}
+			},
+			invalid: func() sasl.Mechanism {
+				return &oauthbearer.Mechanism{
+					TokenFunc: expiredToken("testuser"),
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		mech := tt.valid()
+
+		t.Run(mech.Name()+" success", func(t *testing.T) {
+			testConnect(t, tt.valid(), true)
+		})
+		t.Run(mech.Name()+" failure", func(t *testing.T) {
+			testConnect(t, tt.invalid(), false)
+		})
+		t.Run(mech.Name()+" is reusable", func(t *testing.T) {
+			mech := tt.valid()
+			testConnect(t, mech, true)
+			testConnect(t, mech, true)
+			testConnect(t, mech, true)
+		})
+	}
+}
+
+func testConnect(t *testing.T, mechanism sasl.Mechanism, success bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	d := kafka.Dialer{
+		SASLMechanism: mechanism,
+	}
+	conn, err := d.DialLeader(ctx, "tcp", oauthbearerTestConnect, oauthbearerTestTopic, 0)
+	if success && err != nil {
+		t.Errorf("should have logged in correctly, got err: %v", err)
+	} else if !success && err == nil {
+		conn.Close()
+		t.Errorf("should not have logged in correctly")
+	} else if err == nil {
+		conn.Close()
+	}
+}

--- a/sasl/oauthbearer/oauthbearer_test.go
+++ b/sasl/oauthbearer/oauthbearer_test.go
@@ -1,0 +1,299 @@
+package oauthbearer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMechanismName(t *testing.T) {
+	m := &Mechanism{}
+	assert.Equal(t, "OAUTHBEARER", m.Name())
+}
+
+func TestMechanismStart(t *testing.T) {
+	tests := []struct {
+		name       string
+		tokenFunc  func(context.Context) (string, error)
+		extensions map[string]string
+		wantErr    string
+		wantResp   string
+	}{
+		{
+			name:      "nil TokenFunc",
+			tokenFunc: nil,
+			wantErr:   "TokenFunc is required",
+		},
+		{
+			name:      "TokenFunc returns error",
+			tokenFunc: func(context.Context) (string, error) { return "", errors.New("token error") },
+			wantErr:   "failed to get token",
+		},
+		{
+			name:      "empty token",
+			tokenFunc: func(context.Context) (string, error) { return "", nil },
+			wantErr:   "token cannot be empty",
+		},
+		{
+			name:      "valid token",
+			tokenFunc: func(context.Context) (string, error) { return "test-token", nil },
+			wantResp:  "n,,\x01auth=Bearer test-token\x01\x01",
+		},
+		{
+			name:       "token with extensions",
+			tokenFunc:  func(context.Context) (string, error) { return "test-token", nil },
+			extensions: map[string]string{"ext": "value"},
+			wantResp:   "n,,\x01auth=Bearer test-token\x01ext=value\x01\x01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Mechanism{TokenFunc: tt.tokenFunc, Extensions: tt.extensions}
+			sm, response, err := m.Start(context.Background())
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, sm)
+				assert.Nil(t, response)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, sm)
+			assert.Equal(t, tt.wantResp, string(response))
+		})
+	}
+}
+
+func TestMechanismStartReturnsItself(t *testing.T) {
+	m := &Mechanism{TokenFunc: func(context.Context) (string, error) { return "token", nil }}
+	sm, _, err := m.Start(context.Background())
+	require.NoError(t, err)
+	assert.Same(t, m, sm)
+}
+
+func TestMechanismNextSuccess(t *testing.T) {
+	m := &Mechanism{TokenFunc: func(context.Context) (string, error) { return "token", nil }}
+	sm, _, err := m.Start(context.Background())
+	require.NoError(t, err)
+
+	done, response, err := sm.Next(context.Background(), nil)
+
+	assert.True(t, done)
+	assert.Nil(t, response)
+	assert.NoError(t, err)
+}
+
+func TestMechanismNextEmptyChallenge(t *testing.T) {
+	m := &Mechanism{TokenFunc: func(context.Context) (string, error) { return "token", nil }}
+	sm, _, _ := m.Start(context.Background())
+
+	done, response, err := sm.Next(context.Background(), []byte{})
+
+	assert.True(t, done)
+	assert.Nil(t, response)
+	assert.NoError(t, err)
+}
+
+func TestMechanismNextError(t *testing.T) {
+	m := &Mechanism{TokenFunc: func(context.Context) (string, error) { return "token", nil }}
+	sm, _, _ := m.Start(context.Background())
+
+	challenge := []byte(`{"status":"invalid_token","scope":"admin"}`)
+	done, response, err := sm.Next(context.Background(), challenge)
+
+	// Must return done=false and 0x01 dummy response per RFC 7628
+	assert.False(t, done)
+	assert.Equal(t, []byte{0x01}, response)
+	require.Error(t, err)
+
+	// Verify error type
+	var oauthErr *Error
+	require.True(t, errors.As(err, &oauthErr))
+	assert.Equal(t, "invalid_token", oauthErr.Status)
+	assert.Equal(t, "admin", oauthErr.Scope)
+}
+
+func TestErrorsIs(t *testing.T) {
+	m := &Mechanism{TokenFunc: func(context.Context) (string, error) { return "token", nil }}
+	sm, _, _ := m.Start(context.Background())
+
+	_, _, err := sm.Next(context.Background(), []byte(`{"status":"invalid_token"}`))
+
+	assert.True(t, errors.Is(err, ErrOAuthBearerAuth))
+}
+
+func TestErrorsAs(t *testing.T) {
+	m := &Mechanism{TokenFunc: func(context.Context) (string, error) { return "token", nil }}
+	sm, _, _ := m.Start(context.Background())
+
+	_, _, err := sm.Next(context.Background(), []byte(`{"status":"insufficient_scope","scope":"write"}`))
+
+	var oauthErr *Error
+	require.True(t, errors.As(err, &oauthErr))
+	assert.Equal(t, "insufficient_scope", oauthErr.Status)
+	assert.Equal(t, "write", oauthErr.Scope)
+	assert.True(t, oauthErr.IsInsufficientScope())
+	assert.False(t, oauthErr.IsInvalidToken())
+}
+
+func TestParseError(t *testing.T) {
+	tests := []struct {
+		name       string
+		challenge  []byte
+		wantStatus string
+		wantScope  string
+		wantOpenID string
+	}{
+		{
+			name:       "valid JSON with all fields",
+			challenge:  []byte(`{"status":"invalid_token","scope":"read","openid-configuration":"https://example.com/.well-known"}`),
+			wantStatus: "invalid_token",
+			wantScope:  "read",
+			wantOpenID: "https://example.com/.well-known",
+		},
+		{
+			name:       "status only",
+			challenge:  []byte(`{"status":"insufficient_scope"}`),
+			wantStatus: "insufficient_scope",
+		},
+		{
+			name:      "invalid JSON",
+			challenge: []byte("not json at all"),
+		},
+		{
+			name:      "empty object",
+			challenge: []byte(`{}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := parseError(tt.challenge)
+
+			assert.Equal(t, tt.wantStatus, err.Status)
+			assert.Equal(t, tt.wantScope, err.Scope)
+			assert.Equal(t, tt.wantOpenID, err.OpenIDConfiguration)
+			assert.Equal(t, tt.challenge, err.Raw)
+		})
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *Error
+		wantMsg string
+	}{
+		{
+			name:    "status and scope",
+			err:     &Error{Status: "invalid_token", Scope: "admin"},
+			wantMsg: "oauthbearer: status=invalid_token scope=admin",
+		},
+		{
+			name:    "status only",
+			err:     &Error{Status: "insufficient_scope"},
+			wantMsg: "oauthbearer: status=insufficient_scope",
+		},
+		{
+			name:    "raw fallback",
+			err:     &Error{Raw: []byte("server error message")},
+			wantMsg: "oauthbearer: server error message",
+		},
+		{
+			name:    "empty error",
+			err:     &Error{},
+			wantMsg: "oauthbearer: authentication failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMsg, tt.err.Error())
+		})
+	}
+}
+
+func TestTokenFuncCalledOnEachStart(t *testing.T) {
+	callCount := 0
+	m := &Mechanism{
+		TokenFunc: func(context.Context) (string, error) {
+			callCount++
+			return "token", nil
+		},
+	}
+
+	_, _, _ = m.Start(context.Background())
+	_, _, _ = m.Start(context.Background())
+	_, _, _ = m.Start(context.Background())
+
+	assert.Equal(t, 3, callCount)
+}
+
+func TestTokenFuncReceivesContext(t *testing.T) {
+	type ctxKey struct{}
+	expectedValue := "test-value"
+
+	m := &Mechanism{
+		TokenFunc: func(ctx context.Context) (string, error) {
+			val := ctx.Value(ctxKey{})
+			if val != expectedValue {
+				return "", errors.New("context value not passed")
+			}
+			return "token", nil
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, expectedValue)
+	_, _, err := m.Start(ctx)
+
+	assert.NoError(t, err)
+}
+
+func TestIsInvalidToken(t *testing.T) {
+	err := &Error{Status: "invalid_token"}
+	assert.True(t, err.IsInvalidToken())
+	assert.False(t, err.IsInsufficientScope())
+}
+
+func TestIsInsufficientScope(t *testing.T) {
+	err := &Error{Status: "insufficient_scope"}
+	assert.True(t, err.IsInsufficientScope())
+	assert.False(t, err.IsInvalidToken())
+}
+
+func TestMechanismImplementsSASLInterfaces(t *testing.T) {
+	m := &Mechanism{TokenFunc: func(context.Context) (string, error) { return "token", nil }}
+
+	// Verify Mechanism returns itself as StateMachine
+	sm, _, err := m.Start(context.Background())
+	require.NoError(t, err)
+
+	// StateMachine should work correctly
+	done, _, err := sm.Next(context.Background(), nil)
+	assert.True(t, done)
+	assert.NoError(t, err)
+}
+
+func TestExtensionsOrder(t *testing.T) {
+	// Extensions use map iteration, so we just verify they're included
+	m := &Mechanism{
+		TokenFunc:  func(context.Context) (string, error) { return "token", nil },
+		Extensions: map[string]string{"key1": "val1", "key2": "val2"},
+	}
+
+	_, response, err := m.Start(context.Background())
+	require.NoError(t, err)
+
+	respStr := string(response)
+	assert.True(t, strings.HasPrefix(respStr, "n,,\x01auth=Bearer token"))
+	assert.True(t, strings.HasSuffix(respStr, "\x01\x01"))
+	assert.Contains(t, respStr, "\x01key1=val1")
+	assert.Contains(t, respStr, "\x01key2=val2")
+}


### PR DESCRIPTION
Implements OAUTHBEARER SASL authentication mechanism per RFC 7628.

Closes #238

## Changes

- Add `sasl/oauthbearer` package with `Mechanism` type
- `TokenFunc` callback enables automatic token refresh on reconnection
- Structured `Error` type with `errors.Is`/`errors.As` support
- RFC 7628 compliant: returns 0x01 dummy response on auth failure
- Unit tests and integration tests against local Kafka

## Design

Uses `TokenFunc func(ctx context.Context) (string, error)` callback instead of static token field. This allows token refresh when connections are re-established, which is essential for short-lived OAuth tokens.

Example usage:
```go
mechanism := &oauthbearer.Mechanism{
    TokenFunc: func(ctx context.Context) (string, error) {
        return getTokenFromProvider(ctx)
    },
}
```

## Testing

- Unit tests cover all code paths
- Integration tests run against Kafka with unsecured OAUTHBEARER mode
- Docker-compose updated to expose OAUTHBEARER listener on port 9094