### PR TITLE
Fix typos in member and response

### DIFF
--- a/joingroup.go
+++ b/joingroup.go
@@ -91,9 +91,9 @@ type JoinGroupResponse struct {
 	Members []JoinGroupResponseMember
 }
 
-// JoinGroupResponseMember represents a group memmber in a reponse to a JoinGroup request.
+// JoinGroupResponseMember represents a group member in a reponse to a JoinGroup request.
 type JoinGroupResponseMember struct {
-	// The group memmber ID.
+	// The group member ID.
 	ID string
 
 	// The unique identifier of the consumer instance.

--- a/joingroup.go
+++ b/joingroup.go
@@ -91,7 +91,7 @@ type JoinGroupResponse struct {
 	Members []JoinGroupResponseMember
 }
 
-// JoinGroupResponseMember represents a group member in a reponse to a JoinGroup request.
+// JoinGroupResponseMember represents a group member in a response to a JoinGroup request.
 type JoinGroupResponseMember struct {
 	// The group member ID.
 	ID string

--- a/joingroup_test.go
+++ b/joingroup_test.go
@@ -104,7 +104,7 @@ func TestClientJoinGroup(t *testing.T) {
 	member := resp.Members[0]
 
 	if member.ID != resp.MemberID {
-		t.Fatal("expected to be the only group memmber")
+		t.Fatal("expected to be the only group member")
 	}
 
 	if member.GroupInstanceID != groupInstanceID {


### PR DESCRIPTION
Corrected a spelling error in the JoinGroup documentation.
- Fixed 'memmber' to 'member'.