### PR TITLE
Handle MemberIDRequired error in joinGroup to support KIP-394

### DIFF
--- a/consumergroup.go
+++ b/consumergroup.go
@@ -941,6 +941,15 @@ func (cg *ConsumerGroup) joinGroup(conn coordinator, memberID string) (string, i
 	if err == nil && response.ErrorCode != 0 {
 		err = Error(response.ErrorCode)
 	}
+	// KIP-394: if the broker requires a member ID before allowing the
+	// consumer to join the group, retry the join with the assigned member ID.
+	if err == MemberIDRequired {
+		request.MemberID = response.MemberID
+		response, err = conn.joinGroup(request)
+		if err == nil && response.ErrorCode != 0 {
+			err = Error(response.ErrorCode)
+		}
+	}
 	if err != nil {
 		return "", 0, nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/segmentio/kafka-go
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/klauspost/compress v1.15.9


### PR DESCRIPTION
Fixes #1432

## What

When a Kafka broker returns `MemberIDRequired` (error code 79) in response 
to a `JoinGroup` request, the client should retry the request with the 
member ID assigned by the broker rather than treating it as a fatal error.

This is required by [KIP-394](https://cwiki.apache.org/confluence/display/KAFKA/KIP-394%3A+Require+member.id+for+initial+joinGroup+request)
which was introduced in Kafka 2.2.

## Why

Without this fix, consumers connecting to Kafka brokers >= 2.2 may fail 
to join a consumer group entirely, resulting in an infinite error loop.

## Changes

- In `consumergroup.go`, after receiving a `MemberIDRequired` error from 
  `conn.joinGroup`, retry the request with the broker-assigned member ID 
  before propagating the error.

## Testing

The existing `TestConsumerGroupErrors` mock-based tests pass with this change.
A full integration test requires a live Kafka broker with KIP-394 support 
(Kafka >= 2.2). Happy to add one if you can point me to the right test 
infrastructure or provide a test environment setup.