### PR TITLE
fix: reject record batches with a negative record count

### DIFF
--- a/protocol/record_batch_test.go
+++ b/protocol/record_batch_test.go
@@ -1,7 +1,10 @@
 package protocol
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
+	"hash/crc32"
 	"io"
 	"reflect"
 	"testing"
@@ -135,6 +138,58 @@ func TestControlRecord(t *testing.T) {
 
 	if !reflect.DeepEqual(records, found) {
 		t.Error("control records mismatch")
+	}
+}
+
+// TestRecordSetNegativeRecordCount verifies that a v2 record batch reporting
+// a negative record count is rejected with an error instead of panicking in
+// make([]optimizedRecord, numRecords). A broker (or any other party that can
+// influence the bytes on the wire) sending such a batch would otherwise crash
+// the client.
+func TestRecordSetNegativeRecordCount(t *testing.T) {
+	rs := &RecordSet{
+		Version: 2,
+		Records: NewRecordReader(Record{
+			Offset: 0,
+			Key:    NewBytes([]byte("key")),
+			Value:  NewBytes([]byte("value")),
+		}),
+	}
+
+	buf := &bytes.Buffer{}
+	if _, err := rs.WriteTo(buf); err != nil {
+		t.Fatal(err)
+	}
+	raw := buf.Bytes()
+
+	// Layout (relative to the 4-byte size prefix written by WriteTo):
+	//   [0:4]   size prefix
+	//   [4:12]  base offset
+	//   [12:16] batch length
+	//   [16:20] partition leader epoch
+	//   [20]    magic byte
+	//   [21:25] crc32
+	//   [25:...] attributes, ..., numRecords, records (crc-protected region)
+	const batchStart = 4
+	const crcOffset = batchStart + 17
+	const crcProtectedStart = batchStart + 21
+	const numRecordsOffset = batchStart + 57
+
+	negativeOne := int32(-1)
+	binary.BigEndian.PutUint32(raw[numRecordsOffset:], uint32(negativeOne))
+
+	crc := crc32.Checksum(raw[crcProtectedStart:], crc32.MakeTable(crc32.Castagnoli))
+	binary.BigEndian.PutUint32(raw[crcOffset:], crc)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("reading a record batch with a negative record count panicked: %v", r)
+		}
+	}()
+
+	out := &RecordSet{}
+	if _, err := out.ReadFrom(bytes.NewReader(raw)); err == nil {
+		t.Fatal("expected an error reading a record batch with a negative record count, got nil")
 	}
 }
 

--- a/protocol/record_v2.go
+++ b/protocol/record_v2.go
@@ -66,6 +66,10 @@ func (rs *RecordSet) readFromVersion2(d *decoder) error {
 	dec.reader = buffer
 	dec.remain = recordsLength
 
+	if numRecords < 0 {
+		return Errorf("invalid negative record count in record batch (%d)", numRecords)
+	}
+
 	records := make([]optimizedRecord, numRecords)
 	// These are two lazy allocators that will be used to optimize allocation of
 	// page references for keys and values.


### PR DESCRIPTION
## Summary

`readFromVersion2` reads `numRecords` as a signed `int32` after the batch length and CRC checks, then uses it directly as the length for `make([]optimizedRecord, numRecords)`. A Fetch response containing a structurally valid v2 record batch with `numRecords=-1` passes those checks and then panics with `makeslice: len out of range`, which crashes any consumer that doesn't wrap the fetch path in a `recover`.

This adds a sign check right before the allocation so the batch is rejected with a normal error instead of panicking.

Fixes #1438

## Test plan

- Added `TestRecordSetNegativeRecordCount` in `protocol/record_batch_test.go`: builds a real v2 record batch via `RecordSet.WriteTo`, patches the record count field to `-1`, recomputes the CRC over the crc-protected region, then feeds it through `RecordSet.ReadFrom` and asserts an error is returned (and that decoding does not panic).
- Verified the new test panics on `main` without the fix and passes with it.
- `go build ./protocol/...`, `go vet ./protocol/...`, `go test ./protocol/...` all pass.
- `gofmt -l` clean on both touched files (ignoring the pre-existing CRLF-vs-LF noise from `gofmt -l` on this Windows checkout, which flags these files identically before and after my change).