### PR TITLE
fix: describe groups should not fail on an issue with a single group

### DIFF
--- a/describegroups.go
+++ b/describegroups.go
@@ -135,11 +135,13 @@ func (c *Client) DescribeGroups(
 		for _, member := range apiGroup.Members {
 			decodedMetadata, err := decodeMemberMetadata(member.MemberMetadata)
 			if err != nil {
-				return nil, err
+				group.Error = fmt.Errorf("failed to decode member metadata for group %s: %w", apiGroup.GroupID, err)
+				break
 			}
 			decodedAssignments, err := decodeMemberAssignments(member.MemberAssignment)
 			if err != nil {
-				return nil, err
+				group.Error = fmt.Errorf("failed to decode member assignments for group %s: %w", apiGroup.GroupID, err)
+				break
 			}
 
 			group.Members = append(group.Members, DescribeGroupsResponseMember{

--- a/describegroups.go
+++ b/describegroups.go
@@ -136,11 +136,13 @@ func (c *Client) DescribeGroups(
 			decodedMetadata, err := decodeMemberMetadata(member.MemberMetadata)
 			if err != nil {
 				group.Error = fmt.Errorf("failed to decode member metadata for group %s: %w", apiGroup.GroupID, err)
+				group.Members = nil // clear any previously decoded members
 				break
 			}
 			decodedAssignments, err := decodeMemberAssignments(member.MemberAssignment)
 			if err != nil {
 				group.Error = fmt.Errorf("failed to decode member assignments for group %s: %w", apiGroup.GroupID, err)
+				group.Members = nil // clear any previously decoded members
 				break
 			}
 

--- a/describegroups_test.go
+++ b/describegroups_test.go
@@ -3,11 +3,14 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/segmentio/kafka-go/protocol/describegroups"
 )
 
 func TestClientDescribeGroups(t *testing.T) {
@@ -126,5 +129,182 @@ func TestClientDescribeGroups(t *testing.T) {
 			"expected", []int{0, 1},
 			"got", mt.Partitions,
 		)
+	}
+}
+
+// mockRoundTripper is a mock transport that returns a fixed response.
+type mockRoundTripper struct {
+	response Response
+	err      error
+}
+
+func (m *mockRoundTripper) RoundTrip(ctx context.Context, addr net.Addr, req Request) (Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.response, nil
+}
+
+func TestDescribeGroupsErrorHandling(t *testing.T) {
+	// This test verifies that when one group has invalid metadata/assignments,
+	// it doesn't prevent other groups from being returned successfully.
+
+	// Create a mock response with multiple groups where one has invalid data.
+	mockResp := &describegroups.Response{
+		Groups: []describegroups.ResponseGroup{
+			{
+				ErrorCode:    0,
+				GroupID:      "valid-group-1",
+				GroupState:   "Stable",
+				ProtocolType: "consumer",
+				Members: []describegroups.ResponseGroupMember{
+					{
+						MemberID:   "member-1",
+						ClientID:   "client-1",
+						ClientHost: "/127.0.0.1",
+						// Valid metadata: version (int16) = 0, topics array length (int32) = 0, userdata length (int32) = 0
+						MemberMetadata: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						// Valid assignments: version (int16) = 0, topics array length (int32) = 0, userdata length (int32) = 0
+						MemberAssignment: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					},
+				},
+			},
+			{
+				ErrorCode:    0,
+				GroupID:      "invalid-group",
+				GroupState:   "Stable",
+				ProtocolType: "consumer",
+				Members: []describegroups.ResponseGroupMember{
+					{
+						MemberID:   "member-2",
+						ClientID:   "client-2",
+						ClientHost: "/127.0.0.1",
+						// Invalid metadata - truncated data
+						MemberMetadata:   []byte{0x00},
+						MemberAssignment: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					},
+				},
+			},
+			{
+				ErrorCode:    0,
+				GroupID:      "valid-group-2",
+				GroupState:   "Stable",
+				ProtocolType: "consumer",
+				Members: []describegroups.ResponseGroupMember{
+					{
+						MemberID:   "member-3",
+						ClientID:   "client-3",
+						ClientHost: "/127.0.0.1",
+						// Valid metadata
+						MemberMetadata: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						// Valid assignments
+						MemberAssignment: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					},
+				},
+			},
+		},
+	}
+
+	client := &Client{
+		Transport: &mockRoundTripper{response: mockResp},
+	}
+
+	ctx := context.Background()
+	resp, err := client.DescribeGroups(ctx, &DescribeGroupsRequest{
+		Addr:     TCP("localhost:9092"),
+		GroupIDs: []string{"valid-group-1", "invalid-group", "valid-group-2"},
+	})
+
+	if err != nil {
+		t.Fatalf("Unexpected error from DescribeGroups: %v", err)
+	}
+
+	if len(resp.Groups) != 3 {
+		t.Fatalf("Expected 3 groups, got %d", len(resp.Groups))
+	}
+
+	// Verify valid-group-1 has no error and has members
+	if resp.Groups[0].GroupID != "valid-group-1" {
+		t.Errorf("Expected first group to be valid-group-1, got %s", resp.Groups[0].GroupID)
+	}
+	if resp.Groups[0].Error != nil {
+		t.Errorf("Expected valid-group-1 to have no error, got %v", resp.Groups[0].Error)
+	}
+	if len(resp.Groups[0].Members) != 1 {
+		t.Errorf("Expected valid-group-1 to have 1 member, got %d", len(resp.Groups[0].Members))
+	}
+
+	// Verify invalid-group has an error and no members
+	if resp.Groups[1].GroupID != "invalid-group" {
+		t.Errorf("Expected second group to be invalid-group, got %s", resp.Groups[1].GroupID)
+	}
+	if resp.Groups[1].Error == nil {
+		t.Error("Expected invalid-group to have an error, got nil")
+	}
+	if len(resp.Groups[1].Members) != 0 {
+		t.Errorf("Expected invalid-group to have 0 members due to error, got %d", len(resp.Groups[1].Members))
+	}
+
+	// Verify valid-group-2 has no error and has members
+	if resp.Groups[2].GroupID != "valid-group-2" {
+		t.Errorf("Expected third group to be valid-group-2, got %s", resp.Groups[2].GroupID)
+	}
+	if resp.Groups[2].Error != nil {
+		t.Errorf("Expected valid-group-2 to have no error, got %v", resp.Groups[2].Error)
+	}
+	if len(resp.Groups[2].Members) != 1 {
+		t.Errorf("Expected valid-group-2 to have 1 member, got %d", len(resp.Groups[2].Members))
+	}
+}
+
+func TestDescribeGroupsInvalidAssignments(t *testing.T) {
+	// Test the case where assignments are invalid but metadata is valid
+	mockResp := &describegroups.Response{
+		Groups: []describegroups.ResponseGroup{
+			{
+				ErrorCode:    0,
+				GroupID:      "group-with-bad-assignments",
+				GroupState:   "Stable",
+				ProtocolType: "consumer",
+				Members: []describegroups.ResponseGroupMember{
+					{
+						MemberID:   "member-1",
+						ClientID:   "client-1",
+						ClientHost: "/127.0.0.1",
+						// Valid metadata
+						MemberMetadata: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						// Invalid assignments - truncated
+						MemberAssignment: []byte{0x00},
+					},
+				},
+			},
+		},
+	}
+
+	client := &Client{
+		Transport: &mockRoundTripper{response: mockResp},
+	}
+
+	ctx := context.Background()
+	resp, err := client.DescribeGroups(ctx, &DescribeGroupsRequest{
+		Addr:     TCP("localhost:9092"),
+		GroupIDs: []string{"group-with-bad-assignments"},
+	})
+
+	if err != nil {
+		t.Fatalf("Unexpected error from DescribeGroups: %v", err)
+	}
+
+	// Verify we got the group back with an error
+	if len(resp.Groups) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(resp.Groups))
+	}
+
+	if resp.Groups[0].Error == nil {
+		t.Error("Expected group to have an error for invalid assignments, got nil")
+	}
+
+	if len(resp.Groups[0].Members) != 0 {
+		t.Errorf("Expected group to have 0 members due to error, got %d", len(resp.Groups[0].Members))
 	}
 }

--- a/describegroups_test.go
+++ b/describegroups_test.go
@@ -308,3 +308,65 @@ func TestDescribeGroupsInvalidAssignments(t *testing.T) {
 		t.Errorf("Expected group to have 0 members due to error, got %d", len(resp.Groups[0].Members))
 	}
 }
