### PR TITLE
Retry writes that fail with EOF

### DIFF
--- a/error.go
+++ b/error.go
@@ -611,7 +611,8 @@ func isTemporary(err error) bool {
 }
 
 func isTransientNetworkError(err error) bool {
-	return errors.Is(err, io.ErrUnexpectedEOF) ||
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, syscall.ECONNREFUSED) ||
 		errors.Is(err, syscall.ECONNRESET) ||
 		errors.Is(err, syscall.EPIPE)

--- a/error_test.go
+++ b/error_test.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,4 +125,10 @@ func TestError(t *testing.T) {
 		assert.Contains(t, msgTooLarge.Error(), MessageSizeTooLarge.Error())
 		assert.ErrorIs(t, msgTooLarge, MessageSizeTooLarge)
 	})
+}
+
+func TestIsTransientNetworkErrorEOF(t *testing.T) {
+	if !isTransientNetworkError(io.EOF) {
+		t.Fatal("io.EOF should be treated as a transient network error")
+	}
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -6,14 +6,61 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	metadataAPI "github.com/segmentio/kafka-go/protocol/metadata"
+	produceAPI "github.com/segmentio/kafka-go/protocol/produce"
+
 	"github.com/segmentio/kafka-go/sasl/plain"
 )
+
+type roundTripperFunc func(context.Context, net.Addr, Request) (Response, error)
+
+func (f roundTripperFunc) RoundTrip(ctx context.Context, addr net.Addr, req Request) (Response, error) {
+	return f(ctx, addr, req)
+}
+
+func TestWriterRetriesEOF(t *testing.T) {
+	var produceCalls int
+	transport := roundTripperFunc(func(ctx context.Context, addr net.Addr, req Request) (Response, error) {
+		switch req.(type) {
+		case *metadataAPI.Request:
+			return &metadataAPI.Response{Topics: []metadataAPI.ResponseTopic{{Name: "topic", Partitions: []metadataAPI.ResponsePartition{{}}}}}, nil
+		case *produceAPI.Request:
+			produceCalls++
+			if produceCalls == 1 {
+				return nil, io.EOF
+			}
+			return &produceAPI.Response{Topics: []produceAPI.ResponseTopic{{Topic: "topic", Partitions: []produceAPI.ResponsePartition{{}}}}}, nil
+		default:
+			return nil, fmt.Errorf("unexpected request type %T", req)
+		}
+	})
+
+	w := &Writer{
+		Addr:            TCP("broker:9092"),
+		Topic:           "topic",
+		Transport:       transport,
+		MaxAttempts:     2,
+		BatchSize:       1,
+		BatchTimeout:    time.Hour,
+		WriteBackoffMin: time.Nanosecond,
+		WriteBackoffMax: time.Nanosecond,
+	}
+	defer w.Close()
+
+	if err := w.WriteMessages(context.Background(), Message{Value: []byte("value")}); err != nil {
+		t.Fatalf("WriteMessages returned error: %v", err)
+	}
+	if produceCalls != 2 {
+		t.Fatalf("Produce calls = %d, want 2", produceCalls)
+	}
+}
 
 func TestBatchQueue(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

The Writer currently treats `io.ErrUnexpectedEOF` and several connection errors as transient, but a plain `io.EOF` returned while a broker connection is being closed is not retried. During routine broker rolling maintenance, this can turn a recoverable connection interruption into a permanent write failure.

This change classifies `io.EOF` as a transient network error, allowing the existing Writer retry loop to handle it without changing retry limits or backoff behavior.

## Testing

- Added `TestIsTransientNetworkErrorEOF` to cover error classification.
- Added `TestWriterRetriesEOF` using a fake `RoundTripper`: metadata succeeds, the first Produce returns `io.EOF`, and the second succeeds. The test asserts the write succeeds after exactly two Produce attempts.
- `gofmt` and `git diff --check` pass.
- `go test -mod=mod . -run '^TestWriterRetriesEOF$' -count=1 -race -timeout=20s` passes.
- `go test -mod=mod . -run 'Test(Error|IsTransientNetworkErrorEOF)$' -count=1` passes.
- `go vet ./...` passes.
- The integration tests requiring Kafka were not run because no local broker was available; the failures are environment connection-refused errors, not code failures.

Fixes #1352