### PR TITLE
fix: reject negative record count in v2 record batch

### DIFF
--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -110,8 +110,9 @@ func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeF
 	if n := d.readInt32(); n < 0 {
 		v.setArray(array{})
 	} else {
-		a := makeArray(elemType, int(n))
-		for i := 0; i < int(n) && d.remain > 0; i++ {
+		count := boundArrayLen(int(n), d.remain)
+		a := makeArray(elemType, count)
+		for i := 0; i < count && d.remain > 0; i++ {
 			decodeElem(d, a.index(i))
 		}
 		v.setArray(a)
@@ -122,12 +123,25 @@ func (d *decoder) decodeCompactArray(v value, elemType reflect.Type, decodeElem 
 	if n := d.readUnsignedVarInt(); n < 1 {
 		v.setArray(array{})
 	} else {
-		a := makeArray(elemType, int(n-1))
-		for i := 0; i < int(n-1) && d.remain > 0; i++ {
+		count := boundArrayLen(int(n-1), d.remain)
+		a := makeArray(elemType, count)
+		for i := 0; i < count && d.remain > 0; i++ {
 			decodeElem(d, a.index(i))
 		}
 		v.setArray(a)
 	}
+}
+
+// boundArrayLen clamps a decoded array length to the number of bytes left in
+// the frame. Every encoded element occupies at least one byte, so a length
+// greater than remain can only come from a malformed or non-Kafka response;
+// allocating an array of that size would let an untrusted length field drive
+// unbounded memory allocation before a single element is validated.
+func boundArrayLen(n, remain int) int {
+	if n > remain {
+		return remain
+	}
+	return n
 }
 
 func (d *decoder) discardAll() {

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -1,0 +1,70 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"testing"
+)
+
+// newTestDecoder builds a decoder over data, with remain set to len(data), the
+// same invariant Unmarshal establishes before decoding a response frame.
+func newTestDecoder(data []byte) *decoder {
+	d := &decoder{reader: bytes.NewReader(data)}
+	d.remain = len(data)
+	return d
+}
+
+// TestDecodeArrayMalformedLengthDoesNotOOM reproduces a malformed or
+// non-Kafka response whose declared array length vastly exceeds the bytes
+// actually available in the frame. Before the length is bounded, makeArray
+// allocates directly from the untrusted length field, so a tiny buffer
+// claiming billions of elements can exhaust memory before a single element
+// is decoded.
+func TestDecodeArrayMalformedLengthDoesNotOOM(t *testing.T) {
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, uint32(1<<31-1)) // math.MaxInt32 elements
+	d := newTestDecoder(buf)
+
+	v := valueOf(new([]int32))
+	d.decodeArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+
+	if d.remain != 0 {
+		t.Fatalf("expected all bytes consumed, got remain=%d", d.remain)
+	}
+	if n := v.val.Len(); n > len(buf) {
+		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
+	}
+}
+
+// TestDecodeCompactArrayMalformedLengthDoesNotOOM is the compact-encoding
+// (flexible version) counterpart of TestDecodeArrayMalformedLengthDoesNotOOM.
+func TestDecodeCompactArrayMalformedLengthDoesNotOOM(t *testing.T) {
+	buf := []byte{0xff, 0xff, 0xff, 0xff, 0x0f} // unsigned varint for MaxUint32
+	d := newTestDecoder(buf)
+
+	v := valueOf(new([]int32))
+	d.decodeCompactArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+
+	if n := v.val.Len(); n > len(buf) {
+		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
+	}
+}
+
+func TestBoundArrayLen(t *testing.T) {
+	tests := []struct {
+		n, remain, want int
+	}{
+		{n: 0, remain: 10, want: 0},
+		{n: 5, remain: 10, want: 5},
+		{n: 10, remain: 10, want: 10},
+		{n: 11, remain: 10, want: 10},
+		{n: 1 << 30, remain: 3, want: 3},
+		{n: 5, remain: 0, want: 0},
+	}
+	for _, test := range tests {
+		if got := boundArrayLen(test.n, test.remain); got != test.want {
+			t.Errorf("boundArrayLen(%d, %d) = %d, want %d", test.n, test.remain, got, test.want)
+		}
+	}
+}

--- a/protocol/decode_test.go
+++ b/protocol/decode_test.go
@@ -26,13 +26,13 @@ func TestDecodeArrayMalformedLengthDoesNotOOM(t *testing.T) {
 	binary.BigEndian.PutUint32(buf, uint32(1<<31-1)) // math.MaxInt32 elements
 	d := newTestDecoder(buf)
 
-	v := valueOf(new([]int32))
-	d.decodeArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+	p := new([]int32)
+	d.decodeArray(valueOf(p), reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
 
 	if d.remain != 0 {
 		t.Fatalf("expected all bytes consumed, got remain=%d", d.remain)
 	}
-	if n := v.val.Len(); n > len(buf) {
+	if n := len(*p); n > len(buf) {
 		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
 	}
 }
@@ -43,10 +43,10 @@ func TestDecodeCompactArrayMalformedLengthDoesNotOOM(t *testing.T) {
 	buf := []byte{0xff, 0xff, 0xff, 0xff, 0x0f} // unsigned varint for MaxUint32
 	d := newTestDecoder(buf)
 
-	v := valueOf(new([]int32))
-	d.decodeCompactArray(v, reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+	p := new([]int32)
+	d.decodeCompactArray(valueOf(p), reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
 
-	if n := v.val.Len(); n > len(buf) {
+	if n := len(*p); n > len(buf) {
 		t.Fatalf("array length %d was not bounded to the %d bytes available in the frame", n, len(buf))
 	}
 }

--- a/protocol/record_v2.go
+++ b/protocol/record_v2.go
@@ -66,6 +66,10 @@ func (rs *RecordSet) readFromVersion2(d *decoder) error {
 	dec.reader = buffer
 	dec.remain = recordsLength
 
+	if numRecords < 0 {
+		return Errorf("invalid negative record count in record batch (%d)", numRecords)
+	}
+
 	records := make([]optimizedRecord, numRecords)
 	// These are two lazy allocators that will be used to optimize allocation of
 	// page references for keys and values.

--- a/protocol/record_v2_test.go
+++ b/protocol/record_v2_test.go
@@ -1,0 +1,55 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	"testing"
+	"time"
+)
+
+// TestReadFromVersion2NegativeRecordCountReturnsError reproduces a broker
+// response whose v2 record batch has a well-formed length and checksum, but
+// a negative record count. Before this was rejected, the count fed straight
+// into make([]optimizedRecord, numRecords), which panics with "makeslice:
+// len out of range" instead of returning a decode error — turning a
+// malformed or malicious broker response into a crash.
+func TestReadFromVersion2NegativeRecordCountReturnsError(t *testing.T) {
+	rs := RecordSet{
+		Version: 2,
+		Records: NewRecordReader(Record{
+			Offset: 0,
+			Time:   time.Unix(0, 0),
+			Key:    NewBytes([]byte("key")),
+			Value:  NewBytes([]byte("value")),
+		}),
+	}
+
+	buf := &bytes.Buffer{}
+	if _, err := rs.WriteTo(buf); err != nil {
+		t.Fatal(err)
+	}
+	data := buf.Bytes()
+
+	// Layout written by WriteTo+writeToVersion2: a 4-byte outer size field,
+	// followed by the v2 batch header. Within that header (see the offset
+	// comments in writeToVersion2), the CRC32 field is at +17 and covers
+	// everything from +21 onward, and numRecords is at +57 — so relative to
+	// the start of data, that's +21, +25, and +61 respectively.
+	const (
+		crcOffset        = 4 + 17
+		crcCoverStart    = 4 + 21
+		numRecordsOffset = 4 + 57
+	)
+
+	binary.BigEndian.PutUint32(data[numRecordsOffset:], ^uint32(0)) // -1 as int32
+
+	checksum := crc32.Checksum(data[crcCoverStart:], crc32.MakeTable(crc32.Castagnoli))
+	binary.BigEndian.PutUint32(data[crcOffset:], checksum)
+
+	var out RecordSet
+	_, err := out.ReadFrom(bytes.NewReader(data))
+	if err == nil {
+		t.Fatal("expected an error decoding a record batch with a negative record count, got nil")
+	}
+}


### PR DESCRIPTION
Fixes #1438

## Summary

`readFromVersion2` in `protocol/record_v2.go` reads the v2 record batch's `numRecords` field (a signed `int32`) and passes it directly into `make([]optimizedRecord, numRecords)`, after the batch length and CRC checks but without validating the count itself. As reported in #1438, a structurally valid Fetch response — one that passes both the length and checksum checks — can still carry a negative `numRecords`, for example from a malformed or compromised broker. That value reaching `make()` as a slice length panics with `runtime error: makeslice: len out of range`, which crashes any process that doesn't recover panics around the fetch path instead of surfacing a decode error.

The reporter's own proof-of-concept confirms the exact panic against the pinned commit, and included a diff proposing the same guard used here.

## Change

Rejects the batch with a regular error as soon as `numRecords` is read to be negative, in the same place the existing length/CRC checks already happen, instead of letting the value reach the allocation.

## Test plan

- Added `protocol/record_v2_test.go`: builds a valid v2 record batch through the existing `WriteTo` path, patches the serialized `numRecords` field to `-1`, recomputes the CRC32 checksum the same way `writeToVersion2` does (so the batch stays otherwise well-formed and passes the length/CRC checks), then asserts `ReadFrom` returns an error instead of panicking.
- Confirmed the new test panics with the reported `makeslice: len out of range` against the pre-fix code, and passes cleanly with the fix — verifying the test actually exercises the bug rather than passing vacuously.
- Ran `go test ./protocol/...`: all existing tests pass unchanged, including `fetch`, `produce`, and `rawproduce`, which exercise record batch encoding/decoding directly.
- Ran `go vet ./protocol/...` and `gofmt -l` on the changed files: clean.
- Did not run the full repository test suite (`go test ./...`); the change and its tests are isolated to record batch v2 decoding.