### PR TITLE
Reject protocol arrays larger than the remaining frame

### DIFF
--- a/protocol/decode.go
+++ b/protocol/decode.go
@@ -109,6 +109,8 @@ func (d *decoder) decodeCompactBytes(v value) {
 func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeFunc) {
 	if n := d.readInt32(); n < 0 {
 		v.setArray(array{})
+	} else if !d.validArrayLen(int(n)) {
+		v.setArray(array{})
 	} else {
 		a := makeArray(elemType, int(n))
 		for i := 0; i < int(n) && d.remain > 0; i++ {
@@ -121,6 +123,8 @@ func (d *decoder) decodeArray(v value, elemType reflect.Type, decodeElem decodeF
 func (d *decoder) decodeCompactArray(v value, elemType reflect.Type, decodeElem decodeFunc) {
 	if n := d.readUnsignedVarInt(); n < 1 {
 		v.setArray(array{})
+	} else if !d.validArrayLen(int(n - 1)) {
+		v.setArray(array{})
 	} else {
 		a := makeArray(elemType, int(n-1))
 		for i := 0; i < int(n-1) && d.remain > 0; i++ {
@@ -128,6 +132,21 @@ func (d *decoder) decodeCompactArray(v value, elemType reflect.Type, decodeElem 
 		}
 		v.setArray(a)
 	}
+}
+
+// validArrayLen reports whether n elements can exist in the remaining frame.
+// Each element occupies at least one byte on the wire, so n cannot exceed
+// remain; a larger value is garbage (or a non-Kafka peer) and must not
+// allocate.
+func (d *decoder) validArrayLen(n int) bool {
+	if d.err != nil {
+		return false
+	}
+	if n < 0 || n > d.remain {
+		d.setError(fmt.Errorf("cannot decode array of length %d from remaining %d bytes", n, d.remain))
+		return false
+	}
+	return true
 }
 
 func (d *decoder) discardAll() {

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -340,3 +340,38 @@ func TestFloat64(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeArrayRejectsLengthLargerThanRemaining(t *testing.T) {
+	// 1e9-element array claimed in an 8-byte frame (non-Kafka garbage).
+	payload := []byte{0x3b, 0x9a, 0xca, 0x00, 0x00, 0x00, 0x00, 0x00}
+	d := &decoder{reader: bytes.NewReader(payload), remain: len(payload)}
+	var got []int32
+	d.decodeArray(valueOf(&got), reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+	if d.err == nil {
+		t.Fatal("expected decode error for array length larger than remaining bytes")
+	}
+
+	// A well-formed 2-element int32 array still decodes.
+	ok := []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02}
+	d = &decoder{reader: bytes.NewReader(ok), remain: len(ok)}
+	got = nil
+	d.decodeArray(valueOf(&got), reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+	if d.err != nil {
+		t.Fatalf("unexpected error: %v", d.err)
+	}
+	if !reflect.DeepEqual(got, []int32{1, 2}) {
+		t.Fatalf("got %v, want [1 2]", got)
+	}
+}
+
+func TestDecodeCompactArrayRejectsLengthLargerThanRemaining(t *testing.T) {
+	// Compact array length is N+1 as an unsigned varint. 0xFF 0xFF 0xFF 0xFF 0x0F
+	// is 268435455+..., far larger than the remaining 2 bytes.
+	payload := []byte{0xff, 0xff, 0xff, 0xff, 0x0f, 0x00, 0x00}
+	d := &decoder{reader: bytes.NewReader(payload), remain: len(payload)}
+	var got []int32
+	d.decodeCompactArray(valueOf(&got), reflect.TypeOf(int32(0)), (*decoder).decodeInt32)
+	if d.err == nil {
+		t.Fatal("expected decode error for compact array length larger than remaining bytes")
+	}
+}


### PR DESCRIPTION
Fixes #1439

`decodeArray` / `decodeCompactArray` allocated from the decoded length before checking whether that many elements could fit in the remaining response. Each array element occupies at least one byte on the wire, so a length larger than `remain` is malformed (or a non-Kafka peer whose bytes were decoded as a Kafka response).

The previous behavior called `make` / `unsafe_NewArray` with that length and could OOM the process. Header counts were already guarded in a similar way (#319); this applies the same bound to general protocol arrays.

A length that cannot fit in the remaining frame now returns a decode error instead of allocating.