+
+func TestDescribeGroupsPartialMembersCleared(t *testing.T) {
+	mockResp := &describegroups.Response{
+		Groups: []describegroups.ResponseGroup{
+			{
+				ErrorCode:    0,
+				GroupID:      "multi-member-group",
+				GroupState:   "Stable",
+				ProtocolType: "consumer",
+				Members: []describegroups.ResponseGroupMember{
+					{
+						MemberID:         "member-1", // valid
+						ClientID:         "client-1",
+						ClientHost:       "/127.0.0.1",
+						MemberMetadata:   []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						MemberAssignment: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					},
+					{
+						MemberID:         "member-2", // invalid
+						ClientID:         "client-2",
+						ClientHost:       "/127.0.0.1",
+						MemberMetadata:   []byte{0x00},
+						MemberAssignment: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					},
+					{
+						MemberID:         "member-3", // valid, but never processed
+						ClientID:         "client-3",
+						ClientHost:       "/127.0.0.1",
+						MemberMetadata:   []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						MemberAssignment: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					},
+				},
+			},
+		},
+	}
+
+	client := &Client{
+		Transport: &mockRoundTripper{response: mockResp},
+	}
+
+	ctx := context.Background()
+	resp, err := client.DescribeGroups(ctx, &DescribeGroupsRequest{
+		Addr:     TCP("localhost:9092"),
+		GroupIDs: []string{"multi-member-group"},
+	})
+
+	if err != nil {
+		t.Fatalf("Unexpected error from DescribeGroups: %v", err)
+	}
+
+	if len(resp.Groups) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(resp.Groups))
+	}
+
+	group := resp.Groups[0]
+	if group.Error == nil {
+		t.Fatal("Expected group to have an error, got nil")
+	}
+	if len(group.Members) != 0 {
+		t.Errorf("Expected 0 members when error occurs, got %d", len(group.Members))
+	}
+}


### PR DESCRIPTION
## Summary
- https://twilio-engineering.atlassian.net/browse/TUBE-3799
- `DescribeGroups` loops through all groups returned by the broker and decodes member metadata and assignments for each. Previously, a decode failure on any single group's member would cause the entire call to return an error, preventing all other groups from being returned
- This change scopes decode errors to the individual group by setting `group.Error` instead of returning a top-level error. Groups that decode successfully are unaffected by failures in other groups.
- Additionally, when a decode error occurs partway through a group's member list, any previously decoded members are cleared to avoid returning a partial member list alongside an error.

## Testing
- Added below unit tests:
  - `TestDescribeGroupsErrorHandling` — one bad group among three, valid groups still returned with members
  - `TestDescribeGroupsInvalidAssignments` — valid metadata but invalid assignments sets group error
  - `TestDescribeGroupsPartialMembersCleared` — multi-member group where member 2 fails; verifies member 1 is cleared