### PR TITLE
fix: correct typos in comments

### DIFF
--- a/addpartitionstotxn.go
+++ b/addpartitionstotxn.go
@@ -16,7 +16,7 @@ type AddPartitionToTxn struct {
 	Partition int
 }
 
-// AddPartitionsToTxnRequest is the request structure fo the AddPartitionsToTxn function.
+// AddPartitionsToTxnRequest is the request structure for the AddPartitionsToTxn function.
 type AddPartitionsToTxnRequest struct {
 	// Address of the kafka broker to send the request to.
 	Addr net.Addr

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ const (
 	defaultMaxWait                 = 500 * time.Millisecond
 )
 
-// Client is a high-level API to interract with kafka brokers.
+// Client is a high-level API to interact with kafka brokers.
 //
 // All methods of the Client type accept a context as first argument, which may
 // be used to asynchronously cancel the requests.

--- a/createpartitions.go
+++ b/createpartitions.go
@@ -10,7 +10,7 @@ import (
 )
 
 // CreatePartitionsRequest represents a request sent to a kafka broker to create
-// and update topic parititions.
+// and update topic partitions.
 type CreatePartitionsRequest struct {
 	// Address of the kafka broker to send the request to.
 	Addr net.Addr

--- a/createtopics.go
+++ b/createtopics.go
@@ -108,7 +108,7 @@ func (t createTopicsRequestV0ConfigEntry) writeTo(wb *writeBuffer) {
 type ReplicaAssignment struct {
 	Partition int
 	// The list of brokers where the partition should be allocated. There must
-	// be as many entries in thie list as there are replicas of the partition.
+	// be as many entries in the list as there are replicas of the partition.
 	// The first entry represents the broker that will be the preferred leader
 	// for the partition.
 	//

--- a/endtxn.go
+++ b/endtxn.go
@@ -9,7 +9,7 @@ import (
 	"github.com/segmentio/kafka-go/protocol/endtxn"
 )
 
-// EndTxnRequest represets a request sent to a kafka broker to end a transaction.
+// EndTxnRequest represents a request sent to a kafka broker to end a transaction.
 type EndTxnRequest struct {
 	// Address of the kafka broker to send the request to.
 	Addr net.Addr
@@ -27,7 +27,7 @@ type EndTxnRequest struct {
 	Committed bool
 }
 
-// EndTxnResponse represents a resposne from a kafka broker to an end transaction request.
+// EndTxnResponse represents a response from a kafka broker to an end transaction request.
 type EndTxnResponse struct {
 	// The amount of time that the broker throttled the request.
 	Throttle time.Duration

--- a/joingroup.go
+++ b/joingroup.go
@@ -54,7 +54,7 @@ type GroupProtocolSubscription struct {
 	// The Topics to subscribe to.
 	Topics []string
 
-	// UserData assosiated with the subscription for the given protocol
+	// UserData associated with the subscription for the given protocol
 	UserData []byte
 
 	// Partitions owned by this consumer.
@@ -91,9 +91,9 @@ type JoinGroupResponse struct {
 	Members []JoinGroupResponseMember
 }
 
-// JoinGroupResponseMember represents a group memmber in a reponse to a JoinGroup request.
+// JoinGroupResponseMember represents a group member in a response to a JoinGroup request.
 type JoinGroupResponseMember struct {
-	// The group memmber ID.
+	// The group member ID.
 	ID string
 
 	// The unique identifier of the consumer instance.

--- a/leavegroup.go
+++ b/leavegroup.go
@@ -22,7 +22,7 @@ type LeaveGroupRequest struct {
 	Members []LeaveGroupRequestMember
 }
 
-// LeaveGroupRequestMember represents the indentify of a member leaving a group.
+// LeaveGroupRequestMember represents the identity of a member leaving a group.
 type LeaveGroupRequestMember struct {
 	// The member ID to remove from the group.
 	ID string
@@ -54,7 +54,7 @@ type LeaveGroupResponseMember struct {
 	// The group instance ID to remove from the group.
 	GroupInstanceID string
 
-	// An error that may have occured when attempting to remove the member from the group.
+	// An error that may have occurred when attempting to remove the member from the group.
 	//
 	// The errors contain the kafka error code. Programs may use the standard
 	// errors.Is function to test the error against kafka error codes.

--- a/metadata.go
+++ b/metadata.go
@@ -115,7 +115,7 @@ func (r topicMetadataRequestV1) size() int32 {
 
 func (r topicMetadataRequestV1) writeTo(wb *writeBuffer) {
 	// communicate nil-ness to the broker by passing -1 as the array length.
-	// for this particular request, the broker interpets a zero length array
+	// for this particular request, the broker interprets a zero length array
 	// as a request for no topics whereas a nil array is for all topics.
 	if r == nil {
 		wb.writeArrayLen(-1)
@@ -211,7 +211,7 @@ func (r topicMetadataRequestV6) size() int32 {
 
 func (r topicMetadataRequestV6) writeTo(wb *writeBuffer) {
 	// communicate nil-ness to the broker by passing -1 as the array length.
-	// for this particular request, the broker interpets a zero length array
+	// for this particular request, the broker interprets a zero length array
 	// as a request for no topics whereas a nil array is for all topics.
 	if r.Topics == nil {
 		wb.writeArrayLen(-1)

--- a/protocol/buffer.go
+++ b/protocol/buffer.go
@@ -71,7 +71,7 @@ func (rc *refCount) unref(onZero func()) {
 }
 
 const (
-	// Size of the memory buffer for a single page. We use a farily
+	// Size of the memory buffer for a single page. We use a fairly
 	// large size here (64 KiB) because batches exchanged with kafka
 	// tend to be multiple kilobytes in size, sometimes hundreds.
 	// Using large pages amortizes the overhead of the page metadata

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -459,7 +459,7 @@ type Partition struct {
 	Offline  []int32
 }
 
-// RawExchanger is an extention to the Message interface to allow messages
+// RawExchanger is an extension to the Message interface to allow messages
 // to control the request response cycle for the message. This is currently
 // only used to facilitate v0 SASL Authenticate requests being written in
 // a non-standard fashion when the SASL Handshake was done at v0 but not

--- a/syncgroup.go
+++ b/syncgroup.go
@@ -40,7 +40,7 @@ type SyncGroupRequest struct {
 	Assignments []SyncGroupRequestAssignment
 }
 
-// SyncGroupRequestAssignment represents an assignement for a goroup memeber.
+// SyncGroupRequestAssignment represents an assignment for a group member.
 type SyncGroupRequestAssignment struct {
 	// The ID of the member to assign.
 	MemberID string
@@ -70,12 +70,12 @@ type SyncGroupResponse struct {
 	Assignment GroupProtocolAssignment
 }
 
-// GroupProtocolAssignment represents an assignment of topics and partitions for a group memeber.
+// GroupProtocolAssignment represents an assignment of topics and partitions for a group member.
 type GroupProtocolAssignment struct {
-	// The topics and partitions assigned to the group memeber.
+	// The topics and partitions assigned to the group member.
 	AssignedPartitions map[string][]int
 
-	// UserData for the assignemnt.
+	// UserData for the assignment.
 	UserData []byte
 }
 

--- a/transport.go
+++ b/transport.go
@@ -1200,7 +1200,7 @@ func (g *connGroup) connect(ctx context.Context, addr net.Addr) (*conn, error) {
 	ver := make(map[protocol.ApiKey]int16, len(res.ApiKeys))
 
 	if res.ErrorCode != 0 {
-		return nil, fmt.Errorf("negotating API versions with kafka broker at %s: %w", g.addr, Error(res.ErrorCode))
+		return nil, fmt.Errorf("negotiating API versions with kafka broker at %s: %w", g.addr, Error(res.ErrorCode))
 	}
 
 	for _, r := range res.ApiKeys {


### PR DESCRIPTION
Fix several typos found in Go source file comments across the codebase.

Changes:
- `addpartitionstotxn.go`: `fo` -> `for`
- `client.go`: `interract` -> `interact`
- `createpartitions.go`: `parititions` -> `partitions`
- `createtopics.go`: `thie` -> `the`
- `endtxn.go`: `represets` -> `represents`, `resposne` -> `response`
- `joingroup.go`: `assosiated` -> `associated`, `memmber` -> `member`, `reponse` -> `response`
- `leavegroup.go`: `indentify` -> `identity`, `occured` -> `occurred`
- `metadata.go`: `interpets` -> `interprets` (two occurrences)
- `protocol/buffer.go`: `farily` -> `fairly`
- `protocol/protocol.go`: `extention` -> `extension`
- `syncgroup.go`: `assignement` -> `assignment`, `goroup` -> `group`, `memeber` -> `member` (multiple), `assignemnt` -> `assignment`
- `transport.go`: `negotating` -> `negotiating`

All changes are in comments only — no logic or API surface is affected.