### PR TITLE
fix: bound decoded array length to remaining frame bytes

### DIFF
--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -110,8 +110,9 @@ func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeF
 	if n := d.readInt32(); n < 0 {
 		v.setArray(array{})
 	} else {
-		a := makeArray(elemType, int(n))
-		for i := 0; i < int(n) && d.remain > 0; i++ {
+		count := boundArrayLen(int(n), d.remain)
+		a := makeArray(elemType, count)
+		for i := 0; i < count && d.remain > 0; i++ {
 			decodeElem(d, a.index(i))
 		}
 		v.setArray(a)
@@ -122,12 +123,25 @@ func (d *decoder) decodeCompactArray(v value, elemType reflect.Type, decodeElem 
 	if n := d.readUnsignedVarInt(); n < 1 {
 		v.setArray(array{})
 	} else {
-		a := makeArray(elemType, int(n-1))
-		for i := 0; i < int(n-1) && d.remain > 0; i++ {
+		count := boundArrayLen(int(n-1), d.remain)
+		a := makeArray(elemType, count)
+		for i := 0; i < count && d.remain > 0; i++ {
 			decodeElem(d, a.index(i))
 		}
 		v.setArray(a)
 	}
+}
+
+// boundArrayLen clamps a decoded array length to the number of bytes left in
+// the frame. Every encoded element occupies at least one byte, so a length
+// greater than remain can only come from a malformed or non-Kafka response;
+// allocating an array of that size would let an untrusted length field drive
+// unbounded memory allocation before a single element is validated.
+func boundArrayLen(n, remain int) int {
+	if n > remain {
+		return remain
+	}
+	return n
 }
 
 func (d *decoder) discardAll() {

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -1,0 +1,70 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"testing"
+)
+
+// newTestDecoder builds a decoder over data, with remain set to len(data), the
+// same invariant Unmarshal establishes before decoding a response frame.
+func newTestDecoder(data []byte) *decoder {
+	d := &decoder{reader: bytes.NewReader(data)}
+	d.remain = len(data)
+	return d
+}
+
+// TestDecodeArrayMalformedLengthDoesNotOOM reproduces a malformed or
+// non-Kafka response whose declared array length vastly exceeds the bytes
+// actually available in the frame. Before the length is bounded, makeArray
+// allocates directly from the untrusted length field, so a tiny buffer
+// claiming billions of elements can exhaust memory before a single element
+// is decoded.
+func TestDecodeArrayMalformedLengthDoesNotOOM(t *testing.T) {
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, uint32(1<<31-1)) // math.MaxInt32 elements
+	d := newTestDecoder(buf)
+
+	v := valueOf(new([]int32))
+	d.decodeArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+
+	if d.remain != 0 {
+		t.Fatalf("expected all bytes consumed, got remain=%d", d.remain)
+	}
+	if n := v.val.Len(); n > len(buf) {
+		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
+	}
+}
+
+// TestDecodeCompactArrayMalformedLengthDoesNotOOM is the compact-encoding
+// (flexible version) counterpart of TestDecodeArrayMalformedLengthDoesNotOOM.
+func TestDecodeCompactArrayMalformedLengthDoesNotOOM(t *testing.T) {
+	buf := []byte{0xff, 0xff, 0xff, 0xff, 0x0f} // unsigned varint for MaxUint32
+	d := newTestDecoder(buf)
+
+	v := valueOf(new([]int32))
+	d.decodeCompactArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+
+	if n := v.val.Len(); n > len(buf) {
+		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
+	}
+}
+
+func TestBoundArrayLen(t *testing.T) {
+	tests := []struct {
+		n, remain, want int
+	}{
+		{n: 0, remain: 10, want: 0},
+		{n: 5, remain: 10, want: 5},
+		{n: 10, remain: 10, want: 10},
+		{n: 11, remain: 10, want: 10},
+		{n: 1 << 30, remain: 3, want: 3},
+		{n: 5, remain: 0, want: 0},
+	}
+	for _, test := range tests {
+		if got := boundArrayLen(test.n, test.remain); got != test.want {
+			t.Errorf("boundArrayLen(%d, %d) = %d, want %d", test.n, test.remain, got, test.want)
+		}
+	}
+}

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -26,13 +26,13 @@ func TestDecodeArrayMalformedLengthDoesNotOOM(t *testing.T) {
 	binary.BigEndian.PutUint32(buf, uint32(1<<31-1)) // math.MaxInt32 elements
 	d := newTestDecoder(buf)
 
-	v := valueOf(new([]int32))
-	d.decodeArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+	p := new([]int32)
+	d.decodeArray(valueOf(p), reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
 
 	if d.remain != 0 {
 		t.Fatalf("expected all bytes consumed, got remain=%d", d.remain)
 	}
-	if n := v.val.Len(); n > len(buf) {
+	if n := len(*p); n > len(buf) {
 		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
 	}
 }
@@ -43,10 +43,10 @@ func TestDecodeCompactArrayMalformedLengthDoesNotOOM(t *testing.T) {
 	buf := []byte{0xff, 0xff, 0xff, 0xff, 0x0f} // unsigned varint for MaxUint32
 	d := newTestDecoder(buf)
 
-	v := valueOf(new([]int32))
-	d.decodeCompactArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+	p := new([]int32)
+	d.decodeCompactArray(valueOf(p), reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
 
-	if n := v.val.Len(); n > len(buf) {
+	if n := len(*p); n > len(buf) {
 		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
 	}
 }


### PR DESCRIPTION
Fixes #1439

## Summary

`decodeArray` and `decodeCompactArray` in `protocol/decode.go` allocate a slice directly from the array-length field read off the wire (`makeArray(elemType, int(n))`), before checking that field against the bytes actually remaining in the frame. As described in #1439, a malformed or non-Kafka response — for example a misconfigured broker whose advertised address happens to route to an unrelated local service — can carry an arbitrary 32-bit length. `reflect.MakeSlice` then tries to allocate an array of that size before a single element has been decoded, which crashes the process with an out-of-memory error instead of returning a decode error.

There's a precedent for this kind of guard in #319, which capped header counts at a fixed constant (1024). This PR uses a tighter, self-adjusting bound instead of a magic number: every encoded Kafka protocol element occupies at least one byte, so a declared array length greater than `decoder.remain` (the exact number of bytes left in the frame) can only come from a corrupt or non-Kafka payload. Both `decodeArray` and `decodeCompactArray` now clamp the length to `remain` via a new `boundArrayLen` helper before allocating. Decoding still proceeds against the clamped length — it will naturally hit a decode error once real elements run out, since the loop already bails out when `d.remain` reaches 0 — rather than allocating unbounded memory up front.

## Test plan

- Added `protocol/decode_test.go` with a test per encoding (`decodeArray` and the compact/flexible `decodeCompactArray`), each constructing a small buffer that declares far more elements than it has bytes for and asserting the resulting array is bounded to the buffer size.
- Added a direct unit test for the new `boundArrayLen` helper covering the boundary cases (equal, over, under, zero remain).
- Ran `go test ./protocol/...`: all existing tests across every protocol message type pass unchanged, confirming no regression to normal (well-formed) decoding.
- Ran `go vet ./protocol/...` and `gofmt -l` on the changed files: clean.
- Did not run the full repository test suite (`go test ./...`), since the rest of the module depends on packages unrelated to this change; the fix and its tests are isolated to `protocol/decode.go`.