### PR TITLE
fix: prevent panic from negative count on compacted topics

### DIFF
--- a/message_reader.go
+++ b/message_reader.go
@@ -135,6 +135,14 @@ func (r *messageSetReader) readMessage(min int64, key readBytesFunc, val readByt
 		// Set an invalid value so that it can be ignored
 		lastOffset = -1
 	case 2:
+		// On compacted topics, a record batch may have all its records
+		// removed by compaction, resulting in count=0. Skip over these
+		// empty batches by reading the next header.
+		for r.count == 0 && r.remain > 0 {
+			if err = r.readHeader(); err != nil {
+				return
+			}
+		}
 		offset, lastOffset, timestamp, headers, err = r.readMessageV2(min, key, val)
 	default:
 		err = r.header.badMagic()
@@ -350,7 +358,10 @@ func (r *messageSetReader) discardN(sz int) (err error) {
 
 func (r *messageSetReader) markRead() {
 	if r.count == 0 {
-		panic("markRead: negative count")
+		// On compacted topics, records may be removed from a batch,
+		// causing count to reach zero before all records are read.
+		// Clamp to zero instead of panicking.
+		return
 	}
 	r.count--
 	r.unwindStack()

--- a/message_reader_test.go
+++ b/message_reader_test.go
@@ -1,0 +1,37 @@
+package kafka
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func TestMarkReadDoesNotPanicOnZeroCount(t *testing.T) {
+	// On compacted topics, the record count in a batch header may exceed
+	// the number of records actually present. markRead must not panic
+	// when count has already reached zero.
+	r := &messageSetReader{
+		readerStack: &readerStack{
+			reader: bufio.NewReader(bytes.NewReader(nil)),
+			count:  0,
+		},
+	}
+	// This previously caused: panic("markRead: negative count")
+	r.markRead()
+	if r.count != 0 {
+		t.Fatalf("expected count to remain 0, got %d", r.count)
+	}
+}
+
+func TestMarkReadDecrementsCount(t *testing.T) {
+	r := &messageSetReader{
+		readerStack: &readerStack{
+			reader: bufio.NewReader(bytes.NewReader(nil)),
+			count:  3,
+		},
+	}
+	r.markRead()
+	if r.count != 2 {
+		t.Fatalf("expected count=2, got %d", r.count)
+	}
+}


### PR DESCRIPTION
Fixes #1393

When reading compacted topics, records can be removed from a batch by compaction. The batch header still reports the original count, but fewer records actually exist. This causes `markRead()` to be called when `count` is already zero, triggering a panic.

Two changes here:

1. **Skip empty batches in `readMessage()`** - for v2 messages, when a batch has `count=0` (all records compacted out), loop to read the next header instead of trying to read a non-existent record.

2. **Guard `markRead()` against zero count** - instead of panicking, return early. This is defensive; the first fix should prevent this path, but compaction edge cases are tricky.

Tested with unit tests covering both the normal decrement and the zero-count guard path.