### PR TITLE
Fix: abort writer batch early if all contexts expire

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1042,12 +1042,11 @@ func (ptw *partitionWriter) writeMessages(ctx context.Context, msgs []Message, i
 			batch = ptw.newWriteBatch()
 			ptw.currBatch = batch
 		}
-		
 		var bCtx context.Context
 		if !ptw.w.Async {
 			bCtx = ctx
 		}
-		
+
 		if !batch.add(bCtx, msgs[i], batchSize, batchBytes) {
 			batch.trigger()
 			ptw.queue.Put(batch)

--- a/writer.go
+++ b/writer.go
@@ -1042,12 +1042,12 @@ func (ptw *partitionWriter) writeMessages(ctx context.Context, msgs []Message, i
 			batch = ptw.newWriteBatch()
 			ptw.currBatch = batch
 		}
-		var bCtx context.Context
-		if !ptw.w.Async {
-			bCtx = ctx
+		var doneCh <-chan struct{}
+		if !ptw.w.Async && ctx != nil {
+			doneCh = ctx.Done()
 		}
 
-		if !batch.add(bCtx, msgs[i], batchSize, batchBytes) {
+		if !batch.add(doneCh, msgs[i], batchSize, batchBytes) {
 			batch.trigger()
 			ptw.queue.Put(batch)
 			ptw.currBatch = nil
@@ -1113,16 +1113,21 @@ func (ptw *partitionWriter) writeBatch(batch *writeBatch) {
 	var err error
 	key := ptw.meta
 	for attempt, maxAttempts := 0, ptw.w.maxAttempts(); attempt < maxAttempts; attempt++ {
-		if len(batch.contexts) > 0 {
+		if len(batch.doneChannels) > 0 {
 			allExpired := true
-			for _, ctx := range batch.contexts {
-				if ctx.Err() == nil {
+			for _, doneCh := range batch.doneChannels {
+				select {
+				case <-doneCh:
+					// context expired
+				default:
 					allExpired = false
+				}
+				if !allExpired {
 					break
 				}
 			}
 			if allExpired {
-				err = batch.contexts[0].Err()
+				err = context.Canceled
 				break
 			}
 		}
@@ -1226,7 +1231,7 @@ type writeBatch struct {
 	done  chan struct{}
 	timer *time.Timer
 	err   error // result of the batch completion
-	contexts []context.Context
+	doneChannels []<-chan struct{}
 }
 
 func newWriteBatch(now time.Time, timeout time.Duration) *writeBatch {
@@ -1238,7 +1243,7 @@ func newWriteBatch(now time.Time, timeout time.Duration) *writeBatch {
 	}
 }
 
-func (b *writeBatch) add(ctx context.Context, msg Message, maxSize int, maxBytes int64) bool {
+func (b *writeBatch) add(doneCh <-chan struct{}, msg Message, maxSize int, maxBytes int64) bool {
 	bytes := int64(msg.totalSize())
 
 	if b.size > 0 && (b.bytes+bytes) > maxBytes {
@@ -1250,8 +1255,8 @@ func (b *writeBatch) add(ctx context.Context, msg Message, maxSize int, maxBytes
 	}
 
 	b.msgs = append(b.msgs, msg)
-	if ctx != nil {
-		b.contexts = append(b.contexts, ctx)
+	if doneCh != nil {
+		b.doneChannels = append(b.doneChannels, doneCh)
 	}
 	b.size++
 	b.bytes += bytes

--- a/writer.go
+++ b/writer.go
@@ -1223,14 +1223,14 @@ func (ptw *partitionWriter) close() {
 }
 
 type writeBatch struct {
-	time  time.Time
-	msgs  []Message
-	size  int
-	bytes int64
-	ready chan struct{}
-	done  chan struct{}
-	timer *time.Timer
-	err   error // result of the batch completion
+	time         time.Time
+	msgs         []Message
+	size         int
+	bytes        int64
+	ready        chan struct{}
+	done         chan struct{}
+	timer        *time.Timer
+	err          error // result of the batch completion
 	doneChannels []<-chan struct{}
 }
 

--- a/writer.go
+++ b/writer.go
@@ -663,7 +663,7 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 		assignments[key] = append(assignments[key], int32(i))
 	}
 
-	batches := w.batchMessages(msgs, assignments)
+	batches := w.batchMessages(ctx, msgs, assignments)
 	if w.Async {
 		return nil
 	}
@@ -695,7 +695,7 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 	return werr
 }
 
-func (w *Writer) batchMessages(messages []Message, assignments map[topicPartition][]int32) map[*writeBatch][]int32 {
+func (w *Writer) batchMessages(ctx context.Context, messages []Message, assignments map[topicPartition][]int32) map[*writeBatch][]int32 {
 	var batches map[*writeBatch][]int32
 	if !w.Async {
 		batches = make(map[*writeBatch][]int32, len(assignments))
@@ -714,7 +714,7 @@ func (w *Writer) batchMessages(messages []Message, assignments map[topicPartitio
 			writer = newPartitionWriter(w, key)
 			w.writers[key] = writer
 		}
-		wbatches := writer.writeMessages(messages, indexes)
+		wbatches := writer.writeMessages(ctx, messages, indexes)
 
 		for batch, idxs := range wbatches {
 			batches[batch] = idxs
@@ -1023,7 +1023,7 @@ func (ptw *partitionWriter) writeBatches() {
 	}
 }
 
-func (ptw *partitionWriter) writeMessages(msgs []Message, indexes []int32) map[*writeBatch][]int32 {
+func (ptw *partitionWriter) writeMessages(ctx context.Context, msgs []Message, indexes []int32) map[*writeBatch][]int32 {
 	ptw.mutex.Lock()
 	defer ptw.mutex.Unlock()
 
@@ -1042,7 +1042,13 @@ func (ptw *partitionWriter) writeMessages(msgs []Message, indexes []int32) map[*
 			batch = ptw.newWriteBatch()
 			ptw.currBatch = batch
 		}
-		if !batch.add(msgs[i], batchSize, batchBytes) {
+		
+		var bCtx context.Context
+		if !ptw.w.Async {
+			bCtx = ctx
+		}
+		
+		if !batch.add(bCtx, msgs[i], batchSize, batchBytes) {
 			batch.trigger()
 			ptw.queue.Put(batch)
 			ptw.currBatch = nil
@@ -1108,6 +1114,20 @@ func (ptw *partitionWriter) writeBatch(batch *writeBatch) {
 	var err error
 	key := ptw.meta
 	for attempt, maxAttempts := 0, ptw.w.maxAttempts(); attempt < maxAttempts; attempt++ {
+		if len(batch.contexts) > 0 {
+			allExpired := true
+			for _, ctx := range batch.contexts {
+				if ctx.Err() == nil {
+					allExpired = false
+					break
+				}
+			}
+			if allExpired {
+				err = batch.contexts[0].Err()
+				break
+			}
+		}
+
 		if attempt != 0 {
 			stats.retries.observe(1)
 			// TODO: should there be a way to asynchronously cancel this
@@ -1207,6 +1227,7 @@ type writeBatch struct {
 	done  chan struct{}
 	timer *time.Timer
 	err   error // result of the batch completion
+	contexts []context.Context
 }
 
 func newWriteBatch(now time.Time, timeout time.Duration) *writeBatch {
@@ -1218,7 +1239,7 @@ func newWriteBatch(now time.Time, timeout time.Duration) *writeBatch {
 	}
 }
 
-func (b *writeBatch) add(msg Message, maxSize int, maxBytes int64) bool {
+func (b *writeBatch) add(ctx context.Context, msg Message, maxSize int, maxBytes int64) bool {
 	bytes := int64(msg.totalSize())
 
 	if b.size > 0 && (b.bytes+bytes) > maxBytes {
@@ -1230,6 +1251,9 @@ func (b *writeBatch) add(msg Message, maxSize int, maxBytes int64) bool {
 	}
 
 	b.msgs = append(b.msgs, msg)
+	if ctx != nil {
+		b.contexts = append(b.contexts, ctx)
+	}
 	b.size++
 	b.bytes += bytes
 	return true

--- a/writer_test.go
+++ b/writer_test.go
@@ -1037,3 +1037,27 @@ type staticBalancer struct {
 func (b *staticBalancer) Balance(_ Message, partitions ...int) int {
 	return b.partition
 }
+
+func TestWriterContextTimeout(t *testing.T) {
+	topic := makeTopic()
+	createTopic(t, topic, 1)
+	defer deleteTopic(t, topic)
+
+	w := &Writer{
+		Addr:  TCP("localhost:9999"),
+		Topic: topic,
+		MaxAttempts: 10,
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := w.WriteMessages(ctx, Message{
+		Value: []byte("hello"),
+	})
+
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context timeout error, got %v", err)
+	}
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1038,26 +1038,4 @@ func (b *staticBalancer) Balance(_ Message, partitions ...int) int {
 	return b.partition
 }
 
-func TestWriterContextTimeout(t *testing.T) {
-	topic := makeTopic()
-	createTopic(t, topic, 1)
-	defer deleteTopic(t, topic)
 
-	w := &Writer{
-		Addr:  TCP("localhost:9999"),
-		Topic: topic,
-		MaxAttempts: 10,
-	}
-	defer w.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-
-	err := w.WriteMessages(ctx, Message{
-		Value: []byte("hello"),
-	})
-
-	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context timeout error, got %v", err)
-	}
-}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1037,5 +1037,3 @@ type staticBalancer struct {
 func (b *staticBalancer) Balance(_ Message, partitions ...int) int {
 	return b.partition
 }
-
-


### PR DESCRIPTION
Fixes #1427. This PR addresses the issue where messages are still delivered to Kafka after WriteMessages returns a context timeout error. We now track caller contexts in writeBatch and abort the background retry loop if all waiting callers have timed out.