### PR TITLE
docs: fix README compile error, stale Go version, and deprecated Writer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ in the Kafka API may not yet be implemented in the client.
 
 ## Go versions
 
-`kafka-go` requires Go version 1.15 or later.
+`kafka-go` requires Go version 1.23 or later.
 
 ## Connection [![GoDoc](https://godoc.org/github.com/segmentio/kafka-go?status.svg)](https://godoc.org/github.com/segmentio/kafka-go#Conn)
 
@@ -372,7 +372,7 @@ if err := w.Close(); err != nil {
 ```go
 // Make a writer that publishes messages to topic-A.
 // The topic will be created if it is missing.
-w := &Writer{
+w := &kafka.Writer{
     Addr:                   kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"),
     Topic:                  "topic-A",
     AllowAutoTopicCreation: true,
@@ -580,7 +580,9 @@ w := kafka.Writer{
     }
 ```
 
-Using `kafka.NewWriter`
+Using `kafka.NewWriter` (Deprecated)
+
+> **Note:** `kafka.NewWriter` and `kafka.WriterConfig` are deprecated and will be removed in a future release. Use the `kafka.Writer{}` struct directly, as shown above, instead.
 
 ```go
 dialer := &kafka.Dialer{
@@ -596,7 +598,6 @@ w := kafka.NewWriter(kafka.WriterConfig{
 	Dialer:   dialer,
 })
 ```
-Note that `kafka.NewWriter` and `kafka.WriterConfig` are deprecated and will be removed in a future release.
 
 ## SASL Support
 


### PR DESCRIPTION
## Summary
- Fixes an undefined `Writer` reference in the "Missing topic creation before publication" example — should be `kafka.Writer`, since only the `kafka` package is imported. Anyone copy-pasting this snippet hits a compile error.
- Updates the "Go versions" section from "1.15 or later" to "1.23 or later" to match `go.mod` (`go 1.23`).
- Moves the deprecation notice for `kafka.NewWriter`/`kafka.WriterConfig` to appear *before* the example instead of after, and marks the section heading "(Deprecated)", so readers see the warning before copying the deprecated pattern.

Fixes #1409

## Test plan
- [x] Diffed the changed lines against `go.mod` and the `Deprecated` doc comments on `NewWriter`/`WriterConfig` in source to confirm accuracy
- [x] Docs-only change, no code/build impact