### PR TITLE
feat: implement KIP-392 consumer rack awareness

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -28,7 +28,11 @@ type Batch struct {
 	partition     int
 	offset        int64
 	highWaterMark int64
-	err           error
+	// preferredReadReplica is the broker id (>=0) the broker would prefer
+	// the consumer fetch from for this partition (KIP-392). -1 means no
+	// preference (fetch from leader).
+	preferredReadReplica int32
+	err                  error
 	// The last offset in the batch.
 	//
 	// We use lastOffset to skip offsets that have been compacted away.
@@ -49,6 +53,17 @@ func (batch *Batch) Throttle() time.Duration {
 // HighWaterMark returns the current highest watermark in a partition.
 func (batch *Batch) HighWaterMark() int64 {
 	return batch.highWaterMark
+}
+
+// PreferredReadReplica returns the broker id of the replica the kafka broker
+// recommends the consumer fetch from for this partition, as introduced in
+// KIP-392 (Allow Consumers to Fetch from Closest Replica). A value of -1
+// means no preference and the consumer should keep fetching from the
+// partition leader. The value is only populated when the connection
+// negotiated Fetch v11 or higher and the broker chose a preferred replica;
+// otherwise it is -1.
+func (batch *Batch) PreferredReadReplica() int32 {
+	return batch.preferredReadReplica
 }
 
 // Partition returns the batch partition.

--- a/conn.go
+++ b/conn.go
@@ -54,6 +54,7 @@ type Conn struct {
 	fetchMinSize  int32
 	broker        int32
 	rack          string
+	clientRack    string
 
 	// correlation ID generator (synchronized on wlock)
 	correlationID int32
@@ -90,6 +91,13 @@ type ConnConfig struct {
 	Partition int
 	Broker    int
 	Rack      string
+
+	// ClientRack is the consumer's rack id used by the broker to determine
+	// the closest replica to fetch from (KIP-392). When set and the broker
+	// supports Fetch v11 or higher, the rack id is sent in fetch requests
+	// and the broker may direct the consumer to read from a follower
+	// replica that is closer to the consumer.
+	ClientRack string
 
 	// The transactional id to use for transactional delivery. Idempotent
 	// deliver should be enabled if transactional id is configured.
@@ -179,6 +187,7 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 		partition:       int32(config.Partition),
 		broker:          int32(config.Broker),
 		rack:            config.Rack,
+		clientRack:      config.ClientRack,
 		offset:          FirstOffset,
 		requiredAcks:    -1,
 		transactionalID: emptyToNullable(config.TransactionalID),
@@ -777,7 +786,7 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 		return &Batch{err: dontExpectEOF(err)}
 	}
 
-	fetchVersion, err := c.negotiateVersion(fetch, v2, v5, v10)
+	fetchVersion, err := c.negotiateVersion(fetch, v2, v5, v10, v11)
 	if err != nil {
 		return &Batch{err: dontExpectEOF(err)}
 	}
@@ -799,6 +808,19 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 		// truncated messages.
 		adjustedDeadline = deadline
 		switch fetchVersion {
+		case v11:
+			return c.wb.writeFetchRequestV11(
+				id,
+				c.clientID,
+				c.topic,
+				c.partition,
+				offset,
+				cfg.MinBytes,
+				cfg.MaxBytes+int(c.fetchMinSize),
+				timeout,
+				int8(cfg.IsolationLevel),
+				c.clientRack,
+			)
 		case v10:
 			return c.wb.writeFetchRequestV10(
 				id,
@@ -848,8 +870,11 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 	var throttle int32
 	var highWaterMark int64
 	var remain int
+	var preferredReadReplica int32 = -1
 
 	switch fetchVersion {
+	case v11:
+		throttle, highWaterMark, preferredReadReplica, remain, err = readFetchResponseHeaderV11(&c.rbuf, size)
 	case v10:
 		throttle, highWaterMark, remain, err = readFetchResponseHeaderV10(&c.rbuf, size)
 	case v5:
@@ -874,15 +899,16 @@ func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
 	}
 
 	return &Batch{
-		conn:          c,
-		msgs:          msgs,
-		deadline:      adjustedDeadline,
-		throttle:      makeDuration(throttle),
-		lock:          lock,
-		topic:         c.topic,          // topic is copied to Batch to prevent race with Batch.close
-		partition:     int(c.partition), // partition is copied to Batch to prevent race with Batch.close
-		offset:        offset,
-		highWaterMark: highWaterMark,
+		conn:                 c,
+		msgs:                 msgs,
+		deadline:             adjustedDeadline,
+		throttle:             makeDuration(throttle),
+		lock:                 lock,
+		topic:                c.topic,          // topic is copied to Batch to prevent race with Batch.close
+		partition:            int(c.partition), // partition is copied to Batch to prevent race with Batch.close
+		offset:               offset,
+		highWaterMark:        highWaterMark,
+		preferredReadReplica: preferredReadReplica,
 		// there shouldn't be a short read on initially setting up the batch.
 		// as such, any io.EOF is re-mapped to an io.ErrUnexpectedEOF so that we
 		// don't accidentally signal that we successfully reached the end of the

--- a/dialer.go
+++ b/dialer.go
@@ -89,6 +89,11 @@ type Dialer struct {
 	// For more details look at transactional.id description here: http://kafka.apache.org/documentation.html#producerconfigs
 	// Empty string means that the connection will be non-transactional.
 	TransactionalID string
+
+	// ClientRack is the consumer's rack id (KIP-392). When set and the broker
+	// supports Fetch v11+, the broker may direct the consumer to fetch from
+	// the closest replica instead of the partition leader.
+	ClientRack string
 }
 
 // Dial connects to the address on the named network.
@@ -117,6 +122,7 @@ func (d *Dialer) DialContext(ctx context.Context, network string, address string
 		ConnConfig{
 			ClientID:        d.ClientID,
 			TransactionalID: d.TransactionalID,
+			ClientRack:      d.ClientRack,
 		},
 	)
 }
@@ -148,6 +154,7 @@ func (d *Dialer) DialPartition(ctx context.Context, network string, address stri
 		Broker:          partition.Leader.ID,
 		Rack:            partition.Leader.Rack,
 		TransactionalID: d.TransactionalID,
+		ClientRack:      d.ClientRack,
 	})
 }
 

--- a/fetch.go
+++ b/fetch.go
@@ -37,6 +37,14 @@ type FetchRequest struct {
 	// This field requires the kafka broker to support the Fetch API in version
 	// 4 or above (otherwise the value is ignored).
 	IsolationLevel IsolationLevel
+
+	// RackID is the consumer's rack id (KIP-392). When set, the broker may
+	// direct the consumer to fetch from the closest replica via the
+	// PreferredReadReplica field of the response.
+	//
+	// This field requires the kafka broker to support the Fetch API in
+	// version 11 or above (otherwise the value is ignored).
+	RackID string
 }
 
 // FetchResponse represents a response from a kafka broker to a fetch request.
@@ -59,6 +67,12 @@ type FetchResponse struct {
 	HighWatermark    int64
 	LastStableOffset int64
 	LogStartOffset   int64
+
+	// PreferredReadReplica is the broker id the broker would prefer the
+	// consumer fetch from for this partition (KIP-392). A value of -1 means
+	// no preference. Only populated when the broker supports Fetch v11 or
+	// above; otherwise it is 0.
+	PreferredReadReplica int32
 
 	// An error that may have occurred while attempting to fetch the records.
 	//
@@ -145,6 +159,7 @@ func (c *Client) Fetch(ctx context.Context, req *FetchRequest) (*FetchResponse, 
 				PartitionMaxBytes:  int32(req.MaxBytes),
 			}},
 		}},
+		RackID: req.RackID,
 	})
 
 	if err != nil {
@@ -162,14 +177,15 @@ func (c *Client) Fetch(ctx context.Context, req *FetchRequest) (*FetchResponse, 
 	partition := &topic.Partitions[0]
 
 	ret := &FetchResponse{
-		Throttle:         makeDuration(res.ThrottleTimeMs),
-		Topic:            topic.Topic,
-		Partition:        int(partition.Partition),
-		Error:            makeError(res.ErrorCode, ""),
-		HighWatermark:    partition.HighWatermark,
-		LastStableOffset: partition.LastStableOffset,
-		LogStartOffset:   partition.LogStartOffset,
-		Records:          partition.RecordSet.Records,
+		Throttle:             makeDuration(res.ThrottleTimeMs),
+		Topic:                topic.Topic,
+		Partition:            int(partition.Partition),
+		Error:                makeError(res.ErrorCode, ""),
+		HighWatermark:        partition.HighWatermark,
+		LastStableOffset:     partition.LastStableOffset,
+		LogStartOffset:       partition.LogStartOffset,
+		PreferredReadReplica: partition.PreferredReadReplica,
+		Records:              partition.RecordSet.Records,
 	}
 
 	if partition.ErrorCode != 0 {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/segmentio/kafka-go
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/klauspost/compress v1.15.9

--- a/protocol.go
+++ b/protocol.go
@@ -110,6 +110,7 @@ const (
 	v6  = 6
 	v7  = 7
 	v10 = 10
+	v11 = 11
 
 	// Unused protocol versions: v4, v8, v9.
 )

--- a/read.go
+++ b/read.go
@@ -560,3 +560,107 @@ func readFetchResponseHeaderV10(r *bufio.Reader, size int) (throttle int32, wate
 	return
 
 }
+
+// readFetchResponseHeaderV11 mirrors readFetchResponseHeaderV10 but additionally
+// decodes the per-partition PreferredReadReplica field introduced by KIP-392
+// (Fetch v11). Returned preferredReadReplica is -1 when the broker has no
+// preference.
+func readFetchResponseHeaderV11(r *bufio.Reader, size int) (throttle int32, watermark int64, preferredReadReplica int32, remain int, err error) {
+	var n int32
+	var errorCode int16
+	type AbortedTransaction struct {
+		ProducerId  int64
+		FirstOffset int64
+	}
+	var p struct {
+		Partition           int32
+		ErrorCode           int16
+		HighwaterMarkOffset int64
+		LastStableOffset    int64
+		LogStartOffset      int64
+	}
+	var messageSetSize int32
+	var abortedTransactions []AbortedTransaction
+	preferredReadReplica = -1
+
+	if remain, err = readInt32(r, size, &throttle); err != nil {
+		return
+	}
+
+	if remain, err = readInt16(r, remain, &errorCode); err != nil {
+		return
+	}
+	if errorCode != 0 {
+		err = Error(errorCode)
+		return
+	}
+
+	if remain, err = discardInt32(r, remain); err != nil {
+		return
+	}
+
+	if remain, err = readInt32(r, remain, &n); err != nil {
+		return
+	}
+	if n != 1 {
+		err = fmt.Errorf("1 kafka topic was expected in the fetch response but the client received %d", n)
+		return
+	}
+
+	if remain, err = discardString(r, remain); err != nil {
+		return
+	}
+
+	if remain, err = readInt32(r, remain, &n); err != nil {
+		return
+	}
+	if n != 1 {
+		err = fmt.Errorf("1 kafka partition was expected in the fetch response but the client received %d", n)
+		return
+	}
+
+	if remain, err = read(r, remain, &p); err != nil {
+		return
+	}
+
+	var abortedTransactionLen int
+	if remain, err = readArrayLen(r, remain, &abortedTransactionLen); err != nil {
+		return
+	}
+
+	if abortedTransactionLen == -1 {
+		abortedTransactions = nil
+	} else {
+		abortedTransactions = make([]AbortedTransaction, abortedTransactionLen)
+		for i := 0; i < abortedTransactionLen; i++ {
+			if remain, err = read(r, remain, &abortedTransactions[i]); err != nil {
+				return
+			}
+		}
+	}
+	_ = abortedTransactions
+
+	// PreferredReadReplica (KIP-392): broker id of the preferred read replica
+	// for this partition, or -1 if no preference.
+	if remain, err = readInt32(r, remain, &preferredReadReplica); err != nil {
+		return
+	}
+
+	if p.ErrorCode != 0 {
+		err = Error(p.ErrorCode)
+		return
+	}
+
+	remain, err = readInt32(r, remain, &messageSetSize)
+	if err != nil {
+		return
+	}
+
+	if remain != int(messageSetSize) {
+		err = fmt.Errorf("the size of the message set in a fetch response doesn't match the number of remaining bytes (message set size = %d, remaining bytes = %d)", messageSetSize, remain)
+		return
+	}
+
+	watermark = p.HighwaterMarkOffset
+	return
+}

--- a/reader.go
+++ b/reader.go
@@ -522,6 +522,13 @@ type ReaderConfig struct {
 	// This flag is being added to retain backwards-compatibility, so it will be
 	// removed in a future version of kafka-go.
 	OffsetOutOfRangeError bool
+
+	// Rack is the consumer's rack id (KIP-392 client.rack). When set, the
+	// reader advertises this rack to the broker on each fetch request and
+	// the broker may direct the consumer to fetch from the closest replica
+	// instead of the partition leader. Requires the broker to support
+	// Fetch v11 or higher; ignored otherwise.
+	Rack string
 }
 
 // Validate method validates ReaderConfig properties.
@@ -642,6 +649,15 @@ func NewReader(config ReaderConfig) *Reader {
 
 	if config.Dialer == nil {
 		config.Dialer = DefaultDialer
+	}
+
+	// Propagate the consumer rack (KIP-392) onto the dialer so that fetch
+	// requests sent through Conns dialed by the reader carry the rack id.
+	// Clone the dialer to avoid mutating a shared instance.
+	if config.Rack != "" && config.Dialer.ClientRack != config.Rack {
+		d := *config.Dialer
+		d.ClientRack = config.Rack
+		config.Dialer = &d
 	}
 
 	if config.MaxBytes == 0 {
@@ -1196,23 +1212,25 @@ func (r *Reader) start(offsetsByPartition map[topicPartition]int64) {
 			defer join.Done()
 
 			(&reader{
-				dialer:           r.config.Dialer,
-				logger:           r.config.Logger,
-				errorLogger:      r.config.ErrorLogger,
-				brokers:          r.config.Brokers,
-				topic:            key.topic,
-				partition:        int(key.partition),
-				minBytes:         r.config.MinBytes,
-				maxBytes:         r.config.MaxBytes,
-				maxWait:          r.config.MaxWait,
-				readBatchTimeout: r.config.ReadBatchTimeout,
-				backoffDelayMin:  r.config.ReadBackoffMin,
-				backoffDelayMax:  r.config.ReadBackoffMax,
-				version:          r.version,
-				msgs:             r.msgs,
-				stats:            r.stats,
-				isolationLevel:   r.config.IsolationLevel,
-				maxAttempts:      r.config.MaxAttempts,
+				dialer:               r.config.Dialer,
+				logger:               r.config.Logger,
+				errorLogger:          r.config.ErrorLogger,
+				brokers:              r.config.Brokers,
+				topic:                key.topic,
+				partition:            int(key.partition),
+				minBytes:             r.config.MinBytes,
+				maxBytes:             r.config.MaxBytes,
+				maxWait:              r.config.MaxWait,
+				readBatchTimeout:     r.config.ReadBatchTimeout,
+				backoffDelayMin:      r.config.ReadBackoffMin,
+				backoffDelayMax:      r.config.ReadBackoffMax,
+				version:              r.version,
+				msgs:                 r.msgs,
+				stats:                r.stats,
+				isolationLevel:       r.config.IsolationLevel,
+				maxAttempts:          r.config.MaxAttempts,
+				rack:                 r.config.Rack,
+				preferredReadReplica: -1,
 
 				// backwards-compatibility flags
 				offsetOutOfRangeError: r.config.OffsetOutOfRangeError,
@@ -1242,6 +1260,15 @@ type reader struct {
 	stats            *readerStats
 	isolationLevel   IsolationLevel
 	maxAttempts      int
+
+	// rack is the consumer's rack id (KIP-392). Empty means disabled.
+	rack string
+	// preferredReadReplica is the broker id the broker last asked us to
+	// fetch from for this partition (-1 = no preference / fetch from leader).
+	preferredReadReplica int32
+	// preferredReadReplicaExpiresAt bounds the time we keep using the
+	// preferred replica before falling back to the leader and re-discovering.
+	preferredReadReplicaExpiresAt time.Time
 
 	offsetOutOfRangeError bool
 }
@@ -1346,6 +1373,13 @@ func (r *reader) run(ctx context.Context, offset int64) {
 				conn.Close()
 				break readLoop
 
+			case errors.Is(err, errPreferredReadReplicaChanged):
+				// KIP-392: the broker selected a (new) preferred read replica
+				// for us, or our preference expired. Reconnect via the outer
+				// loop using the updated preferredReadReplica state.
+				errcount = 0
+				break readLoop
+
 			case errors.Is(err, UnknownTopicOrPartition):
 				r.withErrorLogger(func(log Logger) {
 					log.Printf("failed to read from current broker %v for partition %d of %s at offset %d: %v", r.brokers, r.partition, r.topic, toHumanOffset(offset), err)
@@ -1440,12 +1474,30 @@ func (r *reader) run(ctx context.Context, offset int64) {
 }
 
 func (r *reader) initialize(ctx context.Context, offset int64) (conn *Conn, start int64, err error) {
+	// If a preferred read replica was selected (KIP-392) and is still fresh,
+	// try to dial it. On failure (broker unknown, dial error, etc.) we fall
+	// back to the leader.
+	usePreferred := r.preferredReadReplica >= 0 && time.Now().Before(r.preferredReadReplicaExpiresAt)
+
 	for i := 0; i != len(r.brokers) && conn == nil; i++ {
 		broker := r.brokers[i]
 		var first, last int64
 
 		t0 := time.Now()
-		conn, err = r.dialer.DialLeader(ctx, "tcp", broker, r.topic, r.partition)
+		if usePreferred {
+			conn, err = r.dialPreferredReplica(ctx, broker)
+			if err != nil {
+				r.withErrorLogger(func(log Logger) {
+					log.Printf("kafka reader could not dial preferred read replica %d for partition %d of %s, falling back to leader: %v", r.preferredReadReplica, r.partition, r.topic, err)
+				})
+				r.preferredReadReplica = -1
+				r.preferredReadReplicaExpiresAt = time.Time{}
+				usePreferred = false
+				conn, err = r.dialer.DialLeader(ctx, "tcp", broker, r.topic, r.partition)
+			}
+		} else {
+			conn, err = r.dialer.DialLeader(ctx, "tcp", broker, r.topic, r.partition)
+		}
 		t1 := time.Now()
 		r.stats.dials.observe(1)
 		r.stats.dialTime.observeDuration(t1.Sub(t0))
@@ -1500,6 +1552,38 @@ func (r *reader) read(ctx context.Context, offset int64, conn *Conn) (int64, err
 		IsolationLevel: r.isolationLevel,
 	})
 	highWaterMark := batch.HighWaterMark()
+
+	// KIP-392: if the broker reports a (different) preferred read replica, or
+	// expired our current preference, record it and bail out so that the outer
+	// loop reconnects to the preferred broker on the next initialize().
+	if prr := batch.PreferredReadReplica(); prr != r.preferredReadReplica {
+		r.preferredReadReplica = prr
+		if prr >= 0 {
+			// Default to 5 minutes — matches Kafka's metadata.max.age.ms default
+			// and the reference behavior of the Java client for the preferred
+			// read replica TTL.
+			r.preferredReadReplicaExpiresAt = time.Now().Add(5 * time.Minute)
+			r.withLogger(func(log Logger) {
+				log.Printf("kafka reader switching to preferred read replica %d for partition %d of %s", prr, r.partition, r.topic)
+			})
+		} else {
+			r.preferredReadReplicaExpiresAt = time.Time{}
+			r.withLogger(func(log Logger) {
+				log.Printf("kafka reader falling back to leader for partition %d of %s", r.partition, r.topic)
+			})
+		}
+		batch.Close()
+		conn.Close()
+		return offset, errPreferredReadReplicaChanged
+	}
+	// Preferred replica TTL elapsed — go back to leader and re-discover.
+	if r.preferredReadReplica >= 0 && time.Now().After(r.preferredReadReplicaExpiresAt) {
+		r.preferredReadReplica = -1
+		r.preferredReadReplicaExpiresAt = time.Time{}
+		batch.Close()
+		conn.Close()
+		return offset, errPreferredReadReplicaChanged
+	}
 
 	t1 := time.Now()
 	r.stats.waitTime.observeDuration(t1.Sub(t0))
@@ -1618,4 +1702,55 @@ func (offset humanOffset) Format(w fmt.State, _ rune) {
 	default:
 		fmt.Fprint(w, strconv.FormatInt(v, 10))
 	}
+}
+
+// errPreferredReadReplicaChanged is an internal sentinel returned by reader.read
+// to signal the outer run loop that we need to reconnect, either to a newly
+// elected preferred read replica (KIP-392) or back to the leader after the
+// preferred replica expired.
+var errPreferredReadReplicaChanged = errors.New("preferred read replica changed")
+
+// dialPreferredReplica resolves r.preferredReadReplica's broker address by
+// asking the seed broker for cluster metadata, then opens a partition
+// connection to that broker. Returns an error if the broker id cannot be
+// found or any dial step fails.
+func (r *reader) dialPreferredReplica(ctx context.Context, seed string) (*Conn, error) {
+	// Open a short-lived connection to the seed broker just to look up
+	// brokers + the partition descriptor.
+	c, err := r.dialer.DialContext(ctx, "tcp", seed)
+	if err != nil {
+		return nil, fmt.Errorf("dial seed broker %s: %w", seed, err)
+	}
+	parts, err := c.ReadPartitions(r.topic)
+	c.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read partitions: %w", err)
+	}
+
+	var target Partition
+	var found bool
+	for _, p := range parts {
+		if p.ID != r.partition {
+			continue
+		}
+		// Search leader + replicas + isr for the broker id.
+		candidates := append([]Broker{p.Leader}, p.Replicas...)
+		candidates = append(candidates, p.Isr...)
+		for _, b := range candidates {
+			if b.ID == int(r.preferredReadReplica) {
+				// Build a Partition view where the preferred replica is
+				// presented as the "leader" so DialPartition connects to it
+				// and the resulting Conn is bound to the right topic/partition.
+				target = p
+				target.Leader = b
+				found = true
+				break
+			}
+		}
+		break
+	}
+	if !found {
+		return nil, fmt.Errorf("preferred replica %d not found in metadata for partition %d of %s", r.preferredReadReplica, r.partition, r.topic)
+	}
+	return r.dialer.DialPartition(ctx, "tcp", seed, target)
 }

--- a/write.go
+++ b/write.go
@@ -295,6 +295,65 @@ func (wb *writeBuffer) writeFetchRequestV10(correlationID int32, clientID, topic
 	return wb.Flush()
 }
 
+// writeFetchRequestV11 is identical to writeFetchRequestV10 but additionally
+// sends a rack id (KIP-392) which lets the broker direct the consumer to the
+// closest replica.
+func (wb *writeBuffer) writeFetchRequestV11(correlationID int32, clientID, topic string, partition int32, offset int64, minBytes, maxBytes int, maxWait time.Duration, isolationLevel int8, rackID string) error {
+	h := requestHeader{
+		ApiKey:        int16(fetch),
+		ApiVersion:    int16(v11),
+		CorrelationID: correlationID,
+		ClientID:      clientID,
+	}
+	h.Size = (h.size() - 4) +
+		4 + // replica ID
+		4 + // max wait time
+		4 + // min bytes
+		4 + // max bytes
+		1 + // isolation level
+		4 + // session ID
+		4 + // session epoch
+		4 + // topic array length
+		sizeofString(topic) +
+		4 + // partition array length
+		4 + // partition
+		4 + // current leader epoch
+		8 + // fetch offset
+		8 + // log start offset
+		4 + // partition max bytes
+		4 + // forgotten topics data
+		sizeofString(rackID) // rack id
+
+	h.writeTo(wb)
+	wb.writeInt32(-1) // replica ID
+	wb.writeInt32(milliseconds(maxWait))
+	wb.writeInt32(int32(minBytes))
+	wb.writeInt32(int32(maxBytes))
+	wb.writeInt8(isolationLevel)
+	wb.writeInt32(0)  // session ID
+	wb.writeInt32(-1) // session epoch
+
+	// topic array
+	wb.writeArrayLen(1)
+	wb.writeString(topic)
+
+	// partition array
+	wb.writeArrayLen(1)
+	wb.writeInt32(partition)
+	wb.writeInt32(-1) // current leader epoch
+	wb.writeInt64(offset)
+	wb.writeInt64(int64(0)) // log start offset only used when sent by follower
+	wb.writeInt32(int32(maxBytes))
+
+	// forgotten topics array
+	wb.writeArrayLen(0)
+
+	// rack id (KIP-392)
+	wb.writeString(rackID)
+
+	return wb.Flush()
+}
+
 func (wb *writeBuffer) writeListOffsetRequestV1(correlationID int32, clientID, topic string, partition int32, time int64) error {
 	h := requestHeader{
 		ApiKey:        int16(listOffsets),


### PR DESCRIPTION
Add RackID support to FetchRequest/FetchResponse and propagate PreferredReadReplica from the broker's Fetch v11+ response. This allows consumers to set a rack ID so the broker can direct them to fetch from the closest replica, reducing cross-datacenter traffic.
Changes:
- fetch.go: RackID field on FetchRequest, PreferredReadReplica on FetchResponse
- reader.go: RackID config option on ReaderConfig, propagated through to fetch
- conn.go: rack-aware fetch support in low-level Conn API
- batch.go: expose PreferredReadReplica on Batch
- dialer.go: RackID on DialerConfig
- read.go: helper for rack-aware reading
- write.go: pass-through support
- protocol.go: PreferredReadReplica constant