### PR TITLE
Document Transport lifecycle ownership on Client, Writer, and Transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,13 +570,21 @@ r := kafka.NewReader(kafka.ReaderConfig{
 Direct Writer creation
 
 ```go
+// Transports are responsible for managing connection pools and other
+// resources, so it's generally best to create a single Transport and share
+// it across the Writer (and Client) values in your application, rather than
+// creating one per Writer. A Transport that is never shared and never
+// closed (via its CloseIdleConnections method) will leak the goroutine it
+// starts to discover the cluster layout.
+sharedTransport := &kafka.Transport{
+    TLS: &tls.Config{},
+}
+
 w := kafka.Writer{
     Addr: kafka.TCP("localhost:9092", "localhost:9093", "localhost:9094"), 
     Topic:   "topic-A",
     Balancer: &kafka.Hash{},
-    Transport: &kafka.Transport{
-        TLS: &tls.Config{},
-      },
+    Transport: sharedTransport,
     }
 ```
 

--- a/client.go
+++ b/client.go
@@ -41,6 +41,12 @@ type Client struct {
 	// A transport used to communicate with the kafka brokers.
 	//
 	// If nil, DefaultTransport is used.
+	//
+	// The Client never closes the Transport; the caller retains ownership of
+	// it and is responsible for calling its CloseIdleConnections method once
+	// it is no longer needed. Prefer sharing a single Transport across
+	// Client (and Writer) values instead of creating a new one per Client,
+	// see Transport's documentation for details.
 	Transport RoundTripper
 }
 

--- a/transport.go
+++ b/transport.go
@@ -54,6 +54,17 @@ type RoundTripper interface {
 //
 // Note: The intent is for the Transport to become the underlying layer of the
 // kafka.Reader and kafka.Writer types.
+//
+// Like http.Transport, a Transport owns background goroutines and connections
+// for as long as it is used, and it is never closed automatically by the
+// Client, Reader, or Writer values that reference it (with the sole exception
+// of the deprecated NewWriter constructor, which closes the Transport it
+// creates internally). Callers are responsible for calling
+// CloseIdleConnections on a Transport once it is no longer needed, or reusing
+// a single Transport across multiple Client/Reader/Writer values instead of
+// creating one per instance. Creating a new Transport for every request or
+// every short-lived Writer/Client will leak the goroutine started to discover
+// the cluster layout.
 type Transport struct {
 	// A function used to establish connections to the kafka cluster.
 	Dial func(context.Context, string, string) (net.Conn, error)
@@ -132,6 +143,11 @@ var DefaultTransport RoundTripper = &Transport{
 
 // CloseIdleConnections closes all idle connections immediately, and marks all
 // connections that are in use to be closed when they become idle again.
+//
+// This also stops the background goroutines that the Transport started to
+// discover the cluster layout. Call this method once the Transport is no
+// longer needed to avoid leaking those goroutines; the Transport is not
+// closed automatically by the Client, Reader, or Writer values that use it.
 func (t *Transport) CloseIdleConnections() {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()

--- a/writer.go
+++ b/writer.go
@@ -195,6 +195,14 @@ type Writer struct {
 	// A transport used to send messages to kafka clusters.
 	//
 	// If nil, DefaultTransport is used.
+	//
+	// When set, the Transport is not closed when the Writer is closed via
+	// Close; the caller retains ownership of it and is responsible for
+	// calling its CloseIdleConnections method once it is no longer needed.
+	// Prefer creating a single Transport and sharing it across Writer (and
+	// Client) values instead of creating a new one per Writer, as each
+	// Transport starts a background goroutine that otherwise leaks for as
+	// long as the Transport is never closed.
 	Transport RoundTripper
 
 	// AllowAutoTopicCreation notifies writer to create topic if missing.
@@ -552,6 +560,11 @@ func (w *Writer) spawn(f func()) {
 // returning. Calling Close also prevents new writes from being submitted to
 // the writer, further calls to WriteMessages and the like will fail with
 // io.ErrClosedPipe.
+//
+// Close only releases the Transport it created internally (when the Writer
+// was constructed via the deprecated NewWriter). If the Transport field was
+// set explicitly, Close does not call CloseIdleConnections on it; see the
+// Transport field's documentation for details on who owns its lifecycle.
 func (w *Writer) Close() error {
 	w.mutex.Lock()
 	// Marking the writer as closed here causes future calls to WriteMessages to


### PR DESCRIPTION
## Summary

Fixes the documentation gap behind #1358 ("Goroutines left behind after writing message even after closing writer").

The leak reported in #1358 isn't a bug in the connection pool's ref-counting (`transport.go`'s `refc`/`ref`/`unref`), that logic is correct. The actual cause is that `Writer.Close()` only calls `CloseIdleConnections()` on a `Transport` it created *internally*, via the deprecated `NewWriter(WriterConfig)` constructor. A `Writer{Transport: &kafka.Transport{...}}` built via struct literal (the common, non-deprecated way, and the way the bug report's repro does it) never gets its `Transport` cleaned up by `Close()`, so the background `discover()` goroutine that `Transport` starts runs forever unless the caller calls `CloseIdleConnections()` themselves.

This turns out to be intentional design, confirmed by @achille-roussel in #599 (2020): `Transport` follows the same ownership model as `net/http.Transport`, long-lived, meant to be shared and reused across many `Writer`/`Client`/`Reader` values, with the caller responsible for closing it. The README already documents the correct "shared transport" pattern (in the SASL section), but:
- none of the godoc comments on `Transport`, `Writer.Transport`, `Client.Transport`, or `CloseIdleConnections` state this contract, and
- the README's plain "Direct Writer creation" example (right above the SASL section) creates a fresh `&kafka.Transport{}` inline with no warning, modeling the exact anti-pattern from the bug report.

## What this PR does

- Adds doc comments to `Transport`, `Transport.CloseIdleConnections`, `Client.Transport`, `Writer.Transport`, and `Writer.Close` making the ownership/lifecycle contract explicit (mirrors `net/http`; caller must call `CloseIdleConnections` or reuse a shared `Transport`).
- Fixes the README's "Direct Writer creation" example to construct and share a `Transport` the same way the SASL examples already do, instead of silently modeling the leak.

## What this PR intentionally does not do

- No behavioral/code change to `Transport`, `Writer`, or `Client`. An automatic-cleanup change would require guessing at `Transport` ownership, which the existing design (per #599) deliberately avoids since `Transport` values are meant to be shared across multiple owners. I scoped that out rather than attempt a heuristic that could silently break shared-Transport usage.

Updates #1358 (documentation-only; does not change runtime behavior).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on changed `.go` files (clean)
- [x] Ran the full test suite locally against a live broker via `docker-compose up` (`KAFKA_VERSION=3.7.0 go test -cover ./...`); pre-existing failures (`TestConn`, `TestReaderConsumerGroup/verify_offset_committed`) are unrelated flakes from single-node broker auto-topic-creation races, present before this change.
- [x] Ran `TestWriter`/`TestClient`/`TestTransport` explicitly against a live broker after the change - all pass.
